### PR TITLE
Eko 231/3a2 send initial documents on subscribe

### DIFF
--- a/server/logic/publications.ts
+++ b/server/logic/publications.ts
@@ -33,7 +33,6 @@ export class Publications {
   async handleMessage(clientId: string, message: ClientMessage): Promise<void> {
     if (message.type === 'subscribe') {
       const queryFn = this.publications.get(message.name);
-      const publicationsExists = this.publications.has(message.name);
 
       if (!queryFn) {
         this.ws.send(clientId, {
@@ -44,15 +43,13 @@ export class Publications {
         return Promise.resolve();
       }
 
-      if (publicationsExists) {
-        const { collection, query } = queryFn();
-        const docs = await this.mongo.find<{ _id: string }>(collection, query);
+      const { collection, query } = queryFn();
+      const docs = await this.mongo.find<{ _id: string }>(collection, query);
 
-        for (const doc of docs) {
-          this.ws.send(clientId, toAddedMsg(collection, doc));
-        }
-        this.ws.send(clientId, toReadyMsg(message.id));
+      for (const doc of docs) {
+        this.ws.send(clientId, toAddedMsg(collection, doc));
       }
+      this.ws.send(clientId, toReadyMsg(message.id));
     }
     return Promise.resolve();
   }

--- a/server/logic/publications.ts
+++ b/server/logic/publications.ts
@@ -4,6 +4,18 @@ import { WebSocketWrapper } from '../infrastructure/websocket.ts';
 
 type PublicationDef = () => { collection: string; query: object };
 
+const toAddedMsg = (collection: string, doc: Record<string, unknown>) => ({
+  type: 'added',
+  collection,
+  id: doc._id as string,
+  fields: Object.fromEntries(Object.entries(doc).filter(([key]) => key !== '_id')),
+});
+
+const toReadyMsg = (subId: string) => ({
+  type: 'ready',
+  id: subId,
+});
+
 export class Publications {
   private publications = new Map<string, PublicationDef>();
   private ws: WebSocketWrapper;
@@ -37,17 +49,9 @@ export class Publications {
         const docs = await this.mongo.find<{ _id: string }>(collection, query);
 
         for (const doc of docs) {
-          this.ws.send(clientId, {
-            type: 'added',
-            collection,
-            id: doc._id,
-            fields: Object.fromEntries(Object.entries(doc).filter(([key]) => key !== '_id')),
-          });
+          this.ws.send(clientId, toAddedMsg(collection, doc));
         }
-        this.ws.send(clientId, {
-          type: 'ready',
-          id: message.id,
-        });
+        this.ws.send(clientId, toReadyMsg(message.id));
       }
     }
     return Promise.resolve();

--- a/server/logic/publications.ts
+++ b/server/logic/publications.ts
@@ -21,6 +21,8 @@ export class Publications {
   async handleMessage(clientId: string, message: ClientMessage): Promise<void> {
     if (message.type === 'subscribe') {
       const queryFn = this.publications.get(message.name);
+      const publicationsExists = this.publications.has(message.name);
+
       if (!queryFn) {
         this.ws.send(clientId, {
           type: 'error',
@@ -28,6 +30,24 @@ export class Publications {
           error: { code: 404, message: `Unknown publication: ${message.name}` },
         });
         return Promise.resolve();
+      }
+
+      if (publicationsExists) {
+        const { collection, query } = queryFn();
+        const docs = await this.mongo.find<{ _id: string }>(collection, query);
+
+        for (const doc of docs) {
+          this.ws.send(clientId, {
+            type: 'added',
+            collection,
+            id: doc._id,
+            fields: Object.fromEntries(Object.entries(doc).filter(([key]) => key !== '_id')),
+          });
+        }
+        this.ws.send(clientId, {
+          type: 'ready',
+          id: message.id,
+        });
       }
     }
     return Promise.resolve();

--- a/server/logic/publications.ts
+++ b/server/logic/publications.ts
@@ -4,14 +4,14 @@ import { WebSocketWrapper } from '../infrastructure/websocket.ts';
 
 type PublicationDef = () => { collection: string; query: object };
 
-const toAddedMsg = (collection: string, doc: Record<string, unknown>) => ({
+const addedMessage = (collection: string, doc: Record<string, unknown>) => ({
   type: 'added',
   collection,
   id: doc._id as string,
   fields: Object.fromEntries(Object.entries(doc).filter(([key]) => key !== '_id')),
 });
 
-const toReadyMsg = (subId: string) => ({
+const readyMessage = (subId: string) => ({
   type: 'ready',
   id: subId,
 });
@@ -47,9 +47,9 @@ export class Publications {
       const docs = await this.mongo.find<{ _id: string }>(collection, query);
 
       for (const doc of docs) {
-        this.ws.send(clientId, toAddedMsg(collection, doc));
+        this.ws.send(clientId, addedMessage(collection, doc));
       }
-      this.ws.send(clientId, toReadyMsg(message.id));
+      this.ws.send(clientId, readyMessage(message.id));
     }
     return Promise.resolve();
   }

--- a/tests/logic/publications.test.ts
+++ b/tests/logic/publications.test.ts
@@ -50,4 +50,24 @@ describe('Publications', () => {
       id: 'sub1',
     });
   });
+
+  it('sends ready even when no documents exist', async () => {
+    const mongo = MongoWrapper.createNull({
+      find: [[]],
+    });
+    const ws = WebSocketWrapper.createNull();
+    const client = ws.simulateConnection();
+    const pubs = new Publications(mongo, ws);
+
+    pubs.define('files.all', () => ({ collection: 'files', query: {} }));
+
+    await pubs.handleMessage(client.id, {
+      type: 'subscribe',
+      id: 'sub1',
+      name: 'files.all',
+    });
+
+    expect(client.messages).toHaveLength(1);
+    expect(client.messages[0]).toEqual({ type: 'ready', id: 'sub1' });
+  });
 });

--- a/tests/logic/publications.test.ts
+++ b/tests/logic/publications.test.ts
@@ -39,16 +39,19 @@ describe('Publications', () => {
       name: 'files.all',
     });
 
-    expect(client.messages).toContainEqual({
-      type: 'added',
-      collection: 'files',
-      id: '1',
-      fields: { name: 'existing.bam' },
-    });
-    expect(client.messages).toContainEqual({
-      type: 'ready',
-      id: 'sub1',
-    });
+    expect(client.messages).toHaveLength(2);
+    expect(client.messages).toEqual([
+      {
+        type: 'added',
+        collection: 'files',
+        id: '1',
+        fields: { name: 'existing.bam' },
+      },
+      {
+        type: 'ready',
+        id: 'sub1',
+      },
+    ]);
   });
 
   it('sends ready even when no documents exist', async () => {

--- a/tests/logic/publications.test.ts
+++ b/tests/logic/publications.test.ts
@@ -22,4 +22,32 @@ describe('Publications', () => {
       error: { code: 404, message: 'Unknown publication: nonexistent' },
     });
   });
+
+  it('sends initial documents and ready signal on subscribe', async () => {
+    const mongo = MongoWrapper.createNull({
+      find: [[{ _id: '1', name: 'existing.bam' }]],
+    });
+    const ws = WebSocketWrapper.createNull();
+    const client = ws.simulateConnection();
+    const pubs = new Publications(mongo, ws);
+
+    pubs.define('files.all', () => ({ collection: 'files', query: {} }));
+
+    await pubs.handleMessage(client.id, {
+      type: 'subscribe',
+      id: 'sub1',
+      name: 'files.all',
+    });
+
+    expect(client.messages).toContainEqual({
+      type: 'added',
+      collection: 'files',
+      id: '1',
+      fields: { name: 'existing.bam' },
+    });
+    expect(client.messages).toContainEqual({
+      type: 'ready',
+      id: 'sub1',
+    });
+  });
 });


### PR DESCRIPTION
- test for send initial documents on subscribe
- enhanced handleMessage in publication for handling existing publications
- test for sends ready even when no documents exist
- red -> green -> refactor was followed


https://linear.app/ekohacks/issue/EKO-231/3a2-send-initial-documents-on-subscribe