### PR TITLE
2.A.1: WS route accepts connections

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,7 +1,8 @@
-import Fastify from 'fastify';
 import fastifyStatic from '@fastify/static';
-import { resolve, dirname } from 'node:path';
+import Fastify from 'fastify';
+import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { websocketRoute } from './plugins/websocketRoutes.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -11,6 +12,6 @@ export async function createServer() {
   await server.register(fastifyStatic, {
     root: resolve(__dirname, '..', 'dist', 'client'),
   });
-
+  await server.register(websocketRoute);
   return server;
 }

--- a/server/plugins/websocketRoutes.ts
+++ b/server/plugins/websocketRoutes.ts
@@ -1,0 +1,10 @@
+import fastifyWebsocket from '@fastify/websocket';
+import { FastifyInstance } from 'fastify';
+
+export async function websocketRoute(app: FastifyInstance) {
+  await app.register(fastifyWebsocket);
+
+  app.get('/ws', { websocket: true }, (socket) => {
+    console.log(socket);
+  });
+}

--- a/server/plugins/websocketRoutes.ts
+++ b/server/plugins/websocketRoutes.ts
@@ -1,10 +1,8 @@
 import fastifyWebsocket from '@fastify/websocket';
-import { FastifyInstance } from 'fastify';
+import { type FastifyInstance } from 'fastify';
 
 export async function websocketRoute(app: FastifyInstance) {
   await app.register(fastifyWebsocket);
 
-  app.get('/ws', { websocket: true }, (socket) => {
-    console.log(socket);
-  });
+  app.get('/ws', { websocket: true }, () => {});
 }

--- a/tests/server/server.integration.test.ts
+++ b/tests/server/server.integration.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
+import WebSocket from 'ws';
 import { createServer } from '../../server/index.ts';
 
 describe('Server', () => {
@@ -15,5 +16,23 @@ describe('Server', () => {
 
     expect(response.statusCode).toBe(200);
     expect(response.headers['content-type']).toContain('text/html');
+  });
+});
+describe('Websocket fastify intergration test', () => {
+  it('accepts Websocket connection on /ws', async () => {
+    const server = await createServer();
+    await server.listen({ port: 0 });
+    const port = String(server.addresses()[0].port);
+
+    const ws = new WebSocket(`ws://localhost:${port}/ws`);
+
+    await new Promise((resolve, reject) => {
+      ws.on('open', resolve);
+      ws.on('error', reject);
+    });
+
+    expect(ws.readyState).toBe(WebSocket.OPEN);
+    ws.close();
+    await server.close();
   });
 });

--- a/tests/server/server.integration.test.ts
+++ b/tests/server/server.integration.test.ts
@@ -18,13 +18,20 @@ describe('Server', () => {
     expect(response.headers['content-type']).toContain('text/html');
   });
 });
-describe('Websocket fastify intergration test', () => {
+describe('Websocket fastify integration test', () => {
+  let server: Awaited<ReturnType<typeof createServer>>;
+  let ws: WebSocket;
+
+  afterEach(async () => {
+    ws.close();
+    await server.close();
+  });
   it('accepts Websocket connection on /ws', async () => {
-    const server = await createServer();
+    server = await createServer();
     await server.listen({ port: 0 });
     const port = String(server.addresses()[0].port);
 
-    const ws = new WebSocket(`ws://localhost:${port}/ws`);
+    ws = new WebSocket(`ws://localhost:${port}/ws`);
 
     await new Promise((resolve, reject) => {
       ws.on('open', resolve);
@@ -32,7 +39,5 @@ describe('Websocket fastify intergration test', () => {
     });
 
     expect(ws.readyState).toBe(WebSocket.OPEN);
-    ws.close();
-    await server.close();
   });
 });


### PR DESCRIPTION
- RED: Initialized the create server for test with a random port
- Tested the Fastify server on a WebSocket route("/ws") 
- GREEN: updated the prod code to have Fastify initialize the websocket
- REFACTOR: created the plugin to thin out index file