### PR TITLE
EKO-234: Story 2.B Client connects via WebSocket on page load

### DIFF
--- a/client/clientSocket.ts
+++ b/client/clientSocket.ts
@@ -63,7 +63,7 @@ export class StubbedServer {
 
 export class StubbedClientSocket implements ClientSocketInterface {
   private _isConnected = false;
-  private emiiter = new EventEmitter();
+  private emitter = new EventEmitter();
 
   get isConnected(): boolean {
     return this._isConnected;
@@ -80,7 +80,7 @@ export class StubbedClientSocket implements ClientSocketInterface {
 
   send(message: ClientMessage): Promise<void> {
     // Implementation for sending message
-    this.emiiter.emit(EVENT_MESSAGES, message);
+    this.emitter.emit(EVENT_MESSAGES, message);
 
     return Promise.resolve();
   }
@@ -90,10 +90,10 @@ export class StubbedClientSocket implements ClientSocketInterface {
   }
 
   onMessage(message: ServerMessage): void {
-    this.emiiter.emit('message', message);
+    this.emitter.emit('message', message);
   }
 
   trackMessages(): OutputTracker {
-    return new OutputTracker(this.emiiter, EVENT_MESSAGES);
+    return new OutputTracker(this.emitter, EVENT_MESSAGES);
   }
 }

--- a/client/clientSocket.ts
+++ b/client/clientSocket.ts
@@ -63,12 +63,19 @@ class RealClientSocket implements ClientSocketInterface {
 
   connect(): Promise<void> {
     return new Promise((resolve, reject) => {
+      let settled = false;
       this.socket = new WebSocket(this.url);
       this.socket.onopen = () => {
-        resolve();
+        if (!settled) {
+          settled = true;
+          resolve();
+        }
       };
       this.socket.onerror = (err) => {
-        reject(new Error(err.message satisfies string));
+        if (!settled) {
+          settled = true;
+          reject(new Error(err.message satisfies string));
+        }
       };
     });
   }

--- a/client/clientSocket.ts
+++ b/client/clientSocket.ts
@@ -1,3 +1,4 @@
+import { WebSocket } from 'ws';
 import { EventEmitter, OutputTracker } from '../server/infrastructure/output_tracker.ts';
 import { ClientMessage, ServerMessage } from '../shared/protocol.ts';
 
@@ -18,9 +19,9 @@ export class ClientSocket {
     this.client = client;
   }
 
-  //   static create(url: string): ClientSocket {
-  //     return new ClientSocket(new RealClientSocket(url));
-  //   }
+  static create(url: string): ClientSocket {
+    return new ClientSocket(new RealClientSocket(url));
+  }
 
   static createNull(): ClientSocket {
     // Implementation for null socket
@@ -45,6 +46,39 @@ export class ClientSocket {
   }
   trackMessages(): OutputTracker {
     return this.client.trackMessages();
+  }
+}
+
+class RealClientSocket implements ClientSocketInterface {
+  private socket: WebSocket | null = null;
+  private url: string;
+
+  constructor(url: string) {
+    this.url = url;
+  }
+
+  get isConnected(): boolean {
+    return this.socket !== null && this.socket.readyState === WebSocket.OPEN;
+  }
+
+  connect(): Promise<void> {
+    return new Promise((resolve) => {
+      this.socket = new WebSocket(this.url);
+      this.socket.onopen = () => {
+        resolve();
+      };
+      // this.socket.onerror = (err) => reject(err);
+    });
+  }
+
+  close(): Promise<void> {
+    return Promise.resolve();
+  }
+  send(): Promise<void> {
+    return Promise.resolve();
+  }
+  trackMessages(): OutputTracker {
+    return new OutputTracker(new EventEmitter(), '');
   }
 }
 

--- a/client/clientSocket.ts
+++ b/client/clientSocket.ts
@@ -1,0 +1,55 @@
+interface ClientSocketInterface {
+  connect(): Promise<void>;
+  close(): Promise<void>;
+  send(message: unknown): void;
+  get isConnected(): boolean;
+}
+
+export class ClientSocket {
+  private client: ClientSocketInterface;
+
+  private constructor(client: ClientSocketInterface) {
+    this.client = client;
+  }
+
+  //   static create(url: string): ClientSocket {
+  //     return new ClientSocket(new RealClientSocket(url));
+  //   }
+
+  static createNull(): ClientSocket {
+    // Implementation for null socket
+    return new ClientSocket(new StubbedClientSocket());
+  }
+
+  async connect(): Promise<void> {
+    await this.client.connect();
+  }
+
+  async close(): Promise<void> {
+    await this.client.close();
+  }
+
+  get isConnected(): boolean {
+    return this.client.isConnected;
+  }
+}
+
+export class StubbedClientSocket implements ClientSocketInterface {
+  private _isConnected = false;
+
+  connect(): Promise<void> {
+    this._isConnected = true;
+    return Promise.resolve();
+  }
+
+  close(): Promise<void> {
+    this._isConnected = false;
+    return Promise.resolve();
+  }
+
+  send(): void {}
+
+  get isConnected(): boolean {
+    return this._isConnected;
+  }
+}

--- a/client/clientSocket.ts
+++ b/client/clientSocket.ts
@@ -1,4 +1,4 @@
-import { WebSocket } from 'ws';
+import { WebSocket, ClientOptions } from 'ws';
 import { EventEmitter, OutputTracker } from '../server/infrastructure/output_tracker.ts';
 import { ClientMessage, ServerMessage } from '../shared/protocol.ts';
 
@@ -19,12 +19,13 @@ export class ClientSocket {
     this.client = client;
   }
 
-  static create(url: string): ClientSocket {
+  static create(url: string, options: ClientOptions = {}): ClientSocket {
     const parsed = new URL(url);
     if (parsed.protocol !== 'ws:' && parsed.protocol !== 'wss:') {
       throw new Error(`Invalid WebSocket URL: expected ws:// or wss://, got ${parsed.protocol}`);
     }
-    return new ClientSocket(new RealClientSocket(url));
+
+    return new ClientSocket(new RealClientSocket(url, options));
   }
 
   static createNull(): ClientSocket {
@@ -55,10 +56,12 @@ export class ClientSocket {
 class RealClientSocket implements ClientSocketInterface {
   private socket: WebSocket | null = null;
   private readonly url: string;
+  private readonly options: ClientOptions;
   private emitter = new EventEmitter();
 
-  constructor(url: string) {
+  constructor(url: string, options: ClientOptions = {}) {
     this.url = url;
+    this.options = options;
   }
 
   get isConnected(): boolean {
@@ -68,7 +71,7 @@ class RealClientSocket implements ClientSocketInterface {
   connect(): Promise<void> {
     return new Promise((resolve, reject) => {
       let settled = false;
-      this.socket = new WebSocket(this.url);
+      this.socket = new WebSocket(this.url, this.options);
       this.socket.onopen = () => {
         if (!settled) {
           settled = true;

--- a/client/clientSocket.ts
+++ b/client/clientSocket.ts
@@ -1,9 +1,15 @@
+import { EventEmitter, OutputTracker } from '../server/infrastructure/output_tracker.ts';
+import { ClientMessage, ServerMessage } from '../shared/protocol.ts';
+
 interface ClientSocketInterface {
   connect(): Promise<void>;
   close(): Promise<void>;
-  send(message: unknown): void;
+  send(message: unknown): Promise<void>;
   get isConnected(): boolean;
+  trackMessages(): OutputTracker;
 }
+
+const EVENT_MESSAGES = 'message';
 
 export class ClientSocket {
   private client: ClientSocketInterface;
@@ -21,22 +27,47 @@ export class ClientSocket {
     return new ClientSocket(new StubbedClientSocket());
   }
 
+  get isConnected(): boolean {
+    return this.client.isConnected;
+  }
   async connect(): Promise<void> {
     await this.client.connect();
   }
-
   async close(): Promise<void> {
     await this.client.close();
   }
+  async send(message: ClientMessage): Promise<void> {
+    await this.client.send(message);
+  }
+  simulateServer(): StubbedServer {
+    const stub = this.client as StubbedClientSocket;
+    return stub.simulateServer();
+  }
+  trackMessages(): OutputTracker {
+    return this.client.trackMessages();
+  }
+}
 
-  get isConnected(): boolean {
-    return this.client.isConnected;
+export class StubbedServer {
+  private _client: StubbedClientSocket;
+  readonly messages = [] as ServerMessage[];
+
+  constructor(client: StubbedClientSocket) {
+    this._client = client;
+  }
+
+  send(message: ServerMessage): void {
+    this._client.onMessage(message);
   }
 }
 
 export class StubbedClientSocket implements ClientSocketInterface {
   private _isConnected = false;
+  private emiiter = new EventEmitter();
 
+  get isConnected(): boolean {
+    return this._isConnected;
+  }
   connect(): Promise<void> {
     this._isConnected = true;
     return Promise.resolve();
@@ -47,9 +78,22 @@ export class StubbedClientSocket implements ClientSocketInterface {
     return Promise.resolve();
   }
 
-  send(): void {}
+  send(message: ClientMessage): Promise<void> {
+    // Implementation for sending message
+    this.emiiter.emit(EVENT_MESSAGES, message);
 
-  get isConnected(): boolean {
-    return this._isConnected;
+    return Promise.resolve();
+  }
+
+  simulateServer(): StubbedServer {
+    return new StubbedServer(this);
+  }
+
+  onMessage(message: ServerMessage): void {
+    this.emiiter.emit('message', message);
+  }
+
+  trackMessages(): OutputTracker {
+    return new OutputTracker(this.emiiter, EVENT_MESSAGES);
   }
 }

--- a/client/clientSocket.ts
+++ b/client/clientSocket.ts
@@ -13,7 +13,7 @@ interface ClientSocketInterface {
 const EVENT_MESSAGES = 'message';
 
 export class ClientSocket {
-  private client: ClientSocketInterface;
+  private readonly client: ClientSocketInterface;
 
   private constructor(client: ClientSocketInterface) {
     this.client = client;
@@ -24,7 +24,6 @@ export class ClientSocket {
   }
 
   static createNull(): ClientSocket {
-    // Implementation for null socket
     return new ClientSocket(new StubbedClientSocket());
   }
 
@@ -51,7 +50,8 @@ export class ClientSocket {
 
 class RealClientSocket implements ClientSocketInterface {
   private socket: WebSocket | null = null;
-  private url: string;
+  private readonly url: string;
+  private emitter = new EventEmitter();
 
   constructor(url: string) {
     this.url = url;
@@ -62,23 +62,45 @@ class RealClientSocket implements ClientSocketInterface {
   }
 
   connect(): Promise<void> {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       this.socket = new WebSocket(this.url);
       this.socket.onopen = () => {
         resolve();
       };
-      // this.socket.onerror = (err) => reject(err);
+      this.socket.onerror = (err) => {
+        reject(new Error(err.message satisfies string));
+      };
     });
   }
 
   close(): Promise<void> {
-    return Promise.resolve();
+    return new Promise((resolve) => {
+      if (!this.socket) {
+        resolve();
+        return;
+      }
+      this.socket.on('close', () => {
+        resolve();
+      });
+      this.socket.close();
+    });
   }
-  send(): Promise<void> {
-    return Promise.resolve();
+
+  send(message: unknown): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (!this.socket) {
+        reject(new Error('Socket is not connected'));
+        return;
+      }
+      this.socket.send(JSON.stringify(message), (err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
   }
+
   trackMessages(): OutputTracker {
-    return new OutputTracker(new EventEmitter(), '');
+    return new OutputTracker(this.emitter, EVENT_MESSAGES);
   }
 }
 

--- a/client/clientSocket.ts
+++ b/client/clientSocket.ts
@@ -1,4 +1,3 @@
-import { WebSocket, ClientOptions } from 'ws';
 import { EventEmitter, OutputTracker } from '../server/infrastructure/output_tracker.ts';
 import { ClientMessage, ServerMessage } from '../shared/protocol.ts';
 
@@ -19,13 +18,16 @@ export class ClientSocket {
     this.client = client;
   }
 
-  static create(url: string, options: ClientOptions = {}): ClientSocket {
+  static create(url: string, options?: { token?: string }): ClientSocket {
     const parsed = new URL(url);
     if (parsed.protocol !== 'ws:' && parsed.protocol !== 'wss:') {
       throw new Error(`Invalid WebSocket URL: expected ws:// or wss://, got ${parsed.protocol}`);
     }
+    if (options?.token) {
+      parsed.searchParams.set('token', options.token);
+    }
 
-    return new ClientSocket(new RealClientSocket(url, options));
+    return new ClientSocket(new RealClientSocket(parsed.toString()));
   }
 
   static createNull(): ClientSocket {
@@ -56,12 +58,10 @@ export class ClientSocket {
 class RealClientSocket implements ClientSocketInterface {
   private socket: WebSocket | null = null;
   private readonly url: string;
-  private readonly options: ClientOptions;
   private emitter = new EventEmitter();
 
-  constructor(url: string, options: ClientOptions = {}) {
+  constructor(url: string) {
     this.url = url;
-    this.options = options;
   }
 
   get isConnected(): boolean {
@@ -71,17 +71,17 @@ class RealClientSocket implements ClientSocketInterface {
   connect(): Promise<void> {
     return new Promise((resolve, reject) => {
       let settled = false;
-      this.socket = new WebSocket(this.url, this.options);
+      this.socket = new WebSocket(this.url);
       this.socket.onopen = () => {
         if (!settled) {
           settled = true;
           resolve();
         }
       };
-      this.socket.onerror = (err) => {
+      this.socket.onerror = () => {
         if (!settled) {
           settled = true;
-          reject(new Error(err.message satisfies string));
+          reject(new Error('WebSocket connection failed'));
         }
       };
     });
@@ -93,24 +93,19 @@ class RealClientSocket implements ClientSocketInterface {
         resolve();
         return;
       }
-      this.socket.on('close', () => {
+      this.socket.onclose = () => {
         resolve();
-      });
+      };
       this.socket.close();
     });
   }
 
   send(message: unknown): Promise<void> {
-    return new Promise((resolve, reject) => {
-      if (!this.socket) {
-        reject(new Error('Socket is not connected'));
-        return;
-      }
-      this.socket.send(JSON.stringify(message), (err) => {
-        if (err) reject(err);
-        else resolve();
-      });
-    });
+    if (!this.socket) {
+      return Promise.reject(new Error('Socket is not connected'));
+    }
+    this.socket.send(JSON.stringify(message));
+    return Promise.resolve();
   }
 
   trackMessages(): OutputTracker {

--- a/client/clientSocket.ts
+++ b/client/clientSocket.ts
@@ -61,7 +61,7 @@ export class StubbedServer {
   }
 }
 
-export class StubbedClientSocket implements ClientSocketInterface {
+class StubbedClientSocket implements ClientSocketInterface {
   private _isConnected = false;
   private emitter = new EventEmitter();
 

--- a/client/clientSocket.ts
+++ b/client/clientSocket.ts
@@ -1,4 +1,4 @@
-import { WebSocket } from 'ws';
+import { ClientOptions, WebSocket } from 'ws';
 import { EventEmitter, OutputTracker } from '../server/infrastructure/output_tracker.ts';
 import { ClientMessage, ServerMessage } from '../shared/protocol.ts';
 
@@ -19,8 +19,12 @@ export class ClientSocket {
     this.client = client;
   }
 
-  static create(url: string): ClientSocket {
-    return new ClientSocket(new RealClientSocket(url));
+  static create(url: string, options: ClientOptions = {}): ClientSocket {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'ws:' && parsed.protocol !== 'wss:') {
+      throw new Error(`Invalid WebSocket URL: expected ws:// or wss://, got ${parsed.protocol}`);
+    }
+    return new ClientSocket(new RealClientSocket(url, options));
   }
 
   static createNull(): ClientSocket {
@@ -52,9 +56,11 @@ export class ClientSocket {
 class RealClientSocket implements ClientSocketInterface {
   private socket: WebSocket | null = null;
   private url: string;
+  private options: ClientOptions;
 
-  constructor(url: string) {
+  constructor(url: string, options: ClientOptions) {
     this.url = url;
+    this.options = options;
   }
 
   get isConnected(): boolean {
@@ -62,12 +68,21 @@ class RealClientSocket implements ClientSocketInterface {
   }
 
   connect(): Promise<void> {
-    return new Promise((resolve) => {
-      this.socket = new WebSocket(this.url);
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      this.socket = new WebSocket(this.url, this.options);
       this.socket.onopen = () => {
-        resolve();
+        if (!settled) {
+          settled = true;
+          resolve();
+        }
       };
-      // this.socket.onerror = (err) => reject(err);
+      this.socket.onerror = (err) => {
+        if (!settled) {
+          settled = true;
+          reject(new Error(err.message satisfies string));
+        }
+      };
     });
   }
 

--- a/client/clientSocket.ts
+++ b/client/clientSocket.ts
@@ -20,6 +20,10 @@ export class ClientSocket {
   }
 
   static create(url: string): ClientSocket {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'ws:' && parsed.protocol !== 'wss:') {
+      throw new Error(`Invalid WebSocket URL: expected ws:// or wss://, got ${parsed.protocol}`);
+    }
     return new ClientSocket(new RealClientSocket(url));
   }
 

--- a/client/main.ts
+++ b/client/main.ts
@@ -1,4 +1,17 @@
+import { ClientSocket } from './clientSocket.ts';
+
+const client = ClientSocket.create('ws://localhost:9876');
+client
+  .connect()
+  .then(() => {
+    console.log('Connected to server');
+  })
+  .catch((err: unknown) => {
+    console.error('Failed to connect to server:', err);
+  });
+
 const app = document.getElementById('app');
 if (app) {
   app.textContent = 'EkoLite is running.';
+  app.textContent = `Client connection:  ${client.isConnected ? 'ON' : 'OFF'}`;
 }

--- a/client/main.ts
+++ b/client/main.ts
@@ -1,10 +1,17 @@
 import { ClientSocket } from './clientSocket.ts';
 
-const client = ClientSocket.create('ws://localhost:9876');
+const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+const url = `${protocol}//${window.location.host}/ws`;
+
+const client = ClientSocket.create(url);
 client
   .connect()
   .then(() => {
-    console.log('Connected to server');
+    console.warn('Connected to server');
+    const app = document.getElementById('app');
+    if (app) {
+      app.textContent = `EkoLite is running. Connection: ${client.isConnected ? 'ON' : 'OFF'}`;
+    }
   })
   .catch((err: unknown) => {
     console.error('Failed to connect to server:', err);
@@ -13,5 +20,4 @@ client
 const app = document.getElementById('app');
 if (app) {
   app.textContent = 'EkoLite is running.';
-  app.textContent = `Client connection:  ${client.isConnected ? 'ON' : 'OFF'}`;
 }

--- a/learning/browser-vs-node-websocket.md
+++ b/learning/browser-vs-node-websocket.md
@@ -1,0 +1,247 @@
+# Browser vs Node: Why Our Client Code Blew Up
+
+> "To simply think about the people, as the dominators do, without any self-giving in that thought, is to deny them their right to think." Paulo Freire
+
+At EkoHacks we don't hand you the answer and move on. We show you the broken thing, ask you why it's broken, and let you figure it out. That way when you see it next time, and you will, you don't need anyone to tell you.
+
+## The error
+
+Run `npm run dev:client`, open the browser, open DevTools (F12), check the Console. You'll see:
+
+```
+Failed to connect to server: TypeError: WebSocket is not a constructor
+```
+
+The app loads. The HTML renders. Then it tries to connect and falls over.
+
+## Before you read on
+
+Open `client/clientSocket.ts` and look at line 1. Then open the browser console and type `WebSocket`. Hit enter. Now type `require('ws')`. Hit enter.
+
+**Question for the pair:** What did each of those return? Why is one a thing and the other isn't?
+
+## The root cause
+
+Line 1 was:
+
+```ts
+import { WebSocket, ClientOptions } from 'ws';
+```
+
+`ws` is an npm package. It's a WebSocket implementation for Node. It works beautifully in Node because Node didn't always have WebSocket built in. But the browser is not Node.
+
+The browser already has `WebSocket`. It's a global. It's been there since 2011. You don't install it, you don't import it, it's just there. Type `WebSocket` in any browser console and you'll see it.
+
+When Vite bundles `client/clientSocket.ts` for the browser, it sees `import { WebSocket } from 'ws'` and tries to resolve the `ws` package for the browser environment. It can't. `ws` depends on Node built ins like `net`, `http`, `stream`. None of those exist in the browser. So the import returns nothing. `WebSocket` is `undefined`. And `new undefined()` gives you `TypeError: WebSocket is not a constructor`.
+
+**Question for the pair:** All our tests ran in vitest, which uses Node. The `ws` package was installed. Everything was green. How did we miss this?
+
+## The fix
+
+Remove the import. The browser already has what we need.
+
+```diff
+- import { WebSocket, ClientOptions } from 'ws';
+```
+
+That's it for the constructor error. But removing the import exposed three more things that were quietly wrong. Each one is a difference between the `ws` library API and the browser's native WebSocket API.
+
+## Hidden problem 1: `.on('close')`
+
+The old `close()` method:
+
+```ts
+close(): Promise<void> {
+  return new Promise((resolve) => {
+    if (!this.socket) {
+      resolve();
+      return;
+    }
+    this.socket.on('close', () => {
+      resolve();
+    });
+    this.socket.close();
+  });
+}
+```
+
+**Stop and think.** Where does `.on()` come from?
+
+`.on()` is a Node EventEmitter method. The `ws` library makes its WebSocket class extend Node's EventEmitter, so `socket.on('close', cb)` works in Node. But the browser's WebSocket is not an EventEmitter. It doesn't have `.on()`. It has `.onclose` and `.addEventListener()`.
+
+**Try it.** Open the browser console:
+
+```js
+const ws = new WebSocket('ws://localhost:3001/ws');
+console.log(typeof ws.on); // what does this print?
+console.log(typeof ws.onclose); // what about this?
+```
+
+The fix:
+
+```ts
+close(): Promise<void> {
+  return new Promise((resolve) => {
+    if (!this.socket) {
+      resolve();
+      return;
+    }
+    this.socket.onclose = () => {
+      resolve();
+    };
+    this.socket.close();
+  });
+}
+```
+
+**Question for the pair:** What is the difference between `socket.onclose = cb` and `socket.addEventListener('close', cb)`? What happens if you assign `onclose` twice? What happens if you call `addEventListener` twice? When would you pick one over the other?
+
+## Hidden problem 2: `send(data, callback)`
+
+The old `send()` method:
+
+```ts
+send(message: unknown): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (!this.socket) {
+      reject(new Error('Socket is not connected'));
+      return;
+    }
+    this.socket.send(JSON.stringify(message), (err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+}
+```
+
+**Stop and think.** The `ws` library's `send()` accepts a callback as the second argument. It calls the callback when the data has been flushed to the network buffer, or with an error if something went wrong. That's a Node pattern.
+
+The browser's `send()` takes one argument: the data. No callback. It's synchronous. It either sends or it throws.
+
+**Try it.** Open the browser console:
+
+```js
+const ws = new WebSocket('ws://localhost:3001/ws');
+ws.onopen = () => {
+  ws.send('hello', (err) => console.log('callback fired'));
+  // does the callback fire?
+};
+```
+
+The fix:
+
+```ts
+send(message: unknown): Promise<void> {
+  if (!this.socket) {
+    return Promise.reject(new Error('Socket is not connected'));
+  }
+  this.socket.send(JSON.stringify(message));
+  return Promise.resolve();
+}
+```
+
+**Question for the pair:** The old version wrapped `send()` in a Promise and used the callback to resolve or reject. The new version just calls `send()` and resolves immediately. What do we lose? If `send()` fails in the browser, how would we know?
+
+## Hidden problem 3: `onerror` event shape
+
+The old `onerror` handler:
+
+```ts
+this.socket.onerror = (err) => {
+  if (!settled) {
+    settled = true;
+    reject(new Error(err.message satisfies string));
+  }
+};
+```
+
+**Stop and think.** The `ws` library fires `onerror` with an `ErrorEvent` that has a `.message` property. The browser fires `onerror` with a plain `Event`. No `.message`. No error details at all.
+
+**Try it.** Open the browser console:
+
+```js
+const ws = new WebSocket('ws://localhost:99999');
+ws.onerror = (e) => {
+  console.log(typeof e.message); // what does this print?
+  console.log(e); // what's actually in here?
+};
+```
+
+The fix:
+
+```ts
+this.socket.onerror = () => {
+  if (!settled) {
+    settled = true;
+    reject(new Error('WebSocket connection failed'));
+  }
+};
+```
+
+We lose the specific error message. That's a tradeoff. The browser intentionally hides WebSocket error details for security reasons (you shouldn't be able to probe internal network topology from JavaScript). So a generic message is the correct thing to do here.
+
+**Question for the pair:** Why would the browser hide error details from JavaScript? Think about what a malicious script in a browser tab could learn if `onerror` told it exactly why a connection to an internal IP address failed.
+
+## Hidden problem 4: the hardcoded URL
+
+This one isn't a Node vs browser issue. It's just wrong. The old `main.ts`:
+
+```ts
+const client = ClientSocket.create('ws://localhost:9876');
+```
+
+Port 9876. The server runs on port 3001. And Vite's dev server proxies `/ws` to `ws://localhost:3001`. So the correct URL in the browser is relative to the current page:
+
+```ts
+const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+const url = `${protocol}//${window.location.host}/ws`;
+```
+
+This way the same code works in dev (Vite proxy) and production (direct).
+
+**Question for the pair:** Why do we check `window.location.protocol` and swap between `ws:` and `wss:`? What is the relationship between `http`/`https` and `ws`/`wss`? What would happen if you used `ws:` on an `https:` page?
+
+## The auth tests
+
+There was also a change to the integration tests. The old auth tests did this:
+
+```ts
+const client = ClientSocket.create(`ws://localhost:${String(PORT)}`, {
+  headers: { Authorization: 'Bearer test-token' },
+});
+```
+
+`ClientSocket.create()` used to accept an options object as a second argument and pass it straight to the `ws` library's WebSocket constructor. That's how we sent auth headers.
+
+But the browser's WebSocket constructor doesn't accept headers. The browser signature is `new WebSocket(url, protocols?)` where protocols is a string or array of strings. Not an options object. Not headers.
+
+So the auth tests now use the `ws` library directly, because they're testing server side auth behaviour, not our `ClientSocket` class:
+
+```ts
+import { WebSocket as WsWebSocket } from 'ws';
+
+const ws = new WsWebSocket(`ws://localhost:${String(PORT)}`, {
+  headers: { Authorization: 'Bearer test-token' },
+});
+```
+
+**Question for the pair:** If the browser's WebSocket can't send custom headers, how do real web apps authenticate WebSocket connections? There are at least three common approaches. See if you can find them. Think about cookies, query parameters, and what you could send as the first message after connecting.
+
+## The big lesson
+
+All our tests passed. Every single one. Green across the board. And the code was fundamentally broken in the environment where it actually needed to run.
+
+This happened because the tests ran in Node (via vitest) and the code was written using the Node `ws` library. The tests and the production code were both speaking Node. They agreed with each other perfectly. But the production code was supposed to speak browser.
+
+**Rule:** If a file lives in `client/`, it runs in the browser. Do not import server packages. If you're not sure whether something is a browser API or a Node API, check MDN for the browser version and the Node docs for the Node version. They are not the same thing, even when they have the same name.
+
+**Question for the pair:** Can you think of other APIs where Node and the browser both have something with the same name but different behaviour? `fetch` is one. `setTimeout` is another. `URL` is another. Pick one and find a difference.
+
+## Your turn
+
+Open `server/infrastructure/websocket.ts` and look at how the server imports from `ws`. That's fine because the server runs in Node. Now open `client/clientSocket.ts` and check that nothing from Node has crept back in. Read every import. Ask yourself: does this exist in the browser?
+
+Then run `npm run dev:client`, open the browser, open DevTools > Network > WS tab. Do you see a WebSocket connection? If you do, EKO-234 is one step closer to done done.
+
+> At EkoHacks we don't just write code that passes tests. We make sure it works where it's supposed to work.

--- a/learning/design-evolution-websocket-auth.md
+++ b/learning/design-evolution-websocket-auth.md
@@ -1,0 +1,181 @@
+# Design Evolution: WebSocket Auth and the Options Problem
+
+> "Knowledge emerges only through invention and reinvention, through the restless, impatient, continuing, hopeful inquiry human beings pursue in the world." Paulo Freire
+
+This one is about how a design changes when it hits a real constraint. We had working code. We had passing tests. Then the code ran in the browser and broke. The fix solved the browser problem but created a gap in our test coverage. We spotted the gap, reasoned about it, and closed it. This session walks through that whole journey so you can see how design evolves when you pay attention.
+
+## Where we started
+
+`ClientSocket.create()` used to look like this:
+
+```ts
+static create(url: string, options: ClientOptions = {}): ClientSocket {
+  const parsed = new URL(url);
+  if (parsed.protocol !== 'ws:' && parsed.protocol !== 'wss:') {
+    throw new Error(`Invalid WebSocket URL: expected ws:// or wss://, got ${parsed.protocol}`);
+  }
+  return new ClientSocket(new RealClientSocket(url, options));
+}
+```
+
+And `RealClientSocket` passed those options straight through to the `ws` library:
+
+```ts
+this.socket = new WebSocket(this.url, this.options);
+```
+
+`ClientOptions` came from the `ws` package. It let you pass headers, custom agents, TLS options, anything Node's HTTP stack supports during the WebSocket upgrade handshake.
+
+The auth integration tests used this to pass an `Authorization` header:
+
+```ts
+const client = ClientSocket.create(`ws://localhost:${String(PORT)}`, {
+  headers: { Authorization: 'Bearer test-token' },
+});
+await client.connect();
+expect(client.isConnected).toBe(true);
+```
+
+That tested our code. `ClientSocket` received options, forwarded them to the real WebSocket, and the server's `verifyClient` callback accepted or rejected the connection based on the header.
+
+## What broke
+
+The browser's WebSocket constructor is not the same as the `ws` library's constructor.
+
+```
+ws library (Node):     new WebSocket(url, protocols, options)
+Browser (native):      new WebSocket(url, protocols)
+```
+
+No options. No headers. The browser doesn't let JavaScript set custom headers on a WebSocket upgrade request. That's by design. The browser controls the upgrade handshake, not your code.
+
+So when we removed the `ws` import to fix the browser error, the options parameter became meaningless. There was nothing to pass it to.
+
+**Question for the pair:** Why would the browser prevent you from setting custom headers on a WebSocket upgrade? Think about what a malicious script could do if it could set arbitrary headers on cross origin requests.
+
+## The gap
+
+With the `ws` import gone and the options removed, the auth tests had nothing to go through. They couldn't call `ClientSocket.create(url, { headers: ... })` anymore because that API didn't exist.
+
+That left us with a choice: drop the auth tests entirely, or find a way to do auth that works in the browser and goes through our code.
+
+**Question for the pair:** Why is it a problem if our tests only exercise someone else's library? Think about what happens when you upgrade the library. Think about what the test is supposed to catch and whether it can still catch it.
+
+## The real question
+
+The question isn't "how do we put the options back." The question is: **does our WebSocket connection need authentication, and if so, whose job is it?**
+
+### What does our app actually do?
+
+Right now, EkoLite is a single page app. One page, one server, no users, no login. Anyone who can reach the server can connect. That's fine for a demo.
+
+**Question for the pair:** At what point would we actually need auth on the WebSocket? What would have to change in the app for unauthenticated connections to be a problem?
+
+### If we do need auth, where does the check happen?
+
+There are two sides to every connection. The client sends something. The server checks it. Both sides need to agree on what "something" is.
+
+**Server side (Fastify):**
+
+The server already has access to everything it needs during the upgrade handshake. Look at `server/plugins/websocketRoutes.ts`:
+
+```ts
+app.get('/ws', { websocket: true }, (socket) => {
+  // ...
+});
+```
+
+That handler receives the socket, but the route also has access to the HTTP request via Fastify's hook system. You could add a `preValidation` hook, check a cookie, check a query param, check whatever you like. If validation fails, Fastify returns a 401 before the WebSocket connection is ever established.
+
+**Question for the pair:** What is the difference between checking auth during the upgrade handshake vs checking auth after the connection is open? Think about timing. Think about what happens if an unauthenticated client connects and the server has to kick them off.
+
+### What can the browser actually send?
+
+The browser's WebSocket constructor gives you two things to work with:
+
+1. **The URL** including query parameters
+2. **Protocols** (a string or array of strings)
+
+That's it. No headers. No body. But the browser also sends cookies automatically on the upgrade request if the domain matches.
+
+So the browser compatible auth options are:
+
+| Approach          | How it works                                                                                | Tradeoff                                                                                                                                                     |
+| ----------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Cookies**       | Server sets an HTTP-only cookie on login. Browser sends it automatically on the WS upgrade. | Requires a login flow first. Cookie handling adds complexity. But it's the most secure and the client code doesn't need to know about auth at all.           |
+| **Query params**  | `ws://localhost/ws?token=xxx`                                                               | Simple. But the token is in the URL. URLs end up in server logs, browser history, proxy logs. Not great for secrets.                                         |
+| **First message** | Connect first, then send `{ type: 'auth', token: 'xxx' }` as the first message.             | Works with any transport. But there's a window between connect and auth where the client is connected but unverified. The server needs to handle that state. |
+| **Subprotocol**   | `new WebSocket(url, 'token.xxx')`                                                           | Hacky. The protocol field isn't meant for auth. Some libraries don't handle it well.                                                                         |
+
+**Question for the pair:** Look at the tradeoffs. Which approach fits EkoLite best right now? Think about what we're building, who the users are, and what's simplest. Think about which approach our Fastify server could check with the least new code.
+
+## What we chose
+
+Query params. Simplest thing that works in the browser and lets us test our own code.
+
+`ClientSocket.create()` now takes an optional `{ token }`:
+
+```ts
+static create(url: string, options?: { token?: string }): ClientSocket {
+  const parsed = new URL(url);
+  if (parsed.protocol !== 'ws:' && parsed.protocol !== 'wss:') {
+    throw new Error(`Invalid WebSocket URL: expected ws:// or wss://, got ${parsed.protocol}`);
+  }
+  if (options?.token) {
+    parsed.searchParams.set('token', options.token);
+  }
+
+  return new ClientSocket(new RealClientSocket(parsed.toString()));
+}
+```
+
+If you pass a token, it gets appended to the URL as a query parameter. `ClientSocket` builds the URL. The server checks the URL. Both sides are our code.
+
+**Stop and read.** Open `client/clientSocket.ts` and find `create()`. Then open `tests/client/clientSocket.integration.test.ts` and find the auth describe block. Read the `createAuthServer()` function. Trace how the token flows from the test, through `create()`, into the URL, and into the server's `verifyClient` callback.
+
+The integration tests now look like this:
+
+```ts
+it('rejects connections without a token', async () => {
+  rawServer = createAuthServer();
+  const client = ClientSocket.create(`ws://localhost:${String(PORT)}`);
+  await expect(client.connect()).rejects.toThrow();
+});
+
+it('connects when a valid token is provided', async () => {
+  rawServer = createAuthServer();
+  const client = ClientSocket.create(`ws://localhost:${String(PORT)}`, {
+    token: 'test-token',
+  });
+  await client.connect();
+  expect(client.isConnected).toBe(true);
+  await client.close();
+});
+```
+
+Both tests go through `ClientSocket.create()`. Both tests exercise our code. The `ws` library and `WebSocketServer` are just the transport underneath. They should have tested their own code. We test ours.
+
+**Question for the pair:** The server in the test uses `verifyClient` from the `ws` library's `WebSocketServer`. In production we'd use Fastify with a `preValidation` hook instead. Does that matter for what we're testing here? What are we actually proving with these tests?
+
+## The tradeoff we accepted
+
+The token is in the URL. That means it's visible in server logs, browser history, and any proxy between client and server. For a demo app with no real users, that's fine. For production with real credentials, we'd probably move to cookies or short lived tokens.
+
+**Question for the pair:** Is there a risk in building on top of query param auth and then needing to change later? What would have to change in `ClientSocket` if we switched to cookies? What about the tests?
+
+## The design evolution lesson
+
+Here's what happened, step by step:
+
+1. We built `ClientSocket` with the `ws` library. It worked. Tests passed.
+2. We ran it in the browser. It broke because `ws` is Node only.
+3. We removed the `ws` dependency. That fixed the browser but removed the options parameter.
+4. The auth tests lost their connection to our code. We spotted the gap.
+5. We looked at the browser compatible options, picked query params, and rebuilt auth through our own API.
+6. The tests go through our code again. The gap is closed.
+
+That's how design evolves. You make a choice, you learn something, the choice no longer fits, you adapt. Each step made sense at the time. The important thing is that we noticed the gap at step 4 instead of shipping it and moving on.
+
+**The rule:** When a constraint forces you to change your approach, don't just fix the immediate problem. Trace the impact. Check what else broke. A fix that creates a gap you don't know about is worse than the original bug.
+
+> At EkoHacks we don't just ship code. We understand why the design is the way it is, and we can trace every decision back to a real constraint.

--- a/learning/pr-20-security-review/01-security-first.md
+++ b/learning/pr-20-security-review/01-security-first.md
@@ -1,0 +1,222 @@
+# Security First: What PR #20 Taught Us
+
+> "Education must begin with the solution of the student teacher contradiction, by reconciling the poles of the contradiction so that both are simultaneously teachers and students." Paulo Freire
+
+This is not a lecture. This is a conversation. Read the code, answer the questions, and talk to your pair about what you notice. The goal is not to memorise rules. The goal is to train your eye so you see these things before anyone has to point them out.
+
+## 1. The Hanging Promise
+
+Here is the original `connect()` method. Read it carefully.
+
+```ts
+connect(): Promise<void> {
+  return new Promise((resolve) => {
+    this.socket = new WebSocket(this.url);
+    this.socket.onopen = () => {
+      resolve();
+    };
+    // this.socket.onerror = (err) => reject(err);
+  });
+}
+```
+
+**Stop and think:**
+
+- What happens if the server is not running?
+- What happens if the URL is wrong?
+- The promise resolves on `onopen`. What resolves it on failure?
+- If nothing resolves or rejects a promise, what happens to the caller that `await`s it?
+
+**Try it yourself.** Paste this into a scratch file and run it:
+
+```ts
+const never = new Promise((resolve) => {
+  // imagine the callback never fires
+});
+
+console.log('before await');
+await never;
+console.log('after await'); // does this ever print?
+```
+
+**The lesson:** Every `new Promise` needs both a resolve path AND a reject path. If you only handle the happy path, the sad path hangs forever. No error, no crash, just silence. That is worse than a crash because nobody knows something went wrong.
+
+**Now look at the fix:**
+
+```ts
+connect(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    this.socket = new WebSocket(this.url, this.options);
+    this.socket.onopen = () => {
+      if (!settled) {
+        settled = true;
+        resolve();
+      }
+    };
+    this.socket.onerror = (err) => {
+      if (!settled) {
+        settled = true;
+        reject(new Error(err.message satisfies string));
+      }
+    };
+  });
+}
+```
+
+**Questions for the pair:**
+
+- Why is `reject` wrapped in `new Error()`? What happens if you reject with something that is not an Error?
+- What is the `settled` flag doing? Can both `onopen` and `onerror` fire? (Yes, they can. Google "WebSocket onerror onclose order".)
+- If we removed the `settled` guard, what would happen when both events fire?
+
+## 2. The URL You Never Checked
+
+Original code:
+
+```ts
+static create(url: string): ClientSocket {
+  return new ClientSocket(new RealClientSocket(url));
+}
+```
+
+**Stop and think:**
+
+- What happens if someone passes `http://localhost:8080`?
+- What happens if someone passes `ftp://dodgy-server.com/payload`?
+- The `ws` library (the Node.js WebSocket client we use) will try to connect to anything. Should your code trust that every string it receives is a valid WebSocket URL?
+
+**The principle:** Validate at the boundary. When data enters your system from outside (user input, config, function parameters), check it before using it. Do not assume the caller got it right.
+
+**The fix:**
+
+```ts
+static create(url: string, options: ClientOptions = {}): ClientSocket {
+  const parsed = new URL(url);
+  if (parsed.protocol !== 'ws:' && parsed.protocol !== 'wss:') {
+    throw new Error(
+      `Invalid WebSocket URL: expected ws:// or wss://, got ${parsed.protocol}`
+    );
+  }
+  return new ClientSocket(new RealClientSocket(url, options));
+}
+```
+
+**Questions for the pair:**
+
+- What does `new URL(url)` do if the string is not a valid URL at all? (Try it in the console.)
+- Why do we check protocol specifically? What attack could a bad protocol enable?
+- Should this check live in `create()` or in `RealClientSocket`'s constructor? What is the tradeoff?
+
+## 3. The Open Door
+
+Here is the original integration test server:
+
+```ts
+webSocketServer = WebSocketWrapper.createRawWs({ port: PORT });
+await webSocketServer.start();
+const client = ClientSocket.create('ws://localhost:9877');
+await client.connect();
+// connected! no questions asked
+```
+
+**Stop and think:**
+
+- The server accepted the connection. Did it ask who the client was?
+- Could any process on the machine connect to this port?
+- In production, could any browser on the internet connect?
+- What is the difference between authentication (who are you?) and authorisation (are you allowed to do this?)?
+
+**Now look at the auth test:**
+
+```ts
+function createAuthServer(): WebSocketServer {
+  return new WebSocketServer({
+    port: PORT,
+    verifyClient: (info, cb) => {
+      const token = info.req.headers['authorization'];
+      if (!token) {
+        cb(false, 401, 'Unauthorized');
+        return;
+      }
+      cb(true);
+    },
+  });
+}
+
+it('rejects connections without an auth token', async () => {
+  rawServer = createAuthServer();
+  const client = ClientSocket.create(`ws://localhost:${String(PORT)}`, {});
+  await expect(client.connect()).rejects.toThrow();
+});
+
+it('connects when a valid auth header is provided', async () => {
+  rawServer = createAuthServer();
+  const client = ClientSocket.create(`ws://localhost:${String(PORT)}`, {
+    headers: { Authorization: 'Bearer test-token' },
+  });
+  await client.connect();
+  expect(client.isConnected).toBe(true);
+  await client.close();
+});
+```
+
+**Questions for the pair:**
+
+- The `verifyClient` callback runs during the HTTP upgrade handshake, before the WebSocket connection is established. Why is that important? What if we checked auth after the connection was open?
+- This test accepts any non empty token. What would a real implementation need to check?
+- Where should the auth check live: the client, the server, or both? Why?
+- What is `Bearer` in `Bearer test-token`? Look up "RFC 6750".
+
+## 4. The Tests That Lied
+
+The original integration test had this:
+
+```ts
+webSocketServer
+  .close()
+  .then(() => {
+    expect(client.isConnected).toBe(false);
+  })
+  .catch(() => {
+    expect(client.isConnected).toBe(true);
+  });
+```
+
+This test passed. But the assertions inside `.then()` and `.catch()` never actually ran.
+
+**Stop and think:**
+
+- The test function is `async`. The `.then()` chain is not `await`ed. What happens?
+- The test runner sees no errors thrown synchronously, so it reports green. But did it actually test anything?
+- How would you prove that a test assertion is actually running? Try it.
+
+**The lesson:** A green test is not the same as a good test. A test that never runs its assertions is worse than no test at all because it gives you false confidence. Always `await` your promises in async tests.
+
+## 5. The Cleanup That Wasn't
+
+Original `afterEach`:
+
+```ts
+afterEach(async () => {
+  await server.close(); // closes the Fastify server
+});
+```
+
+But the test created a `webSocketServer` on port 9877 that was never cleaned up in `afterEach`.
+
+**Stop and think:**
+
+- What happens to a port when a server is not properly closed?
+- If this test file had two tests, what would happen when the second test tries to start a server on the same port?
+- What is a resource leak? Can you name three types? (File handles, database connections, network ports...)
+
+**The principle:** If you open it, close it. If you start it, stop it. Always in `afterEach`, never inside the test body, because `afterEach` runs even when the test fails.
+
+## Your Turn
+
+Pick one of these patterns and find it in another part of the codebase. Does our server code validate URLs? Do we clean up every resource we open? Where else might a promise hang?
+
+Look at the code you wrote last week. What would you change?
+
+> "Knowledge emerges only through invention and reinvention, through the restless, impatient, continuing, hopeful inquiry human beings pursue in the world, with the world, and with each other." Paulo Freire

--- a/learning/pr-20-security-review/02-closures-show-and-tell.md
+++ b/learning/pr-20-security-review/02-closures-show-and-tell.md
@@ -1,0 +1,199 @@
+# Closures: A Show and Tell
+
+> At the dojo we understand what our tools do. We do not just use them. We know how they work.
+
+## What is a closure?
+
+A closure is when a function remembers variables from the place where it was defined, even after that place has finished executing.
+
+That is it. That is the whole concept.
+
+## Show me
+
+Open `tests/client/clientSocket.integration.test.ts` and look at this:
+
+```ts
+describe('ClientSocket auth', () => {
+  const PORT = 9878;
+
+  function createAuthServer(): WebSocketServer {
+    return new WebSocketServer({
+      port: PORT, // <-- where does PORT come from?
+      verifyClient: (info, cb) => {
+        const token = info.req.headers['authorization'];
+        if (!token) {
+          cb(false, 401, 'Unauthorized');
+          return;
+        }
+        cb(true);
+      },
+    });
+  }
+
+  it('rejects connections without an auth token', async () => {
+    rawServer = createAuthServer();
+    const client = ClientSocket.create(`ws://localhost:${String(PORT)}`);
+    // ...
+  });
+});
+```
+
+`createAuthServer` is defined inside the `describe` block. `PORT` is defined in the `describe` block. The function uses `PORT` even though `PORT` is not a parameter and not defined inside the function.
+
+That is a closure. `createAuthServer` "closes over" the variable `PORT`.
+
+## Why should I care?
+
+Because closures are everywhere in JavaScript and you are already using them. Every callback you have ever written inside a function is probably a closure.
+
+### Example 1: Event handlers
+
+```ts
+this.socket.onopen = () => {
+  resolve(); // resolve comes from the enclosing Promise constructor
+};
+```
+
+`resolve` is not defined inside the arrow function. It comes from the `new Promise((resolve, reject) => { ... })` that wraps it. The arrow function closes over `resolve`.
+
+### Example 2: The settled guard
+
+```ts
+connect(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let settled = false;                    // defined here
+
+    this.socket.onopen = () => {
+      if (!settled) {                       // used here
+        settled = true;                     // mutated here
+        resolve();
+      }
+    };
+
+    this.socket.onerror = (err) => {
+      if (!settled) {                       // and here
+        settled = true;                     // and here
+        reject(new Error(err.message));
+      }
+    };
+  });
+}
+```
+
+Two separate functions (`onopen` handler and `onerror` handler) both close over the same `settled` variable. When one sets it to `true`, the other sees the change. They share the same variable, not a copy of it.
+
+**Question:** What would happen if each function got its own copy of `settled` instead of sharing the same one? Would the race condition guard still work?
+
+### Example 3: The OutputTracker
+
+```ts
+export class OutputTracker {
+  private _data: unknown[] = [];
+
+  constructor(emitter: EventEmitter, eventType: string) {
+    emitter.on(eventType, (data: unknown) => {
+      this._data.push(data); // this arrow function closes over `this`
+    });
+  }
+}
+```
+
+The callback passed to `emitter.on` will fire later, possibly much later, long after the constructor has returned. But it still has access to `this._data` because the arrow function closes over `this` from the constructor scope, and then accesses `_data` as a property on it. Arrow functions do not have their own `this`. They always use the one from where they were defined.
+
+## The mental model
+
+Think of it like a backpack. When a function is created, it packs up all the variables from its surrounding scope and carries them along. Wherever that function goes, whatever calls it, it still has its backpack.
+
+```
+┌─────────────────────────────────────┐
+│ describe('ClientSocket auth')       │
+│                                     │
+│   const PORT = 9878                 │
+│                                     │
+│   function createAuthServer() {     │
+│     ┌─────────────┐                │
+│     │  backpack:   │                │
+│     │  PORT = 9878 │                │
+│     └─────────────┘                │
+│     return new WebSocketServer({    │
+│       port: PORT   // from backpack │
+│     });                             │
+│   }                                 │
+│                                     │
+└─────────────────────────────────────┘
+```
+
+## Common traps
+
+### Trap 1: The loop variable
+
+```ts
+// broken
+for (var i = 0; i < 3; i++) {
+  setTimeout(() => console.log(i), 100);
+}
+// prints: 3, 3, 3 (not 0, 1, 2)
+```
+
+Why? All three arrow functions close over the same `i`. By the time they run, the loop is done and `i` is 3.
+
+```ts
+// fixed with let (block scoped, each iteration gets its own)
+for (let i = 0; i < 3; i++) {
+  setTimeout(() => console.log(i), 100);
+}
+// prints: 0, 1, 2
+```
+
+**Question:** Why does `let` fix this but `var` does not? What is the difference in scoping?
+
+### Trap 2: Accidental memory leaks
+
+If a closure holds a reference to a large object, that object cannot be garbage collected as long as the closure exists.
+
+```ts
+function setup() {
+  const hugeArray = new Array(1_000_000).fill('data');
+
+  return () => {
+    console.log(hugeArray.length); // hugeArray lives forever now
+  };
+}
+
+const leakyFn = setup();
+// setup() finished, but hugeArray is still in memory
+// because leakyFn's closure holds a reference to it
+```
+
+**Question:** How would you fix this? When is it OK and when is it a problem?
+
+## Try it yourself
+
+1. Open a Node REPL (`node` in your terminal)
+2. Read the code below and predict the output before running it. Write your predictions down. Then type it in:
+
+```js
+function makeCounter() {
+  let count = 0;
+  return {
+    increment: () => ++count,
+    getCount: () => count,
+  };
+}
+
+const counter = makeCounter();
+console.log(counter.getCount()); // what does this print?
+counter.increment();
+counter.increment();
+console.log(counter.getCount()); // what about this?
+```
+
+3. Now make a second counter: `const counter2 = makeCounter()`. Does incrementing `counter2` affect `counter`? Why or why not?
+
+## The one sentence version
+
+A closure is a function that remembers the variables from where it was born.
+
+Every time you write a callback, an event handler, or a function inside another function, you are using closures. Now you know what to call it.
+
+> At EkoHacks we do not just write code that works. We understand why it works.

--- a/learning/retro-settled-race-condition.md
+++ b/learning/retro-settled-race-condition.md
@@ -1,0 +1,219 @@
+# The Settled Guard: What Our Tests Can and Cannot Prove
+
+> "The teacher is no longer merely the one who teaches, but one who is taught in dialogue with the students." Paulo Freire
+
+At EkoHacks we don't just write code that passes tests. We understand what those tests actually guarantee and, just as importantly, where the guarantees stop. This session walks through a real pattern from our codebase and asks you to think critically about the boundary between what tests prove and what design proves.
+
+## What is a race condition?
+
+Two things are supposed to happen one at a time. But they happen at the same time, or in the wrong order, and the result is broken.
+
+Think of it like this. You and your flatmate both check the fridge. Both of you see there's no milk. Both of you go to the shop. Now you've got two cartons and nobody needed two. You both "read" the same state (no milk) and both "wrote" (bought milk) because neither of you knew the other one was already handling it.
+
+In code it works the same way. Two callbacks, two event handlers, two async operations. They both try to do the same thing. If you don't coordinate them, one of them does something it shouldn't.
+
+### Where this shows up in our code
+
+When a WebSocket connects, the runtime can fire two events:
+
+- `onopen` — connection succeeded
+- `onerror` — something went wrong
+
+Normally only one fires. But in some runtimes, under certain network conditions, both can fire. That's the race. Two callbacks racing to settle the same promise. Whichever one runs first should win. The other should do nothing.
+
+**Try this thought experiment.** You call `connect()`. The TCP handshake completes. `onopen` fires, the promise resolves, your code carries on. Then a split second later the connection hiccups and `onerror` fires too. What should happen?
+
+Nothing. The connection worked. The promise already resolved. The error handler should see that someone already dealt with it and back off.
+
+That's what the `settled` flag does. First one in sets it to `true`. Second one checks, sees `true`, walks away.
+
+**Question for the pair:** What would happen if there was no `settled` flag and both callbacks ran? Remember that `reject()` on an already resolved promise is silently ignored by the runtime. So the promise itself is fine. But what about any other code inside those callbacks?
+
+## The code
+
+Open `client/clientSocket.ts` and find the `connect()` method on `RealClientSocket`. Read it properly, don't skim. Then come back.
+
+```ts
+connect(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    this.socket = new WebSocket(this.url, this.options);
+    this.socket.onopen = () => {
+      if (!settled) {
+        settled = true;
+        resolve();
+      }
+    };
+    this.socket.onerror = (err) => {
+      if (!settled) {
+        settled = true;
+        reject(new Error(err.message satisfies string));
+      }
+    };
+  });
+}
+```
+
+You already know what `settled` does from the closures session. Two functions sharing the same variable so the first one to fire wins.
+
+But now the question is different. Now it's about **testing**.
+
+## What the tests prove
+
+Open `tests/client/clientSocket.integration.test.ts` and find the `ClientSocket connect settles once` describe block. Two tests. Read both.
+
+### Test 1: "ignores onerror after onopen has already resolved"
+
+```ts
+it('ignores onerror after onopen has already resolved', async () => {
+  webSocketServer = WebSocketWrapper.createRawWs({ port: PORT });
+  await webSocketServer.start();
+  const client = ClientSocket.create(`ws://localhost:${String(PORT)}`);
+
+  await client.connect();
+  expect(client.isConnected).toBe(true);
+
+  await client.close();
+});
+```
+
+**Stop and think:**
+
+- This test starts a server, connects, checks it worked, then closes. What is it actually testing?
+- Does it ever trigger `onerror`?
+- If you removed the `settled` guard entirely, would this test still pass?
+
+**Be honest with yourself.** This test proves the happy path resolves. It proves `onopen` fires and the promise settles. That is all. It does not exercise the race condition. It cannot.
+
+### Test 2: "rejects once when server is not running"
+
+```ts
+it('rejects once when server is not running', async () => {
+  webSocketServer = WebSocketWrapper.createRawWs({ port: PORT });
+  await webSocketServer.start();
+  await webSocketServer.close();
+
+  const client = ClientSocket.create(`ws://localhost:${String(PORT)}`);
+  await expect(client.connect()).rejects.toThrow();
+});
+```
+
+**Stop and think:**
+
+- The server starts and then immediately closes. Why?
+- When the client tries to connect, what fires: `onopen` or `onerror`?
+- If you removed the `settled` guard, would this test still pass?
+
+**Be honest with yourself.** This test proves the sad path rejects. `onerror` fires, the promise rejects, the caller gets an error. It does not test what happens when both paths fire.
+
+## How we know the tests aren't lying
+
+When we wrote these tests, they went green immediately. That's suspicious. A test that was never red could be testing nothing.
+
+So we broke the code on purpose. We commented out `resolve()` inside `onopen` and ran the suite.
+
+```
+❯ tests/client/clientSocket.integration.test.ts (5 tests | 3 failed) 35052ms
+  × ClientSocket (real) > connects to a real server 5020ms
+    → Test timed out in 5000ms.
+  × ClientSocket connect settles once > ignores onerror after onopen has already resolved 15010ms
+    → Test timed out in 5000ms.
+  ✓ ClientSocket connect settles once > rejects once when server is not running 7ms
+  ✓ ClientSocket auth > rejects connections without an auth token 5ms
+  × ClientSocket auth > connects when a valid auth header is provided 15009ms
+    → Test timed out in 5000ms.
+```
+
+Three tests hung and timed out. `await client.connect()` never returned because `resolve()` never got called. The promise just sat there. No error, no crash, just silence. The test runner waited 5 seconds and went red.
+
+That's what these tests guard against. If someone removes or breaks `resolve()`, or messes up the state that `isConnected` depends on, these tests catch it immediately.
+
+**Question for the pair:** Look at the output above. Two tests still passed. Why did those two not care that `resolve()` was missing?
+
+## The gap
+
+Here is the scenario the `settled` guard actually protects against:
+
+```
+1. Client calls connect()
+2. WebSocket starts the TCP handshake
+3. onopen fires → promise resolves → caller continues
+4. Something goes wrong on the now-open connection
+5. onerror fires → tries to reject the same promise
+```
+
+Step 5 is the problem. The promise already resolved in step 3. Calling `reject()` on an already-resolved promise is silently ignored by the runtime. So without the guard it wouldn't crash. But.
+
+**Question for the pair:** If `reject()` on a settled promise is silently ignored, why do we need the `settled` guard at all? What is the guard actually preventing?
+
+Think about it before reading on.
+
+## The real reason
+
+The guard is not protecting `resolve` and `reject`. The JavaScript runtime already handles double settlement. You cannot settle a promise twice.
+
+The guard is protecting **everything else inside the callbacks**.
+
+Imagine the code grows. Someone adds logging, state changes, or cleanup inside `onerror`:
+
+```ts
+this.socket.onerror = (err) => {
+  if (!settled) {
+    settled = true;
+    this.connectionAttempts++;
+    this.lastError = err.message;
+    reject(new Error(err.message));
+  }
+};
+```
+
+Without the guard, those side effects run even when the connection already succeeded. `connectionAttempts` gets incremented on a successful connection. `lastError` gets set even though there was no real error. State gets corrupted silently.
+
+The `settled` flag is not about the promise. It is about making the intent explicit: **once one path wins, the other path does nothing. Full stop.** Not just "doesn't settle the promise" but "doesn't execute at all."
+
+**Question for the pair:** Can you think of a scenario in our codebase where running `onerror` side effects after a successful `onopen` would cause a real bug? Look at how we use `isConnected`. What would happen if error handling code set `isConnected = false` after a successful connection?
+
+## Why we cannot test this with a real WebSocket
+
+To test the race condition properly, we would need to:
+
+1. Start a real server
+2. Connect a real client
+3. Have `onopen` fire
+4. Then force `onerror` to fire on the same socket
+
+Step 4 is the problem. We do not control when the runtime fires WebSocket events. We cannot tell a real WebSocket "fire onerror now." Those events come from the operating system's network stack, not from our code.
+
+**Question for the pair:** Could we test this with the null/stubbed version? What would we need to add to `StubbedClientSocket` to simulate both events firing? Would that test be testing our code or testing our simulation?
+
+## What the tests do guarantee
+
+| Test                                                | What it proves                                                                                                                      |
+| --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| "ignores onerror after onopen has already resolved" | The resolve path works. `onopen` fires, promise resolves, `isConnected` is true. If someone breaks the happy path, this catches it. |
+| "rejects once when server is not running"           | The reject path works. `onerror` fires, promise rejects with an error. If someone breaks error handling, this catches it.           |
+
+Together they prove that **both branches of the settled guard work independently**. They do not prove the guard works when both branches race. That is a design guarantee, not a test guarantee.
+
+## The lesson
+
+Some code is correct by design, not by test. The `settled` guard is a pattern. It works because of how closures and shared mutable state behave, and you proved that to yourselves in the closures session. The tests verify each path in isolation. The design ensures they don't interfere.
+
+**This is not a failure of testing.** This is a boundary. Know which guarantees come from your tests and which come from your design. Don't confuse the two. Don't claim a test covers something it doesn't.
+
+When you write a `settled` guard in future code, and you will, you now know:
+
+1. Write a test for the resolve path
+2. Write a test for the reject path
+3. Know that the guard itself is a design decision backed by how closures work
+4. Document why the guard exists so the next person doesn't remove it thinking it's dead code
+
+## Your turn
+
+Look at `RealWebSocketServer.start()` in `server/infrastructure/websocket.ts`. It has a `new Promise` with a resolve inside a callback.
+
+- Does it have a reject path?
+- What happens if the server fails to start?
+- Should it have a settled guard? Why or why not?
+
+> At EkoHacks we don't just write tests that pass. We understand what passing means.

--- a/tests/client/clientSocket.integration.test.ts
+++ b/tests/client/clientSocket.integration.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
+import { WebSocketServer } from 'ws';
 import { ClientSocket } from '../../client/clientSocket.ts';
 import { WebSocketWrapper } from '../../server/infrastructure/websocket.ts';
 
@@ -19,5 +20,48 @@ describe('ClientSocket (real)', () => {
     await client.connect();
     expect(client.isConnected).toBe(true);
     expect(webSocketServer.clientCount).toBe(1);
+  });
+});
+
+describe('ClientSocket auth', () => {
+  const PORT = 9878;
+  let rawServer: WebSocketServer;
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => {
+      rawServer.close(() => {
+        resolve();
+      });
+    });
+  });
+
+  function createAuthServer(): WebSocketServer {
+    return new WebSocketServer({
+      port: PORT,
+      verifyClient: (info, cb) => {
+        const token = info.req.headers['authorization'];
+        if (!token) {
+          cb(false, 401, 'Unauthorized');
+          return;
+        }
+        cb(true);
+      },
+    });
+  }
+
+  it('rejects connections without an auth token', async () => {
+    rawServer = createAuthServer();
+    const client = ClientSocket.create(`ws://localhost:${String(PORT)}`, {});
+    await expect(client.connect()).rejects.toThrow();
+  });
+
+  it('connects when a valid auth header is provided', async () => {
+    rawServer = createAuthServer();
+    const client = ClientSocket.create(`ws://localhost:${String(PORT)}`, {
+      headers: { Authorization: 'Bearer test-token' },
+    });
+    await client.connect();
+    expect(client.isConnected).toBe(true);
+    await client.close();
   });
 });

--- a/tests/client/clientSocket.integration.test.ts
+++ b/tests/client/clientSocket.integration.test.ts
@@ -13,7 +13,6 @@ describe('ClientSocket (real)', () => {
   });
 
   afterEach(async () => {
-    void webSocketServer.close();
     await server.close();
   });
 
@@ -24,6 +23,13 @@ describe('ClientSocket (real)', () => {
     await client.connect();
     expect(client.isConnected).toBe(true);
     expect(webSocketServer.clientCount).toBe(1);
-    await client.close();
+    webSocketServer
+      .close()
+      .then(() => {
+        expect(client.isConnected).toBe(false);
+      })
+      .catch(() => {
+        expect(client.isConnected).toBe(true);
+      });
   });
 });

--- a/tests/client/clientSocket.integration.test.ts
+++ b/tests/client/clientSocket.integration.test.ts
@@ -1,35 +1,23 @@
-import { beforeEach, afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { ClientSocket } from '../../client/clientSocket.ts';
 import { WebSocketWrapper } from '../../server/infrastructure/websocket.ts';
-import { createServer } from '../../server/index.ts';
 
 describe('ClientSocket (real)', () => {
   const PORT = 9877;
   let webSocketServer: WebSocketWrapper;
-  let server: Awaited<ReturnType<typeof createServer>>;
-
-  beforeEach(async () => {
-    server = await createServer();
-  });
+  let client: ClientSocket;
 
   afterEach(async () => {
-    await server.close();
+    await client.close();
+    await webSocketServer.close();
   });
 
   it('connects to a real server', async () => {
     webSocketServer = WebSocketWrapper.createRawWs({ port: PORT });
     await webSocketServer.start();
-    const client = ClientSocket.create('ws://localhost:9877');
+    client = ClientSocket.create('ws://localhost:9877');
     await client.connect();
     expect(client.isConnected).toBe(true);
     expect(webSocketServer.clientCount).toBe(1);
-    webSocketServer
-      .close()
-      .then(() => {
-        expect(client.isConnected).toBe(false);
-      })
-      .catch(() => {
-        expect(client.isConnected).toBe(true);
-      });
   });
 });

--- a/tests/client/clientSocket.integration.test.ts
+++ b/tests/client/clientSocket.integration.test.ts
@@ -16,7 +16,7 @@ describe('ClientSocket (real)', () => {
   it('connects to a real server', async () => {
     webSocketServer = WebSocketWrapper.createRawWs({ port: PORT });
     await webSocketServer.start();
-    client = ClientSocket.create('ws://localhost:9877');
+    client = ClientSocket.create(`ws://localhost:${String(PORT)}`);
     await client.connect();
     expect(client.isConnected).toBe(true);
     expect(webSocketServer.clientCount).toBe(1);
@@ -68,7 +68,8 @@ describe('ClientSocket auth', () => {
     return new WebSocketServer({
       port: PORT,
       verifyClient: (info, cb) => {
-        const token = info.req.headers['authorization'];
+        const url = new URL(info.req.url ?? '', `http://localhost:${String(PORT)}`);
+        const token = url.searchParams.get('token');
         if (!token) {
           cb(false, 401, 'Unauthorized');
           return;
@@ -78,16 +79,16 @@ describe('ClientSocket auth', () => {
     });
   }
 
-  it('rejects connections without an auth token', async () => {
+  it('rejects connections without a token', async () => {
     rawServer = createAuthServer();
-    const client = ClientSocket.create(`ws://localhost:${String(PORT)}`, {});
+    const client = ClientSocket.create(`ws://localhost:${String(PORT)}`);
     await expect(client.connect()).rejects.toThrow();
   });
 
-  it('connects when a valid auth header is provided', async () => {
+  it('connects when a valid token is provided', async () => {
     rawServer = createAuthServer();
     const client = ClientSocket.create(`ws://localhost:${String(PORT)}`, {
-      headers: { Authorization: 'Bearer test-token' },
+      token: 'test-token',
     });
     await client.connect();
     expect(client.isConnected).toBe(true);

--- a/tests/client/clientSocket.integration.test.ts
+++ b/tests/client/clientSocket.integration.test.ts
@@ -1,21 +1,28 @@
-import { afterEach } from 'node:test';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, afterEach, describe, expect, it } from 'vitest';
 import { ClientSocket } from '../../client/clientSocket.ts';
 import { WebSocketWrapper } from '../../server/infrastructure/websocket.ts';
+import { createServer } from '../../server/index.ts';
 
 describe('ClientSocket (real)', () => {
   const PORT = 9877;
-  let server: WebSocketWrapper;
+  let webSocketServer: WebSocketWrapper;
+  let server: Awaited<ReturnType<typeof createServer>>;
+
+  beforeEach(async () => {
+    server = await createServer();
+  });
 
   afterEach(async () => {
+    // await webSocketServer.close();
     await server.close();
   });
 
   it('connects to a real server', async () => {
-    server = WebSocketWrapper.createRawWs({ port: PORT });
+    webSocketServer = WebSocketWrapper.createRawWs({ port: PORT });
+    await webSocketServer.start();
     const client = ClientSocket.create('ws://localhost:9877');
     await client.connect();
     expect(client.isConnected).toBe(true);
-    expect(server.clientCount).toBe(1);
+    expect(webSocketServer.clientCount).toBe(1);
   });
 });

--- a/tests/client/clientSocket.integration.test.ts
+++ b/tests/client/clientSocket.integration.test.ts
@@ -23,6 +23,35 @@ describe('ClientSocket (real)', () => {
   });
 });
 
+describe('ClientSocket connect settles once', () => {
+  const PORT = 9879;
+  let webSocketServer: WebSocketWrapper;
+
+  afterEach(async () => {
+    await webSocketServer.close();
+  });
+
+  it('ignores onerror after onopen has already resolved', async () => {
+    webSocketServer = WebSocketWrapper.createRawWs({ port: PORT });
+    await webSocketServer.start();
+    const client = ClientSocket.create(`ws://localhost:${String(PORT)}`);
+
+    await client.connect();
+    expect(client.isConnected).toBe(true);
+
+    await client.close();
+  });
+
+  it('rejects once when server is not running', async () => {
+    webSocketServer = WebSocketWrapper.createRawWs({ port: PORT });
+    await webSocketServer.start();
+    await webSocketServer.close();
+
+    const client = ClientSocket.create(`ws://localhost:${String(PORT)}`);
+    await expect(client.connect()).rejects.toThrow();
+  });
+});
+
 describe('ClientSocket auth', () => {
   const PORT = 9878;
   let rawServer: WebSocketServer;

--- a/tests/client/clientSocket.integration.test.ts
+++ b/tests/client/clientSocket.integration.test.ts
@@ -1,0 +1,21 @@
+import { afterEach } from 'node:test';
+import { describe, expect, it } from 'vitest';
+import { ClientSocket } from '../../client/clientSocket.ts';
+import { WebSocketWrapper } from '../../server/infrastructure/websocket.ts';
+
+describe('ClientSocket (real)', () => {
+  const PORT = 9877;
+  let server: WebSocketWrapper;
+
+  afterEach(async () => {
+    await server.close();
+  });
+
+  it('connects to a real server', async () => {
+    server = WebSocketWrapper.createRawWs({ port: PORT });
+    const client = ClientSocket.create('ws://localhost:9877');
+    await client.connect();
+    expect(client.isConnected).toBe(true);
+    expect(server.clientCount).toBe(1);
+  });
+});

--- a/tests/client/clientSocket.integration.test.ts
+++ b/tests/client/clientSocket.integration.test.ts
@@ -13,7 +13,7 @@ describe('ClientSocket (real)', () => {
   });
 
   afterEach(async () => {
-    // await webSocketServer.close();
+    void webSocketServer.close();
     await server.close();
   });
 
@@ -24,5 +24,6 @@ describe('ClientSocket (real)', () => {
     await client.connect();
     expect(client.isConnected).toBe(true);
     expect(webSocketServer.clientCount).toBe(1);
+    await client.close();
   });
 });

--- a/tests/client/clientSocket.test.ts
+++ b/tests/client/clientSocket.test.ts
@@ -2,6 +2,24 @@ import { describe, expect, it } from 'vitest';
 import { ClientSocket } from '../../client/clientSocket.ts';
 import { ReadyMsg, UnsubscribeMsg } from '../../shared/protocol.ts';
 
+describe('ClientSocket URL validation', () => {
+  it('rejects non-websocket URLs', () => {
+    expect(() => ClientSocket.create('http://localhost:8080')).toThrow();
+  });
+
+  it('rejects URLs without a protocol', () => {
+    expect(() => ClientSocket.create('localhost:8080')).toThrow();
+  });
+
+  it('accepts ws:// URLs', () => {
+    expect(() => ClientSocket.create('ws://localhost:8080')).not.toThrow();
+  });
+
+  it('accepts wss:// URLs', () => {
+    expect(() => ClientSocket.create('wss://localhost:8080')).not.toThrow();
+  });
+});
+
 describe('ClientSocket (null)', () => {
   it('is not connected before connect is called', () => {
     const socket = ClientSocket.createNull();

--- a/tests/client/clientSocket.test.ts
+++ b/tests/client/clientSocket.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { ClientSocket } from '../../client/clientSocket.ts';
+
+describe('ClientSocket (null)', () => {
+  it('is not connected before connect is called', () => {
+    const socket = ClientSocket.createNull();
+    expect(socket.isConnected).toBe(false);
+  });
+});

--- a/tests/client/clientSocket.test.ts
+++ b/tests/client/clientSocket.test.ts
@@ -22,7 +22,7 @@ describe('ClientSocket (null)', () => {
 
     expect(socket.isConnected).toBe(false);
   });
-  it('can recieve a message from the server', async () => {
+  it('can receive a message from the server', async () => {
     const message: ReadyMsg = { type: 'ready', id: '1' };
     const socket = ClientSocket.createNull();
     const tracker = socket.trackMessages();

--- a/tests/client/clientSocket.test.ts
+++ b/tests/client/clientSocket.test.ts
@@ -1,9 +1,43 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { ClientSocket } from '../../client/clientSocket.ts';
+import { ServerMessage } from '../../shared/protocol.ts';
 
 describe('ClientSocket (null)', () => {
   it('is not connected before connect is called', () => {
     const socket = ClientSocket.createNull();
     expect(socket.isConnected).toBe(false);
   });
+  it('is connected after connect is called', async () => {
+    const socket = ClientSocket.createNull();
+
+    await socket.connect();
+
+    expect(socket.isConnected).toBe(true);
+  });
+  it('is not connected after close is called', async () => {
+    const socket = ClientSocket.createNull();
+
+    await socket.connect();
+    await socket.close();
+
+    expect(socket.isConnected).toBe(false);
+  });
+  it('can recieve a message from the server', async () => {
+    const message: ServerMessage = { type: 'ready', id: '1' };
+    const socket = ClientSocket.createNull();
+    const tracker = socket.trackMessages();
+    await socket.connect();
+    const server = socket.simulateServer();
+    server.send(message);
+    expect(tracker.data).toHaveLength(1);
+    expect(tracker.data[0]).toEqual({ type: 'ready', id: '1' });
+  });
+  //   it('can send a message to the server', async () => {
+  //     const message: UnsubscribeMsg = { type: 'unsubscribe', id: '1' };
+
+  //     const socket = ClientSocket.createNull();
+  //     const tracker = socket.trackMessages();
+  //     await socket.connect();
+  //     const server = socket.simulateServer();
+  //   });
 });

--- a/tests/client/clientSocket.test.ts
+++ b/tests/client/clientSocket.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { ClientSocket } from '../../client/clientSocket.ts';
-import { ServerMessage } from '../../shared/protocol.ts';
+import { ReadyMsg, UnsubscribeMsg } from '../../shared/protocol.ts';
 
 describe('ClientSocket (null)', () => {
   it('is not connected before connect is called', () => {
@@ -23,7 +23,7 @@ describe('ClientSocket (null)', () => {
     expect(socket.isConnected).toBe(false);
   });
   it('can recieve a message from the server', async () => {
-    const message: ServerMessage = { type: 'ready', id: '1' };
+    const message: ReadyMsg = { type: 'ready', id: '1' };
     const socket = ClientSocket.createNull();
     const tracker = socket.trackMessages();
     await socket.connect();
@@ -32,12 +32,14 @@ describe('ClientSocket (null)', () => {
     expect(tracker.data).toHaveLength(1);
     expect(tracker.data[0]).toEqual({ type: 'ready', id: '1' });
   });
-  //   it('can send a message to the server', async () => {
-  //     const message: UnsubscribeMsg = { type: 'unsubscribe', id: '1' };
+  it('can send a message to the server', async () => {
+    const message: UnsubscribeMsg = { type: 'unsubscribe', id: '1' };
 
-  //     const socket = ClientSocket.createNull();
-  //     const tracker = socket.trackMessages();
-  //     await socket.connect();
-  //     const server = socket.simulateServer();
-  //   });
+    const socket = ClientSocket.createNull();
+    const tracker = socket.trackMessages();
+    await socket.connect();
+    await socket.send(message);
+    expect(tracker.data).toHaveLength(1);
+    expect(tracker.data[0]).toEqual({ type: 'unsubscribe', id: '1' });
+  });
 });

--- a/tests/infrastructure/fileStorage.integration.test.ts
+++ b/tests/infrastructure/fileStorage.integration.test.ts
@@ -1,14 +1,10 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { rm, mkdir } from 'node:fs/promises';
-import { FileStorage } from '../../server/infrastructure/fileStorage.ts';
+import path from 'node:path';
 import os from 'node:os';
+import { FileStorage } from '../../server/infrastructure/fileStorage.ts';
 
-let TEST_DIR = `${os.tmpdir()}/ekolite-test-files`;
-
-const plaform = os.platform();
-if (plaform === 'win32') {
-  TEST_DIR = `${os.tmpdir()}\\ekolite-test-files`;
-}
+const TEST_DIR = path.join(os.tmpdir(), 'ekolite-test-files');
 
 describe('FileStorage (real)', () => {
   const storage = FileStorage.create(TEST_DIR);

--- a/tests/infrastructure/fileStorage.integration.test.ts
+++ b/tests/infrastructure/fileStorage.integration.test.ts
@@ -1,8 +1,14 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { rm, mkdir } from 'node:fs/promises';
 import { FileStorage } from '../../server/infrastructure/fileStorage.ts';
+import os from 'node:os';
 
-const TEST_DIR = '/tmp/ekolite-test-files';
+let TEST_DIR = `${os.tmpdir()}/ekolite-test-files`;
+
+const plaform = os.platform();
+if (plaform === 'win32') {
+  TEST_DIR = `${os.tmpdir()}\\ekolite-test-files`;
+}
 
 describe('FileStorage (real)', () => {
   const storage = FileStorage.create(TEST_DIR);


### PR DESCRIPTION
## Summary

- `ClientSocket` class with null/real pattern matching the server side wrappers
- Unit tests (5) covering connection state, message send/receive, and URL validation
- Integration tests (5) covering real WebSocket connection, settled race condition guard, and auth token verification
- Wired up in `client/main.ts` so the connection opens on page load
- Learning material for the settled guard pattern in `learning/retro-settled-race-condition.md`

## What changed

| File | What |
|---|---|
| `client/clientSocket.ts` | New `ClientSocket` class with `create()`, `createNull()`, `RealClientSocket`, `StubbedClientSocket` |
| `client/main.ts` | Imports ClientSocket, connects on page load |
| `tests/client/clientSocket.test.ts` | Null tests: connection state, send, receive, URL validation |
| `tests/client/clientSocket.integration.test.ts` | Real tests: connect, settled guard paths, auth rejection/acceptance |
| `tests/infrastructure/fileStorage.integration.test.ts` | Cross platform fix for test directory paths |
| `learning/retro-settled-race-condition.md` | Retro writeup on the settled guard and test boundaries |

## Test plan

- [ ] `npm test` passes (unit tests)
- [ ] `npm run test:integration` passes (integration tests)
- [ ] Open app in browser, check DevTools > Network > WS tab shows active connection
- [ ] Close tab, confirm server `clientCount` drops

Linear: EKO-234