### PR TITLE
Eko 272/3c2 subscribe with params server side filtering by client knowledge

### DIFF
--- a/client/connectionManager.ts
+++ b/client/connectionManager.ts
@@ -57,7 +57,7 @@ export class ConnectionManager {
     });
   }
 
-  subscribe(name: string): SubscriptionHandle {
+  subscribe(name: string, params?: Record<string, unknown>): SubscriptionHandle {
     this.assertNotDisposed();
     const id = generateSubscriptionId();
     let resolveReady!: () => void;
@@ -77,6 +77,7 @@ export class ConnectionManager {
       type: 'subscribe',
       id,
       name,
+      ...(params ? { params } : {}),
     };
 
     this.socket.send(subscribeMessage).catch((error: unknown) => {

--- a/server/logic/publications.ts
+++ b/server/logic/publications.ts
@@ -1,4 +1,5 @@
 import { ClientMessage, PublicationsObserver, PublicationsReasons } from '../../shared/protocol.ts';
+import { hasMongoOperator } from '../../shared/helperFunctions.ts';
 import { MongoWrapper } from '../infrastructure/mongo.ts';
 import { WebSocketWrapper } from '../infrastructure/websocket.ts';
 import { ChangeEvent } from '../../shared/types.ts';
@@ -67,6 +68,20 @@ export class Publications {
     }
   }
 
+  private sendPublicationError(
+    clientId: string,
+    message: ClientMessage,
+    reason: PublicationsReasons,
+    messageText: string,
+  ): void {
+    this.ws.send(clientId, {
+      type: 'error',
+      id: message.id,
+      error: { code: 400, message: messageText },
+    });
+    this.notifyObserver(message, 'failed', reason);
+  }
+
   private tearDownClient(clientId: string): void {
     const clientSubs = this.subscriptions.get(clientId);
     if (!clientSubs) return;
@@ -96,30 +111,14 @@ export class Publications {
         return Promise.resolve();
       }
 
-      const hasMongoOperator = (obj: unknown): boolean => {
-        if (obj === null || obj === undefined) return false;
-        if (Array.isArray(obj)) return obj.some((item) => hasMongoOperator(item));
-        if (typeof obj === 'object') {
-          for (const [key, val] of Object.entries(obj as Record<string, unknown>)) {
-            if (key.startsWith('$')) return true;
-            if (hasMongoOperator(val)) return true;
-          }
-        }
-        return false;
-      };
-
       if (message.params && hasMongoOperator(message.params)) {
-        this.ws.send(clientId, {
-          type: 'error',
-          id: message.id,
-          error: {
-            code: 400,
-            message: `Invalid subscription params: mongo operators are not allowed`,
-          },
-        });
-
-        this.notifyObserver(message, 'failed', 'invalid-params');
-        return Promise.resolve();
+        this.sendPublicationError(
+          clientId,
+          message,
+          'invalid-params',
+          'Invalid subscription params: mongo operators are not allowed',
+        );
+        return;
       }
 
       let collection: string;
@@ -133,14 +132,8 @@ export class Publications {
             ? `Publication query failed: ${err.message}`
             : 'Publication query failed';
 
-        this.ws.send(clientId, {
-          type: 'error',
-          id: message.id,
-          error: { code: 400, message: messageText },
-        });
-
-        this.notifyObserver(message, 'failed', 'publication-query-failed');
-        return Promise.resolve();
+        this.sendPublicationError(clientId, message, 'publication-query-failed', messageText);
+        return;
       }
 
       let docs;
@@ -152,14 +145,8 @@ export class Publications {
             ? `Publication query failed: ${err.message}`
             : 'Publication query failed';
 
-        this.ws.send(clientId, {
-          type: 'error',
-          id: message.id,
-          error: { code: 400, message: messageText },
-        });
-
-        this.notifyObserver(message, 'failed', 'publication-query-failed');
-        return Promise.resolve();
+        this.sendPublicationError(clientId, message, 'publication-query-failed', messageText);
+        return;
       }
 
       const documentIds = new Set<string>();

--- a/server/logic/publications.ts
+++ b/server/logic/publications.ts
@@ -73,11 +73,12 @@ export class Publications {
     message: ClientMessage,
     reason: PublicationsReasons,
     messageText: string,
+    code: number,
   ): void {
     this.ws.send(clientId, {
       type: 'error',
       id: message.id,
-      error: { code: 400, message: messageText },
+      error: { code: code, message: messageText },
     });
     this.notifyObserver(message, 'failed', reason);
   }
@@ -102,12 +103,13 @@ export class Publications {
       const queryFn = this.publications.get(message.name);
 
       if (!queryFn) {
-        this.ws.send(clientId, {
-          type: 'error',
-          id: message.id,
-          error: { code: 404, message: `Unknown publication: ${message.name}` },
-        });
-        this.notifyObserver(message, 'failed', 'unknown-publication');
+        this.sendPublicationError(
+          clientId,
+          message,
+          'unknown-publication',
+          `Unknown publication: ${message.name}`,
+          404,
+        );
         return Promise.resolve();
       }
 
@@ -117,6 +119,7 @@ export class Publications {
           message,
           'invalid-params',
           'Invalid subscription params: mongo operators are not allowed',
+          400,
         );
         return;
       }
@@ -132,7 +135,7 @@ export class Publications {
             ? `Publication query failed: ${err.message}`
             : 'Publication query failed';
 
-        this.sendPublicationError(clientId, message, 'publication-query-failed', messageText);
+        this.sendPublicationError(clientId, message, 'publication-query-failed', messageText, 400);
         return;
       }
 
@@ -142,10 +145,16 @@ export class Publications {
       } catch (err) {
         const messageText =
           err instanceof Error
-            ? `Publication query failed: ${err.message}`
-            : 'Publication query failed';
+            ? `Publications Mongo find failed: ${err.message}`
+            : 'Publications Mongo find failed';
 
-        this.sendPublicationError(clientId, message, 'publication-query-failed', messageText);
+        this.sendPublicationError(
+          clientId,
+          message,
+          'publications-mongo-find-failed',
+          messageText,
+          400,
+        );
         return;
       }
 

--- a/server/logic/publications.ts
+++ b/server/logic/publications.ts
@@ -3,6 +3,8 @@ import { MongoWrapper } from '../infrastructure/mongo.ts';
 import { WebSocketWrapper } from '../infrastructure/websocket.ts';
 import { ChangeEvent } from '../../shared/types.ts';
 
+// Publication params stay loosely typed at the protocol boundary because
+// client input is unknown
 type PublicationDef = (params?: Record<string, unknown>) => { collection: string; query: object };
 
 type SubscriptionRecord = {

--- a/server/logic/publications.ts
+++ b/server/logic/publications.ts
@@ -3,7 +3,7 @@ import { MongoWrapper } from '../infrastructure/mongo.ts';
 import { WebSocketWrapper } from '../infrastructure/websocket.ts';
 import { ChangeEvent } from '../../shared/types.ts';
 
-type PublicationDef = () => { collection: string; query: object };
+type PublicationDef = (params?: Record<string, unknown>) => { collection: string; query: object };
 
 type SubscriptionRecord = {
   cleanup: () => void;
@@ -94,7 +94,7 @@ export class Publications {
         return Promise.resolve();
       }
 
-      const { collection, query } = queryFn();
+      const { collection, query } = queryFn(message.params ?? {});
       const docs = await this.mongo.find<{ _id: string }>(collection, query);
       const documentIds = new Set<string>();
       const collectionName = collection;

--- a/server/logic/publications.ts
+++ b/server/logic/publications.ts
@@ -100,15 +100,56 @@ export class Publications {
         this.ws.send(clientId, {
           type: 'error',
           id: message.id,
-          error: { code: 404, message: `Wrong message params: ${message.name}` },
+          error: {
+            code: 400,
+            message: `Publication query failed: folderId is required and must be a string`,
+          },
         });
 
-        this.notifyObserver(message, 'failed', 'invalid-params-value');
+        this.notifyObserver(message, 'failed', 'publication-threw');
         return Promise.resolve();
       }
 
-      const { collection, query } = queryFn(message.params ?? {});
-      const docs = await this.mongo.find<{ _id: string }>(collection, query);
+      let collection: string;
+      let query: object;
+
+      try {
+        ({ collection, query } = queryFn(message.params ?? {}));
+      } catch (err) {
+        const messageText =
+          err instanceof Error
+            ? `Publication query failed: ${err.message}`
+            : 'Publication query failed';
+
+        this.ws.send(clientId, {
+          type: 'error',
+          id: message.id,
+          error: { code: 400, message: messageText },
+        });
+
+        this.notifyObserver(message, 'failed', 'publication-threw');
+        return Promise.resolve();
+      }
+
+      let docs;
+      try {
+        docs = await this.mongo.find<{ _id: string }>(collection, query);
+      } catch (err) {
+        const messageText =
+          err instanceof Error
+            ? `Publication query failed: ${err.message}`
+            : 'Publication query failed';
+
+        this.ws.send(clientId, {
+          type: 'error',
+          id: message.id,
+          error: { code: 400, message: messageText },
+        });
+
+        this.notifyObserver(message, 'failed', 'publication-threw');
+        return Promise.resolve();
+      }
+
       const documentIds = new Set<string>();
       const collectionName = collection;
 

--- a/server/logic/publications.ts
+++ b/server/logic/publications.ts
@@ -96,6 +96,17 @@ export class Publications {
         return Promise.resolve();
       }
 
+      if (message.params && typeof (message.params as { folderId: string }).folderId !== 'string') {
+        this.ws.send(clientId, {
+          type: 'error',
+          id: message.id,
+          error: { code: 404, message: `Wrong message params: ${message.name}` },
+        });
+
+        this.notifyObserver(message, 'failed', 'unknown-publication');
+        return Promise.resolve();
+      }
+
       const { collection, query } = queryFn(message.params ?? {});
       const docs = await this.mongo.find<{ _id: string }>(collection, query);
       const documentIds = new Set<string>();

--- a/server/logic/publications.ts
+++ b/server/logic/publications.ts
@@ -95,7 +95,7 @@ export class Publications {
         this.notifyObserver(message, 'failed', 'unknown-publication');
         return Promise.resolve();
       }
-      // Reject any params containing mongo operators (keys starting with '$')
+
       const hasMongoOperator = (obj: unknown): boolean => {
         if (obj === null || obj === undefined) return false;
         if (Array.isArray(obj)) return obj.some((item) => hasMongoOperator(item));

--- a/server/logic/publications.ts
+++ b/server/logic/publications.ts
@@ -103,7 +103,7 @@ export class Publications {
           error: { code: 404, message: `Wrong message params: ${message.name}` },
         });
 
-        this.notifyObserver(message, 'failed', 'unknown-publication');
+        this.notifyObserver(message, 'failed', 'invalid-params-value');
         return Promise.resolve();
       }
 

--- a/server/logic/publications.ts
+++ b/server/logic/publications.ts
@@ -95,18 +95,30 @@ export class Publications {
         this.notifyObserver(message, 'failed', 'unknown-publication');
         return Promise.resolve();
       }
+      // Reject any params containing mongo operators (keys starting with '$')
+      const hasMongoOperator = (obj: unknown): boolean => {
+        if (obj === null || obj === undefined) return false;
+        if (Array.isArray(obj)) return obj.some((item) => hasMongoOperator(item));
+        if (typeof obj === 'object') {
+          for (const [key, val] of Object.entries(obj as Record<string, unknown>)) {
+            if (key.startsWith('$')) return true;
+            if (hasMongoOperator(val)) return true;
+          }
+        }
+        return false;
+      };
 
-      if (message.params && typeof (message.params as { folderId: string }).folderId !== 'string') {
+      if (message.params && hasMongoOperator(message.params)) {
         this.ws.send(clientId, {
           type: 'error',
           id: message.id,
           error: {
             code: 400,
-            message: `Publication query failed: folderId is required and must be a string`,
+            message: `Invalid subscription params: mongo operators are not allowed`,
           },
         });
 
-        this.notifyObserver(message, 'failed', 'publication-threw');
+        this.notifyObserver(message, 'failed', 'invalid-params');
         return Promise.resolve();
       }
 
@@ -127,7 +139,7 @@ export class Publications {
           error: { code: 400, message: messageText },
         });
 
-        this.notifyObserver(message, 'failed', 'publication-threw');
+        this.notifyObserver(message, 'failed', 'publication-query-failed');
         return Promise.resolve();
       }
 
@@ -146,7 +158,7 @@ export class Publications {
           error: { code: 400, message: messageText },
         });
 
-        this.notifyObserver(message, 'failed', 'publication-threw');
+        this.notifyObserver(message, 'failed', 'publication-query-failed');
         return Promise.resolve();
       }
 

--- a/shared/helperFunctions.ts
+++ b/shared/helperFunctions.ts
@@ -1,3 +1,15 @@
 export function assertNever(x: never): never {
   throw new Error(`Unexpected value: ${JSON.stringify(x)}`);
 }
+
+export function hasMongoOperator(obj: unknown): boolean {
+  if (obj === null || obj === undefined) return false;
+  if (Array.isArray(obj)) return obj.some((item) => hasMongoOperator(item));
+  if (typeof obj === 'object') {
+    for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+      if (key.startsWith('$')) return true;
+      if (hasMongoOperator(value)) return true;
+    }
+  }
+  return false;
+}

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -91,7 +91,8 @@ type ReactiveStoreFailReason = 'unsupported-message-type';
 type PublicationsSkipReason = 'unknown-sub-id';
 type PublicationsFailReason = 'unknown-publication';
 type PublicationsDuplicateSubIdReason = 'duplicate-sub-id';
-type PublicationsQueryFailedReason = 'publication-threw';
+type PublicationsQueryFailedReason = 'publication-query-failed';
+type PublicationsInvalidParamsReason = 'invalid-params';
 
 export type ReactiveStoreReasons =
   /** Document with the given ID is unknown to the store.
@@ -111,4 +112,6 @@ export type PublicationsReasons =
    *  not failed. */
   | PublicationsDuplicateSubIdReason
   /** Publication query function threw while building the subscription. */
-  | PublicationsQueryFailedReason;
+  | PublicationsQueryFailedReason
+  /** Subscribe params were rejected by the engine (e.g. contained mongo operators). */
+  | PublicationsInvalidParamsReason;

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -91,6 +91,7 @@ type ReactiveStoreFailReason = 'unsupported-message-type';
 type PublicationsSkipReason = 'unknown-sub-id';
 type PublicationsFailReason = 'unknown-publication';
 type PublicationsDuplicateSubIdReason = 'duplicate-sub-id';
+type PublicationsInvalidParamsValueReason = 'invalid-params-value';
 
 export type ReactiveStoreReasons =
   /** Document with the given ID is unknown to the store.
@@ -108,4 +109,6 @@ export type PublicationsReasons =
   /** Subscribe arrived with an id that already has a watcher on this
    *  client. Old watcher torn down, new one installed. Applied,
    *  not failed. */
-  | PublicationsDuplicateSubIdReason;
+  | PublicationsDuplicateSubIdReason
+  /** Subscribe arrived with a params with invalid structure */
+  | PublicationsInvalidParamsValueReason;

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -93,6 +93,7 @@ type PublicationsFailReason = 'unknown-publication';
 type PublicationsDuplicateSubIdReason = 'duplicate-sub-id';
 type PublicationsQueryFailedReason = 'publication-query-failed';
 type PublicationsInvalidParamsReason = 'invalid-params';
+type PublicationsMongoFailedReason = 'publications-mongo-find-failed';
 
 export type ReactiveStoreReasons =
   /** Document with the given ID is unknown to the store.
@@ -114,4 +115,6 @@ export type PublicationsReasons =
   /** Publication query function threw while building the subscription. */
   | PublicationsQueryFailedReason
   /** Subscribe params were rejected by the engine (e.g. contained mongo operators). */
-  | PublicationsInvalidParamsReason;
+  | PublicationsInvalidParamsReason
+  /**Publication threw when trying to find in Mongo */
+  | PublicationsMongoFailedReason;

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -91,7 +91,7 @@ type ReactiveStoreFailReason = 'unsupported-message-type';
 type PublicationsSkipReason = 'unknown-sub-id';
 type PublicationsFailReason = 'unknown-publication';
 type PublicationsDuplicateSubIdReason = 'duplicate-sub-id';
-type PublicationsInvalidParamsValueReason = 'invalid-params-value';
+type PublicationsQueryFailedReason = 'publication-threw';
 
 export type ReactiveStoreReasons =
   /** Document with the given ID is unknown to the store.
@@ -110,5 +110,5 @@ export type PublicationsReasons =
    *  client. Old watcher torn down, new one installed. Applied,
    *  not failed. */
   | PublicationsDuplicateSubIdReason
-  /** Subscribe arrived with a params with invalid structure */
-  | PublicationsInvalidParamsValueReason;
+  /** Publication query function threw while building the subscription. */
+  | PublicationsQueryFailedReason;

--- a/tests/client/connectionManager.test.ts
+++ b/tests/client/connectionManager.test.ts
@@ -32,6 +32,27 @@ describe('ConnectionManager', () => {
     expect(manager.store('files').getById('1')).toEqual({ _id: '1', name: 'existing.bam' });
   });
 
+  it('subscribe with params includes them in the outbound message', async () => {
+    const socket = ClientSocketWrapper.createNull();
+    const manager = new ConnectionManager(socket);
+    const messages = socket.trackMessages();
+    const server = socket.simulateServer();
+
+    const handle = manager.subscribe('files.byFolder', { folderId: 'folder-a' });
+
+    // Manager sent the subscribe message with params.
+    expect(messages.data).toHaveLength(1);
+    const sent = messages.data[0] as SubscribeMsg;
+    expect(sent.type).toBe('subscribe');
+    expect(sent.name).toBe('files.byFolder');
+    expect(sent.params).toEqual({ folderId: 'folder-a' });
+
+    // Simulate the server responding.
+    server.send({ type: 'ready', id: sent.id });
+
+    await handle.ready;
+  });
+
   it('rejects ready when subscribe fails on the server', async () => {
     const socket = ClientSocketWrapper.createNull();
     const server = socket.simulateServer();

--- a/tests/logic/publications.test.ts
+++ b/tests/logic/publications.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect } from 'vitest';
 import { Publications } from '../../server/logic/publications.ts';
 import { MongoWrapper } from '../../server/infrastructure/mongo.ts';
 import { WebSocketWrapper } from '../../server/infrastructure/websocket.ts';
-import { ObserverOutcome, PublicationsObserver } from '../../shared/protocol.ts';
+import {
+  ObserverOutcome,
+  PublicationsObserver,
+  PublicationsReasons,
+} from '../../shared/protocol.ts';
 
 describe('Publications', () => {
   it('sends error when subscribing to unknown publication', async () => {
@@ -504,5 +508,44 @@ describe('Publications', () => {
 
     expect(queryFnCalled).toBe(false);
     expect(client.messages).toContainEqual(expect.objectContaining({ type: 'error', id: 'sub1' }));
+  });
+
+  it('sends an error to the client when the publication query throws', async () => {
+    const mongo = MongoWrapper.createNull({ find: [[]] });
+    const ws = WebSocketWrapper.createNull();
+    const client = ws.simulateConnection();
+    const notifications: { outcome: ObserverOutcome; reason?: PublicationsReasons | undefined }[] =
+      [];
+    const observer: PublicationsObserver = {
+      onMessage(_msg, outcome, reason) {
+        notifications.push({ outcome, reason });
+      },
+    };
+    const pubs = new Publications(mongo, ws, observer);
+
+    pubs.define('files.byFolder', (params) => {
+      if (typeof (params as { folderId?: unknown }).folderId !== 'string') {
+        throw new Error('folderId is required and must be a string');
+      }
+      return { collection: 'files', query: {} };
+    });
+
+    await pubs.handleMessage(client.id, {
+      type: 'subscribe',
+      id: 'sub1',
+      name: 'files.byFolder',
+      params: {},
+    });
+
+    expect(client.messages).toContainEqual({
+      type: 'error',
+      id: 'sub1',
+      error: {
+        code: 400,
+        message: 'Publication query failed: folderId is required and must be a string',
+      },
+    });
+
+    expect(notifications).toContainEqual(expect.objectContaining({ outcome: 'failed' }));
   });
 });

--- a/tests/logic/publications.test.ts
+++ b/tests/logic/publications.test.ts
@@ -481,4 +481,28 @@ describe('Publications', () => {
 
     expect(receivedParams).toEqual({ folderId: 'folder-a' });
   });
+
+  it('rejects subscribe params that smuggle mongo operators', async () => {
+    const mongo = MongoWrapper.createNull({ find: [[]] });
+    const ws = WebSocketWrapper.createNull();
+    const client = ws.simulateConnection();
+    const pubs = new Publications(mongo, ws);
+
+    let queryFnCalled = false;
+    pubs.define('files.byFolder', (params) => {
+      queryFnCalled = true;
+      const folderId = (params as { folderId: string }).folderId;
+      return { collection: 'files', query: { folderId } };
+    });
+
+    await pubs.handleMessage(client.id, {
+      type: 'subscribe',
+      id: 'sub1',
+      name: 'files.byFolder',
+      params: { folderId: { $ne: null } },
+    });
+
+    expect(queryFnCalled).toBe(false);
+    expect(client.messages).toContainEqual(expect.objectContaining({ type: 'error', id: 'sub1' }));
+  });
 });

--- a/tests/logic/publications.test.ts
+++ b/tests/logic/publications.test.ts
@@ -454,4 +454,31 @@ describe('Publications', () => {
       id: '1',
     });
   });
+
+  it('passes subscribe params to the publication query', async () => {
+    const mongo = MongoWrapper.createNull({
+      find: [[{ _id: '1', name: 'in-folder.bam', folderId: 'folder-a' }]],
+    });
+    const ws = WebSocketWrapper.createNull();
+    const client = ws.simulateConnection();
+    const pubs = new Publications(mongo, ws);
+
+    let receivedParams: unknown;
+    pubs.define('files.byFolder', (params) => {
+      receivedParams = params;
+      return {
+        collection: 'files',
+        query: { folderId: (params as { folderId: string }).folderId },
+      };
+    });
+
+    await pubs.handleMessage(client.id, {
+      type: 'subscribe',
+      id: 'sub1',
+      name: 'files.byFolder',
+      params: { folderId: 'folder-a' },
+    });
+
+    expect(receivedParams).toEqual({ folderId: 'folder-a' });
+  });
 });

--- a/tests/shared/helperFunctions.test.ts
+++ b/tests/shared/helperFunctions.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { hasMongoOperator } from '../../shared/helperFunctions.ts';
+
+describe('hasMongoOperator', () => {
+  it('returns false for primitives and safe nested objects', () => {
+    expect(hasMongoOperator(null)).toBe(false);
+    expect(hasMongoOperator(undefined)).toBe(false);
+    expect(hasMongoOperator('string')).toBe(false);
+    expect(hasMongoOperator(42)).toBe(false);
+    expect(hasMongoOperator({ folderId: 'a', status: 'complete' })).toBe(false);
+    expect(hasMongoOperator({ nested: { value: 1 }, arr: [1, 'two'] })).toBe(false);
+  });
+
+  it('returns true for direct mongo operator keys', () => {
+    expect(hasMongoOperator({ $ne: null })).toBe(true);
+    expect(hasMongoOperator({ folderId: { $in: ['a', 'b'] } })).toBe(true);
+  });
+
+  it('returns true for nested mongo operators at any depth', () => {
+    expect(hasMongoOperator({ folderId: 'a', status: { $ne: null } })).toBe(true);
+    expect(hasMongoOperator({ deep: { nested: { $gt: 5 } } })).toBe(true);
+  });
+
+  it('returns true for mongo operators nested inside arrays', () => {
+    expect(hasMongoOperator([1, { $exists: true }, 3])).toBe(true);
+    expect(hasMongoOperator({ arr: [1, { nested: { $lt: 10 } }] })).toBe(true);
+  });
+});


### PR DESCRIPTION
- test: red - passes subscribe params to the publication query
- added the solution in publications for the test to pass
- test: green - subscribe with params includes them in the outbound message
- docs: commented why we should leave params type as it is

https://linear.app/ekohacks/issue/EKO-272/3c2-subscribe-with-params-server-side-filtering-by-client-knowledge