### PR TITLE
Eko 271/3d observer interface for reactivestore and publications

### DIFF
--- a/client/reactiveStore.ts
+++ b/client/reactiveStore.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from '../server/infrastructure/outputTracker.ts';
-import { DataMsg } from '../shared/protocol.ts';
+import { DataMsg, ReactiveStoreObserver } from '../shared/protocol.ts';
 
 type StoredDoc = Record<string, unknown>;
 
@@ -16,31 +16,54 @@ function assertNever(x: never): never {
 export class ReactiveStore {
   private docs = new Map<string, Record<string, unknown>>();
   private emitter = new EventEmitter();
+  private observer: ReactiveStoreObserver;
+
+  constructor(observer: ReactiveStoreObserver = { onMessage: () => {} }) {
+    this.observer = observer;
+  }
+
+  private notifyObserver(
+    msg: DataMsg,
+    outcome: 'applied' | 'skipped' | 'failed',
+    reason?: string,
+  ): void {
+    try {
+      this.observer.onMessage(msg, outcome, reason);
+    } catch (err) {
+      console.error('Observer error:', err);
+    }
+  }
 
   handleMessage(msg: DataMsg): void {
     switch (msg.type) {
       case 'added':
         this.docs.set(msg.id, msg.fields ?? {});
+        this.notifyObserver(msg, 'applied');
         break;
 
       case 'changed': {
         const existing = this.docs.get(msg.id);
         if (!existing) {
+          this.notifyObserver(msg, 'skipped', 'unknown-id');
           return;
         }
 
         this.docs.set(msg.id, { ...existing, ...msg.fields });
+        this.notifyObserver(msg, 'applied');
         break;
       }
 
       case 'removed':
         if (!this.docs.has(msg.id)) {
+          this.notifyObserver(msg, 'skipped', 'unknown-id');
           return;
         }
         this.docs.delete(msg.id);
+        this.notifyObserver(msg, 'applied');
         break;
 
       default:
+        this.notifyObserver(msg, 'failed', 'unsupported-message-type');
         assertNever(msg);
     }
     this.emitter.emit('change');

--- a/client/reactiveStore.ts
+++ b/client/reactiveStore.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from '../server/infrastructure/outputTracker.ts';
-import { DataMsg, ReactiveStoreObserver } from '../shared/protocol.ts';
+import { DataMsg, ReactiveStoreObserver, ReactiveStoreReasons } from '../shared/protocol.ts';
 
 type StoredDoc = Record<string, unknown>;
 
@@ -25,7 +25,7 @@ export class ReactiveStore {
   private notifyObserver(
     msg: DataMsg,
     outcome: 'applied' | 'skipped' | 'failed',
-    reason?: string,
+    reason?: ReactiveStoreReasons,
   ): void {
     try {
       this.observer.onMessage(msg, outcome, reason);

--- a/server/logic/publications.ts
+++ b/server/logic/publications.ts
@@ -1,4 +1,4 @@
-import { ClientMessage } from '../../shared/protocol.ts';
+import { ClientMessage, ReactiveStoreObserver } from '../../shared/protocol.ts';
 import { MongoWrapper } from '../infrastructure/mongo.ts';
 import { WebSocketWrapper } from '../infrastructure/websocket.ts';
 import { ChangeEvent } from '../../shared/types.ts';
@@ -22,13 +22,31 @@ export class Publications {
   private ws: WebSocketWrapper;
   private mongo: MongoWrapper;
   private subscriptions = new Map<string, Map<string, () => void>>();
+  private observer: ReactiveStoreObserver;
 
-  constructor(mongo: MongoWrapper, ws: WebSocketWrapper) {
+  constructor(
+    mongo: MongoWrapper,
+    ws: WebSocketWrapper,
+    observer: ReactiveStoreObserver = { onMessage: () => {} },
+  ) {
     this.mongo = mongo;
     this.ws = ws;
+    this.observer = observer;
     this.ws.onDisconnect((clientId) => {
       this.tearDownClient(clientId);
     });
+  }
+
+  private notifyObserver(
+    msg: ClientMessage,
+    outcome: 'applied' | 'skipped' | 'failed',
+    reason?: string,
+  ): void {
+    try {
+      this.observer.onMessage(msg, outcome, reason);
+    } catch (err) {
+      console.error('Observer error:', err);
+    }
   }
 
   private tearDownClient(clientId: string): void {
@@ -56,6 +74,7 @@ export class Publications {
           id: message.id,
           error: { code: 404, message: `Unknown publication: ${message.name}` },
         });
+        this.notifyObserver(message, 'failed', 'unknown-publication');
         return Promise.resolve();
       }
 
@@ -86,20 +105,29 @@ export class Publications {
       }
 
       clientSubs.set(message.id, cleanup);
+      this.notifyObserver(message, 'applied', existing ? 'duplicate-sub-id' : undefined);
     } else if (message.type === 'unsubscribe') {
       const clientSubs = this.subscriptions.get(clientId);
 
-      if (!clientSubs) return;
+      if (!clientSubs) {
+        this.notifyObserver(message, 'skipped', 'unknown-sub-id');
+        return Promise.resolve();
+      }
 
       const cleanup = clientSubs.get(message.id);
-      if (cleanup) {
-        cleanup();
-        clientSubs.delete(message.id);
+      if (!cleanup) {
+        this.notifyObserver(message, 'skipped', 'unknown-sub-id');
+        return Promise.resolve();
       }
+
+      cleanup();
+      clientSubs.delete(message.id);
 
       if (clientSubs.size === 0) {
         this.subscriptions.delete(clientId);
       }
+
+      this.notifyObserver(message, 'applied');
     }
     return Promise.resolve();
   }

--- a/server/logic/publications.ts
+++ b/server/logic/publications.ts
@@ -1,8 +1,4 @@
-import {
-  ClientMessage,
-  PublicationsReasons,
-  ReactiveStoreObserver,
-} from '../../shared/protocol.ts';
+import { ClientMessage, PublicationsObserver, PublicationsReasons } from '../../shared/protocol.ts';
 import { MongoWrapper } from '../infrastructure/mongo.ts';
 import { WebSocketWrapper } from '../infrastructure/websocket.ts';
 import { ChangeEvent } from '../../shared/types.ts';
@@ -26,12 +22,12 @@ export class Publications {
   private ws: WebSocketWrapper;
   private mongo: MongoWrapper;
   private subscriptions = new Map<string, Map<string, () => void>>();
-  private observer: ReactiveStoreObserver;
+  private observer: PublicationsObserver;
 
   constructor(
     mongo: MongoWrapper,
     ws: WebSocketWrapper,
-    observer: ReactiveStoreObserver = { onMessage: () => {} },
+    observer: PublicationsObserver = { onMessage: () => {} },
   ) {
     this.mongo = mongo;
     this.ws = ws;

--- a/server/logic/publications.ts
+++ b/server/logic/publications.ts
@@ -1,4 +1,8 @@
-import { ClientMessage, ReactiveStoreObserver } from '../../shared/protocol.ts';
+import {
+  ClientMessage,
+  PublicationsReasons,
+  ReactiveStoreObserver,
+} from '../../shared/protocol.ts';
 import { MongoWrapper } from '../infrastructure/mongo.ts';
 import { WebSocketWrapper } from '../infrastructure/websocket.ts';
 import { ChangeEvent } from '../../shared/types.ts';
@@ -40,7 +44,7 @@ export class Publications {
   private notifyObserver(
     msg: ClientMessage,
     outcome: 'applied' | 'skipped' | 'failed',
-    reason?: string,
+    reason?: PublicationsReasons,
   ): void {
     try {
       this.observer.onMessage(msg, outcome, reason);
@@ -105,7 +109,12 @@ export class Publications {
       }
 
       clientSubs.set(message.id, cleanup);
-      this.notifyObserver(message, 'applied', existing ? 'duplicate-sub-id' : undefined);
+
+      if (existing) {
+        this.notifyObserver(message, 'applied', 'duplicate-sub-id');
+      } else {
+        this.notifyObserver(message, 'applied');
+      }
     } else if (message.type === 'unsubscribe') {
       const clientSubs = this.subscriptions.get(clientId);
 

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -54,6 +54,12 @@ export type DataMsg =
       id: string;
     };
 
+export type ObserverOutcome = 'applied' | 'skipped' | 'failed';
+
+export interface ReactiveStoreObserver {
+  onMessage(msg: DataMsg, outcome: ObserverOutcome, reason?: string): void;
+}
+
 export interface ResultMsg {
   type: 'result';
   id: string;

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -57,7 +57,7 @@ export type DataMsg =
 export type ObserverOutcome = 'applied' | 'skipped' | 'failed';
 
 export interface ReactiveStoreObserver {
-  onMessage(msg: DataMsg, outcome: ObserverOutcome, reason?: string): void;
+  onMessage(msg: DataMsg | ClientMessage, outcome: ObserverOutcome, reason?: string): void;
 }
 
 export interface ResultMsg {

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -92,8 +92,20 @@ type PublicationsSkipReason = 'unknown-sub-id';
 type PublicationsFailReason = 'unknown-publication';
 type PublicationsDuplicateSubIdReason = 'duplicate-sub-id';
 
-export type ReactiveStoreReasons = ReactiveStoreSkipReason | ReactiveStoreFailReason;
+export type ReactiveStoreReasons =
+  /** Document with the given ID is unknown to the store.
+   * This can happen when a changed or removed message is received for an id that has not been added. */
+  | ReactiveStoreSkipReason
+  /** Message type is not supported by the store. */
+  | ReactiveStoreFailReason;
 export type PublicationsReasons =
+  /** Unsubscribe arrived for a sub id this client doesn't have.
+   *  Usually a client bug or a race between client and server. */
   | PublicationsSkipReason
+  /** Subscribe arrived for a publication name that wasn't defined
+   *  on the server. Client and server schemas are out of sync. */
   | PublicationsFailReason
+  /** Subscribe arrived with an id that already has a watcher on this
+   *  client. Old watcher torn down, new one installed. Applied,
+   *  not failed. */
   | PublicationsDuplicateSubIdReason;

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -57,7 +57,11 @@ export type DataMsg =
 export type ObserverOutcome = 'applied' | 'skipped' | 'failed';
 
 export interface ReactiveStoreObserver {
-  onMessage(msg: DataMsg | ClientMessage, outcome: ObserverOutcome, reason?: string): void;
+  onMessage(msg: DataMsg, outcome: ObserverOutcome, reason?: ReactiveStoreReasons): void;
+}
+
+export interface PublicationsObserver {
+  onMessage(msg: ClientMessage, outcome: ObserverOutcome, reason?: PublicationsReasons): void;
 }
 
 export interface ResultMsg {
@@ -86,10 +90,10 @@ type ReactiveStoreSkipReason = 'unknown-id';
 type ReactiveStoreFailReason = 'unsupported-message-type';
 type PublicationsSkipReason = 'unknown-sub-id';
 type PublicationsFailReason = 'unknown-publication';
-type PublicationsDublicateSubIdReason = 'duplicate-sub-id';
+type PublicationsDuplicateSubIdReason = 'duplicate-sub-id';
 
 export type ReactiveStoreReasons = ReactiveStoreSkipReason | ReactiveStoreFailReason;
 export type PublicationsReasons =
   | PublicationsSkipReason
   | PublicationsFailReason
-  | PublicationsDublicateSubIdReason;
+  | PublicationsDuplicateSubIdReason;

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -81,3 +81,15 @@ export interface EkoLiteError {
   message: string;
   details?: unknown;
 }
+
+type ReactiveStoreSkipReason = 'unknown-id';
+type ReactiveStoreFailReason = 'unsupported-message-type';
+type PublicationsSkipReason = 'unknown-sub-id';
+type PublicationsFailReason = 'unknown-publication';
+type PublicationsDublicateSubIdReason = 'duplicate-sub-id';
+
+export type ReactiveStoreReasons = ReactiveStoreSkipReason | ReactiveStoreFailReason;
+export type PublicationsReasons =
+  | PublicationsSkipReason
+  | PublicationsFailReason
+  | PublicationsDublicateSubIdReason;

--- a/tests/client/reactiveStore.test.ts
+++ b/tests/client/reactiveStore.test.ts
@@ -15,6 +15,26 @@ describe('ReactiveStore', () => {
     expect(store.getAll()).toEqual([{ _id: '1', name: 'existing.bam' }]);
   });
 
+  it('notifies observer on applied added message', () => {
+    const applied: Array<{ outcome: string; reason?: string }> = [];
+    const store = new ReactiveStore({
+      onMessage(msg) {
+        if (msg.type === 'added') {
+          applied.push({ outcome: 'applied' });
+        }
+      },
+    });
+
+    store.handleMessage({
+      type: 'added',
+      collection: 'files',
+      id: '1',
+      fields: { name: 'existing.bam' },
+    });
+
+    expect(applied).toEqual([{ outcome: 'applied' }]);
+  });
+
   it('returns a single document by id', () => {
     const store = new ReactiveStore();
 

--- a/tests/client/reactiveStore.test.ts
+++ b/tests/client/reactiveStore.test.ts
@@ -54,6 +54,25 @@ describe('ReactiveStore', () => {
     expect(observed).toEqual([{ outcome: 'skipped', reason: 'unknown-id' }]);
   });
 
+  it('ignores observer errors and continues normal processing', () => {
+    const store = new ReactiveStore({
+      onMessage() {
+        throw new Error('observer failure');
+      },
+    });
+
+    expect(() => {
+      store.handleMessage({
+        type: 'added',
+        collection: 'files',
+        id: '1',
+        fields: { name: 'existing.bam' },
+      });
+    }).not.toThrow();
+
+    expect(store.getAll()).toEqual([{ _id: '1', name: 'existing.bam' }]);
+  });
+
   it('returns a single document by id', () => {
     const store = new ReactiveStore();
 

--- a/tests/client/reactiveStore.test.ts
+++ b/tests/client/reactiveStore.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { ReactiveStore } from '../../client/reactiveStore.ts';
+import { ObserverOutcome } from '../../shared/protocol.ts';
 
 describe('ReactiveStore', () => {
   it('inserts a document on added message', () => {
@@ -33,6 +34,24 @@ describe('ReactiveStore', () => {
     });
 
     expect(applied).toEqual([{ outcome: 'applied' }]);
+  });
+
+  it('notifies observer when changed arrives for an unknown id', () => {
+    const observed: Array<{ outcome: ObserverOutcome; reason?: string | undefined }> = [];
+    const store = new ReactiveStore({
+      onMessage(_, outcome, reason) {
+        observed.push({ outcome, reason });
+      },
+    });
+
+    store.handleMessage({
+      type: 'changed',
+      collection: 'files',
+      id: 'ghost',
+      fields: { name: 'a' },
+    });
+
+    expect(observed).toEqual([{ outcome: 'skipped', reason: 'unknown-id' }]);
   });
 
   it('returns a single document by id', () => {

--- a/tests/client/reactiveStore.test.ts
+++ b/tests/client/reactiveStore.test.ts
@@ -17,12 +17,10 @@ describe('ReactiveStore', () => {
   });
 
   it('notifies observer on applied added message', () => {
-    const applied: Array<{ outcome: string; reason?: string }> = [];
+    const applied: { type: string; outcome: ObserverOutcome; reason?: string }[] = [];
     const store = new ReactiveStore({
-      onMessage(msg) {
-        if (msg.type === 'added') {
-          applied.push({ outcome: 'applied' });
-        }
+      onMessage(msg, outcome) {
+        applied.push({ type: msg.type, outcome });
       },
     });
 
@@ -33,11 +31,11 @@ describe('ReactiveStore', () => {
       fields: { name: 'existing.bam' },
     });
 
-    expect(applied).toEqual([{ outcome: 'applied' }]);
+    expect(applied).toEqual([{ type: 'added', outcome: 'applied' }]);
   });
 
   it('notifies observer when changed arrives for an unknown id', () => {
-    const observed: Array<{ outcome: ObserverOutcome; reason?: string | undefined }> = [];
+    const observed: { outcome: ObserverOutcome; reason?: string | undefined }[] = [];
     const store = new ReactiveStore({
       onMessage(_, outcome, reason) {
         observed.push({ outcome, reason });

--- a/tests/client/reactiveStore.test.ts
+++ b/tests/client/reactiveStore.test.ts
@@ -17,10 +17,10 @@ describe('ReactiveStore', () => {
   });
 
   it('notifies observer on applied added message', () => {
-    const applied: { type: string; outcome: ObserverOutcome; reason?: string }[] = [];
+    const notifications: { type: string; outcome: ObserverOutcome; reason?: string }[] = [];
     const store = new ReactiveStore({
       onMessage(msg, outcome) {
-        applied.push({ type: msg.type, outcome });
+        notifications.push({ type: msg.type, outcome });
       },
     });
 
@@ -31,14 +31,15 @@ describe('ReactiveStore', () => {
       fields: { name: 'existing.bam' },
     });
 
-    expect(applied).toEqual([{ type: 'added', outcome: 'applied' }]);
+    expect(notifications).toHaveLength(1);
+    expect(notifications).toEqual([{ type: 'added', outcome: 'applied' }]);
   });
 
   it('notifies observer when changed arrives for an unknown id', () => {
-    const observed: { outcome: ObserverOutcome; reason?: string | undefined }[] = [];
+    const notifications: { outcome: ObserverOutcome; reason?: string | undefined }[] = [];
     const store = new ReactiveStore({
       onMessage(_, outcome, reason) {
-        observed.push({ outcome, reason });
+        notifications.push({ outcome, reason });
       },
     });
 
@@ -49,7 +50,8 @@ describe('ReactiveStore', () => {
       fields: { name: 'a' },
     });
 
-    expect(observed).toEqual([{ outcome: 'skipped', reason: 'unknown-id' }]);
+    expect(notifications).toHaveLength(1);
+    expect(notifications).toEqual([{ outcome: 'skipped', reason: 'unknown-id' }]);
   });
 
   it('ignores observer errors and continues normal processing', () => {

--- a/tests/client/reactiveStore.test.ts
+++ b/tests/client/reactiveStore.test.ts
@@ -54,6 +54,24 @@ describe('ReactiveStore', () => {
     expect(notifications).toEqual([{ outcome: 'skipped', reason: 'unknown-id' }]);
   });
 
+  it('notifies observer when removed message arrives for unknown id', () => {
+    const notifications: Array<{ outcome: ObserverOutcome; reason?: string | undefined }> = [];
+    const store = new ReactiveStore({
+      onMessage(_, outcome, reason) {
+        notifications.push({ outcome, reason });
+      },
+    });
+
+    store.handleMessage({
+      type: 'removed',
+      collection: 'files',
+      id: 'ghost',
+    });
+
+    expect(notifications).toHaveLength(1);
+    expect(notifications).toEqual([{ outcome: 'skipped', reason: 'unknown-id' }]);
+  });
+
   it('ignores observer errors and continues normal processing', () => {
     const store = new ReactiveStore({
       onMessage() {

--- a/tests/client/reactiveStore.test.ts
+++ b/tests/client/reactiveStore.test.ts
@@ -55,7 +55,7 @@ describe('ReactiveStore', () => {
   });
 
   it('notifies observer when removed message arrives for unknown id', () => {
-    const notifications: Array<{ outcome: ObserverOutcome; reason?: string | undefined }> = [];
+    const notifications: { outcome: ObserverOutcome; reason?: string | undefined }[] = [];
     const store = new ReactiveStore({
       onMessage(_, outcome, reason) {
         notifications.push({ outcome, reason });

--- a/tests/logic/publications.test.ts
+++ b/tests/logic/publications.test.ts
@@ -97,6 +97,35 @@ describe('Publications', () => {
     );
   });
 
+  it('continues normal behaviour if observer throws', async () => {
+    const mongo = MongoWrapper.createNull({
+      find: [[{ _id: '1', name: 'existing.bam' }]],
+    });
+    const ws = WebSocketWrapper.createNull();
+    const client = ws.simulateConnection();
+    const observer = {
+      onMessage: () => {
+        throw new Error('observer failed');
+      },
+    };
+    const pubs = new Publications(mongo, ws, observer);
+
+    pubs.define('files.all', () => ({ collection: 'files', query: {} }));
+
+    await expect(
+      pubs.handleMessage(client.id, {
+        type: 'subscribe',
+        id: 'sub1',
+        name: 'files.all',
+      }),
+    ).resolves.not.toThrow();
+
+    expect(client.messages).toContainEqual({
+      type: 'ready',
+      id: 'sub1',
+    });
+  });
+
   it('sends initial documents and ready signal on subscribe', async () => {
     const mongo = MongoWrapper.createNull({
       find: [[{ _id: '1', name: 'existing.bam' }]],

--- a/tests/logic/publications.test.ts
+++ b/tests/logic/publications.test.ts
@@ -75,6 +75,28 @@ describe('Publications', () => {
     );
   });
 
+  it('notifies observer when unsubscribe cannot find the sub id', async () => {
+    const mongo = MongoWrapper.createNull({ find: [[]] });
+    const ws = WebSocketWrapper.createNull();
+    const client = ws.simulateConnection();
+    const observer = { onMessage: vi.fn() };
+    const pubs = new Publications(mongo, ws, observer);
+
+    await pubs.handleMessage(client.id, {
+      type: 'unsubscribe',
+      id: 'sub1',
+    });
+
+    expect(observer.onMessage).toHaveBeenCalledWith(
+      {
+        type: 'unsubscribe',
+        id: 'sub1',
+      },
+      'skipped',
+      'unknown-sub-id',
+    );
+  });
+
   it('sends initial documents and ready signal on subscribe', async () => {
     const mongo = MongoWrapper.createNull({
       find: [[{ _id: '1', name: 'existing.bam' }]],

--- a/tests/logic/publications.test.ts
+++ b/tests/logic/publications.test.ts
@@ -47,6 +47,34 @@ describe('Publications', () => {
     );
   });
 
+  it('notifies observer on applied subscribe request', async () => {
+    const mongo = MongoWrapper.createNull({
+      find: [[{ _id: '1', name: 'existing.bam' }]],
+    });
+    const ws = WebSocketWrapper.createNull();
+    const client = ws.simulateConnection();
+    const observer = { onMessage: vi.fn() };
+    const pubs = new Publications(mongo, ws, observer);
+
+    pubs.define('files.all', () => ({ collection: 'files', query: {} }));
+
+    await pubs.handleMessage(client.id, {
+      type: 'subscribe',
+      id: 'sub1',
+      name: 'files.all',
+    });
+
+    expect(observer.onMessage).toHaveBeenCalledWith(
+      {
+        type: 'subscribe',
+        id: 'sub1',
+        name: 'files.all',
+      },
+      'applied',
+      undefined,
+    );
+  });
+
   it('sends initial documents and ready signal on subscribe', async () => {
     const mongo = MongoWrapper.createNull({
       find: [[{ _id: '1', name: 'existing.bam' }]],

--- a/tests/logic/publications.test.ts
+++ b/tests/logic/publications.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { Publications } from '../../server/logic/publications.ts';
 import { MongoWrapper } from '../../server/infrastructure/mongo.ts';
 import { WebSocketWrapper } from '../../server/infrastructure/websocket.ts';
@@ -21,6 +21,30 @@ describe('Publications', () => {
       id: 'sub1',
       error: { code: 404, message: 'Unknown publication: nonexistent' },
     });
+  });
+
+  it('notifies observer on failed subscribe for unknown publication', async () => {
+    const mongo = MongoWrapper.createNull();
+    const ws = WebSocketWrapper.createNull();
+    const client = ws.simulateConnection();
+    const observer = { onMessage: vi.fn() };
+    const pubs = new Publications(mongo, ws, observer);
+
+    await pubs.handleMessage(client.id, {
+      type: 'subscribe',
+      id: 'sub1',
+      name: 'nonexistent',
+    });
+
+    expect(observer.onMessage).toHaveBeenCalledWith(
+      {
+        type: 'subscribe',
+        id: 'sub1',
+        name: 'nonexistent',
+      },
+      'failed',
+      'unknown-publication',
+    );
   });
 
   it('sends initial documents and ready signal on subscribe', async () => {

--- a/tests/logic/publications.test.ts
+++ b/tests/logic/publications.test.ts
@@ -25,13 +25,14 @@ describe('Publications', () => {
   });
 
   it('notifies observer on failed subscribe for unknown publication', async () => {
-    const failed: { type: string; outcome: ObserverOutcome; reason?: string | undefined }[] = [];
+    const notifications: { type: string; outcome: ObserverOutcome; reason?: string | undefined }[] =
+      [];
     const mongo = MongoWrapper.createNull();
     const ws = WebSocketWrapper.createNull();
     const client = ws.simulateConnection();
     const observer: ReactiveStoreObserver = {
       onMessage(msg, outcome, reason) {
-        failed.push({ type: msg.type, outcome, reason });
+        notifications.push({ type: msg.type, outcome, reason });
       },
     };
 
@@ -43,7 +44,8 @@ describe('Publications', () => {
       name: 'nonexistent',
     });
 
-    expect(failed).toEqual([
+    expect(notifications).toHaveLength(1);
+    expect(notifications).toEqual([
       {
         type: 'subscribe',
         outcome: 'failed',
@@ -53,7 +55,8 @@ describe('Publications', () => {
   });
 
   it('notifies observer on applied subscribe request', async () => {
-    const applied: { type: string; outcome: ObserverOutcome; reason?: string | undefined }[] = [];
+    const notifications: { type: string; outcome: ObserverOutcome; reason?: string | undefined }[] =
+      [];
     const mongo = MongoWrapper.createNull({
       find: [[{ _id: '1', name: 'existing.bam' }]],
     });
@@ -61,7 +64,7 @@ describe('Publications', () => {
     const client = ws.simulateConnection();
     const observer = {
       onMessage(msg, outcome, reason) {
-        applied.push({ type: msg.type, outcome, reason });
+        notifications.push({ type: msg.type, outcome, reason });
       },
     } as ReactiveStoreObserver;
     const pubs = new Publications(mongo, ws, observer);
@@ -74,7 +77,59 @@ describe('Publications', () => {
       name: 'files.all',
     });
 
-    expect(applied).toEqual([{ type: 'subscribe', outcome: 'applied', reason: undefined }]);
+    expect(notifications).toHaveLength(1);
+    expect(notifications).toEqual([{ type: 'subscribe', outcome: 'applied', reason: undefined }]);
+  });
+
+  it('replaces the watcher when the same client resubscribes with the same id', async () => {
+    const notifications: { type: string; outcome: ObserverOutcome; reason?: string | undefined }[] =
+      [];
+    const mongo = MongoWrapper.createNull({
+      find: [[], []],
+    });
+    const ws = WebSocketWrapper.createNull();
+    const client = ws.simulateConnection();
+    const observer = {
+      onMessage(msg, outcome, reason) {
+        notifications.push({ type: msg.type, outcome, reason });
+      },
+    } as ReactiveStoreObserver;
+    const pubs = new Publications(mongo, ws, observer);
+
+    pubs.define('files.all', () => ({ collection: 'files', query: {} }));
+
+    await pubs.handleMessage(client.id, {
+      type: 'subscribe',
+      id: 'sub1',
+      name: 'files.all',
+    });
+
+    expect(mongo.watcherCount('files')).toBe(1);
+
+    await pubs.handleMessage(client.id, {
+      type: 'subscribe',
+      id: 'sub1',
+      name: 'files.all',
+    });
+
+    expect(mongo.watcherCount('files')).toBe(1);
+    expect(notifications).toContainEqual({
+      type: 'subscribe',
+      outcome: 'applied',
+      reason: 'duplicate-sub-id',
+    });
+
+    const countAfterResub = client.messages.length;
+    await mongo.insert('files', { name: 'still-one-watcher.bam' });
+
+    const newMessages = client.messages.slice(countAfterResub);
+    expect(newMessages).toHaveLength(1);
+    expect(newMessages[0]).toEqual(
+      expect.objectContaining({
+        type: 'added',
+        collection: 'files',
+      }),
+    );
   });
 
   it('notifies observer when unsubscribe cannot find the sub id', async () => {

--- a/tests/logic/publications.test.ts
+++ b/tests/logic/publications.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { Publications } from '../../server/logic/publications.ts';
 import { MongoWrapper } from '../../server/infrastructure/mongo.ts';
 import { WebSocketWrapper } from '../../server/infrastructure/websocket.ts';
-import { ObserverOutcome, ReactiveStoreObserver } from '../../shared/protocol.ts';
+import { ObserverOutcome, PublicationsObserver } from '../../shared/protocol.ts';
 
 describe('Publications', () => {
   it('sends error when subscribing to unknown publication', async () => {
@@ -30,7 +30,7 @@ describe('Publications', () => {
     const mongo = MongoWrapper.createNull();
     const ws = WebSocketWrapper.createNull();
     const client = ws.simulateConnection();
-    const observer: ReactiveStoreObserver = {
+    const observer: PublicationsObserver = {
       onMessage(msg, outcome, reason) {
         notifications.push({ type: msg.type, outcome, reason });
       },
@@ -66,7 +66,7 @@ describe('Publications', () => {
       onMessage(msg, outcome, reason) {
         notifications.push({ type: msg.type, outcome, reason });
       },
-    } as ReactiveStoreObserver;
+    } as PublicationsObserver;
     const pubs = new Publications(mongo, ws, observer);
 
     pubs.define('files.all', () => ({ collection: 'files', query: {} }));
@@ -93,7 +93,7 @@ describe('Publications', () => {
       onMessage(msg, outcome, reason) {
         notifications.push({ type: msg.type, outcome, reason });
       },
-    } as ReactiveStoreObserver;
+    } as PublicationsObserver;
     const pubs = new Publications(mongo, ws, observer);
 
     pubs.define('files.all', () => ({ collection: 'files', query: {} }));
@@ -141,7 +141,7 @@ describe('Publications', () => {
       onMessage(msg, outcome, reason) {
         skipped.push({ type: msg.type, outcome, reason });
       },
-    } as ReactiveStoreObserver;
+    } as PublicationsObserver;
     const pubs = new Publications(mongo, ws, observer);
 
     await pubs.handleMessage(client.id, {

--- a/tests/logic/publications.test.ts
+++ b/tests/logic/publications.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { Publications } from '../../server/logic/publications.ts';
 import { MongoWrapper } from '../../server/infrastructure/mongo.ts';
 import { WebSocketWrapper } from '../../server/infrastructure/websocket.ts';
+import { ObserverOutcome, ReactiveStoreObserver } from '../../shared/protocol.ts';
 
 describe('Publications', () => {
   it('sends error when subscribing to unknown publication', async () => {
@@ -24,10 +25,16 @@ describe('Publications', () => {
   });
 
   it('notifies observer on failed subscribe for unknown publication', async () => {
+    const failed: { type: string; outcome: ObserverOutcome; reason?: string | undefined }[] = [];
     const mongo = MongoWrapper.createNull();
     const ws = WebSocketWrapper.createNull();
     const client = ws.simulateConnection();
-    const observer = { onMessage: vi.fn() };
+    const observer: ReactiveStoreObserver = {
+      onMessage(msg, outcome, reason) {
+        failed.push({ type: msg.type, outcome, reason });
+      },
+    };
+
     const pubs = new Publications(mongo, ws, observer);
 
     await pubs.handleMessage(client.id, {
@@ -36,24 +43,27 @@ describe('Publications', () => {
       name: 'nonexistent',
     });
 
-    expect(observer.onMessage).toHaveBeenCalledWith(
+    expect(failed).toEqual([
       {
         type: 'subscribe',
-        id: 'sub1',
-        name: 'nonexistent',
+        outcome: 'failed',
+        reason: 'unknown-publication',
       },
-      'failed',
-      'unknown-publication',
-    );
+    ]);
   });
 
   it('notifies observer on applied subscribe request', async () => {
+    const applied: { type: string; outcome: ObserverOutcome; reason?: string | undefined }[] = [];
     const mongo = MongoWrapper.createNull({
       find: [[{ _id: '1', name: 'existing.bam' }]],
     });
     const ws = WebSocketWrapper.createNull();
     const client = ws.simulateConnection();
-    const observer = { onMessage: vi.fn() };
+    const observer = {
+      onMessage(msg, outcome, reason) {
+        applied.push({ type: msg.type, outcome, reason });
+      },
+    } as ReactiveStoreObserver;
     const pubs = new Publications(mongo, ws, observer);
 
     pubs.define('files.all', () => ({ collection: 'files', query: {} }));
@@ -64,22 +74,19 @@ describe('Publications', () => {
       name: 'files.all',
     });
 
-    expect(observer.onMessage).toHaveBeenCalledWith(
-      {
-        type: 'subscribe',
-        id: 'sub1',
-        name: 'files.all',
-      },
-      'applied',
-      undefined,
-    );
+    expect(applied).toEqual([{ type: 'subscribe', outcome: 'applied', reason: undefined }]);
   });
 
   it('notifies observer when unsubscribe cannot find the sub id', async () => {
+    const skipped: { type: string; outcome: ObserverOutcome; reason?: string | undefined }[] = [];
     const mongo = MongoWrapper.createNull({ find: [[]] });
     const ws = WebSocketWrapper.createNull();
     const client = ws.simulateConnection();
-    const observer = { onMessage: vi.fn() };
+    const observer = {
+      onMessage(msg, outcome, reason) {
+        skipped.push({ type: msg.type, outcome, reason });
+      },
+    } as ReactiveStoreObserver;
     const pubs = new Publications(mongo, ws, observer);
 
     await pubs.handleMessage(client.id, {
@@ -87,14 +94,13 @@ describe('Publications', () => {
       id: 'sub1',
     });
 
-    expect(observer.onMessage).toHaveBeenCalledWith(
+    expect(skipped).toEqual([
       {
         type: 'unsubscribe',
-        id: 'sub1',
+        outcome: 'skipped',
+        reason: 'unknown-sub-id',
       },
-      'skipped',
-      'unknown-sub-id',
-    );
+    ]);
   });
 
   it('continues normal behaviour if observer throws', async () => {


### PR DESCRIPTION
- refactor: added observerOutcome and reactiveStoreObserver interface
- refactor: added constructor to accomodate reactiveStoreObserver in reactorStore.ts
- test: green - notifies observer on applied added message
- test: green - notifies observer when changed arrives for an unknown id
- test: green - ignores observer errors and continues normal processing
- refactor: reactiveStoreObserver
- test: red - notifies observer on failed subscribe for unknown publication
- test: green - notifies observer on failed subscribe for unknown publication
- test: green - notifies observer on applied subscribe request
- test: green - notifies observer when unsubscribe cannot find the sub id
- test: green - continues normal behavior if observer throws

- refactor: watching out for unrelated event that might slip in
- test: green - replaces the watcher when the same client resubscribes with the same id
- refactor: added reasons code documentation for observers in protocols.ts
- test: green - notifies observer when removed message arrives for unknown id
- refactor: seperated interface so we know have reactStoreObserver and publicationsObserver

https://linear.app/ekohacks/issue/EKO-271/3d-observer-interface-for-reactivestore-and-publications