### PR TITLE
Eko 279/3c4 gate late messages after stop

### DIFF
--- a/client/clientSocket.ts
+++ b/client/clientSocket.ts
@@ -17,7 +17,7 @@ export function isServerMessage(data: unknown): data is ServerMessage {
 
   switch (type) {
     case 'ready':
-      return typeof msg.id === 'string';
+      return typeof msg.id === 'string' && typeof msg.collection === 'string';
     case 'result':
       return typeof msg.id === 'string';
     case 'added':

--- a/client/connectionManager.ts
+++ b/client/connectionManager.ts
@@ -213,14 +213,10 @@ export class ConnectionManager {
       case 'ready': {
         const subscription = this.subscriptions.get(message.id);
         if (subscription) {
-          // The server names the collection on ready. Fall back to the
-          // collection of the initial data buffered for this sub when an older
-          // server omits it.
-          const collection = message.collection ?? this.pendingData.at(0)?.collection;
-          if (collection !== undefined) {
-            subscription.collection = collection;
-            this.flushPending(collection);
-          }
+          // The server names the collection on ready, so bind the subscription
+          // to it and flush any initial data buffered before it arrived.
+          subscription.collection = message.collection;
+          this.flushPending(message.collection);
           subscription.readyResolver();
         }
         break;

--- a/client/connectionManager.ts
+++ b/client/connectionManager.ts
@@ -37,6 +37,8 @@ export class ConnectionManager {
   private readonly socket: ClientSocketWrapper;
   private readonly stores = new Map<string, ReactiveStore>();
   private readonly subscriptions = new Map<string, SubscriptionState>();
+  private readonly subscriptionCollections = new Map<string, string>();
+  private readonly collectionSubscriptions = new Map<string, number>();
   private readonly teardownMessageListener: () => void;
   private readonly teardownCloseListener: () => void;
   private disposed = false;
@@ -73,6 +75,7 @@ export class ConnectionManager {
       readyResolver: resolveReady,
       readyRejector: rejectReady,
     });
+    this.registerLiveSubscription(id, name);
 
     const subscribeMessage: SubscribeMsg = {
       type: 'subscribe',
@@ -82,7 +85,7 @@ export class ConnectionManager {
     };
 
     this.socket.send(subscribeMessage).catch((error: unknown) => {
-      this.subscriptions.delete(id);
+      this.unregisterLiveSubscription(id);
       rejectReady(error);
     });
 
@@ -98,7 +101,7 @@ export class ConnectionManager {
       subscription.readyRejector(new Error('subscription stopped before ready'));
     }
 
-    this.subscriptions.delete(id);
+    this.unregisterLiveSubscription(id);
 
     this.socket.send(unsubscribeMessage).catch((error: unknown) => {
       console.error('Failed to send unsubscribe message:', error);
@@ -144,12 +147,51 @@ export class ConnectionManager {
     }
   }
 
+  private registerLiveSubscription(id: string, name: string): void {
+    const collection = this.getCollectionFromPublicationName(name);
+    this.subscriptionCollections.set(id, collection);
+    this.collectionSubscriptions.set(
+      collection,
+      (this.collectionSubscriptions.get(collection) ?? 0) + 1,
+    );
+  }
+
+  private unregisterLiveSubscription(id: string): void {
+    const collection = this.subscriptionCollections.get(id);
+    if (!collection) {
+      this.subscriptions.delete(id);
+      return;
+    }
+
+    const count = this.collectionSubscriptions.get(collection);
+    if (count === undefined) {
+      this.subscriptionCollections.delete(id);
+      this.subscriptions.delete(id);
+      return;
+    }
+
+    if (count <= 1) {
+      this.collectionSubscriptions.delete(collection);
+    } else {
+      this.collectionSubscriptions.set(collection, count - 1);
+    }
+
+    this.subscriptionCollections.delete(id);
+    this.subscriptions.delete(id);
+  }
+
+  private getCollectionFromPublicationName(name: string): string {
+    return name.split('.')[0];
+  }
+
   private handleServerMessage(message: ServerMessage): void {
     switch (message.type) {
       case 'added':
       case 'changed':
       case 'removed': {
-        this.store(message.collection).handleMessage(message);
+        if (this.collectionSubscriptions.has(message.collection)) {
+          this.store(message.collection).handleMessage(message);
+        }
         break;
       }
       case 'ready': {
@@ -165,7 +207,7 @@ export class ConnectionManager {
         const subscription = this.subscriptions.get(message.id);
         if (subscription) {
           subscription.readyRejector(message.error);
-          this.subscriptions.delete(message.id);
+          this.unregisterLiveSubscription(message.id);
         }
         break;
       }

--- a/client/connectionManager.ts
+++ b/client/connectionManager.ts
@@ -1,6 +1,6 @@
 import { ClientSocketWrapper } from './clientSocket.ts';
 import { ReactiveStore } from './reactiveStore.ts';
-import { ServerMessage, SubscribeMsg, UnsubscribeMsg } from '../shared/protocol.ts';
+import { DataMsg, ServerMessage, SubscribeMsg, UnsubscribeMsg } from '../shared/protocol.ts';
 import { assertNever } from '../shared/helperFunctions.ts';
 
 interface SubscriptionHandle {
@@ -11,7 +11,9 @@ interface SubscriptionHandle {
 interface SubscriptionState {
   readyResolver: () => void;
   readyRejector: (error: unknown) => void;
-  collection: string;
+  // Learned from the server: ready.collection when present, otherwise inferred
+  // from the initial data buffered before ready. Undefined until then.
+  collection?: string;
 }
 
 class SubscriptionHandleImpl implements SubscriptionHandle {
@@ -41,6 +43,10 @@ export class ConnectionManager {
   private readonly teardownMessageListener: () => void;
   private readonly teardownCloseListener: () => void;
   private disposed = false;
+  // Initial `added` documents that arrive before their subscription has learned
+  // its collection. Held here until the matching `ready` binds the collection,
+  // then flushed into the store. See handleServerMessage.
+  private pendingData: DataMsg[] = [];
 
   constructor(socket: ClientSocketWrapper) {
     this.socket = socket;
@@ -70,11 +76,9 @@ export class ConnectionManager {
       rejectReady = reject;
     });
 
-    const collection = this.getCollectionFromPublicationName(name);
     this.subscriptions.set(id, {
       readyResolver: resolveReady,
       readyRejector: rejectReady,
-      collection,
     });
 
     const subscribeMessage: SubscribeMsg = {
@@ -134,6 +138,7 @@ export class ConnectionManager {
 
     this.subscriptions.clear();
     this.stores.clear();
+    this.pendingData = [];
   }
 
   // Test seam: exposes internal state so tests can assert teardown happened.
@@ -156,15 +161,50 @@ export class ConnectionManager {
     return false;
   }
 
-  private getCollectionFromPublicationName(name: string): string {
-    return name.split('.')[0];
+  // True while at least one subscription is still waiting to learn its
+  // collection from a ready. Only then do we hold onto data we cannot place
+  // yet; once every sub is bound, unplaceable data is a late message to drop,
+  // not initial data to buffer.
+  private hasUnboundSubscription(): boolean {
+    for (const sub of this.subscriptions.values()) {
+      if (sub.collection === undefined) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // Route any buffered initial documents for a now-known collection into its
+  // store, keeping the rest waiting for their own ready.
+  private flushPending(collection: string): void {
+    const remaining: DataMsg[] = [];
+    for (const message of this.pendingData) {
+      if (message.collection === collection) {
+        this.store(collection).handleMessage(message);
+      } else {
+        remaining.push(message);
+      }
+    }
+    this.pendingData = remaining;
   }
 
   private handleServerMessage(message: ServerMessage): void {
     switch (message.type) {
-      case 'added':
+      case 'added': {
+        if (this.isCollectionLive(message.collection)) {
+          this.store(message.collection).handleMessage(message);
+        } else if (this.hasUnboundSubscription()) {
+          // Initial data for a subscription that has not learned its collection
+          // yet. Hold it until the matching ready binds the collection.
+          this.pendingData.push(message);
+        }
+        break;
+      }
       case 'changed':
       case 'removed': {
+        // No buffering: changed/removed only ever apply to data already added,
+        // so anything for a collection that is not live is a late message the
+        // stop() gate drops.
         if (this.isCollectionLive(message.collection)) {
           this.store(message.collection).handleMessage(message);
         }
@@ -173,6 +213,14 @@ export class ConnectionManager {
       case 'ready': {
         const subscription = this.subscriptions.get(message.id);
         if (subscription) {
+          // The server names the collection on ready. Fall back to the
+          // collection of the initial data buffered for this sub when an older
+          // server omits it.
+          const collection = message.collection ?? this.pendingData.at(0)?.collection;
+          if (collection !== undefined) {
+            subscription.collection = collection;
+            this.flushPending(collection);
+          }
           subscription.readyResolver();
         }
         break;

--- a/client/connectionManager.ts
+++ b/client/connectionManager.ts
@@ -11,6 +11,7 @@ interface SubscriptionHandle {
 interface SubscriptionState {
   readyResolver: () => void;
   readyRejector: (error: unknown) => void;
+  collection: string;
 }
 
 class SubscriptionHandleImpl implements SubscriptionHandle {
@@ -37,8 +38,6 @@ export class ConnectionManager {
   private readonly socket: ClientSocketWrapper;
   private readonly stores = new Map<string, ReactiveStore>();
   private readonly subscriptions = new Map<string, SubscriptionState>();
-  private readonly subscriptionCollections = new Map<string, string>();
-  private readonly collectionSubscriptions = new Map<string, number>();
   private readonly teardownMessageListener: () => void;
   private readonly teardownCloseListener: () => void;
   private disposed = false;
@@ -71,11 +70,12 @@ export class ConnectionManager {
       rejectReady = reject;
     });
 
+    const collection = this.getCollectionFromPublicationName(name);
     this.subscriptions.set(id, {
       readyResolver: resolveReady,
       readyRejector: rejectReady,
+      collection,
     });
-    this.registerLiveSubscription(id, name);
 
     const subscribeMessage: SubscribeMsg = {
       type: 'subscribe',
@@ -85,7 +85,7 @@ export class ConnectionManager {
     };
 
     this.socket.send(subscribeMessage).catch((error: unknown) => {
-      this.unregisterLiveSubscription(id);
+      this.subscriptions.delete(id);
       rejectReady(error);
     });
 
@@ -101,7 +101,7 @@ export class ConnectionManager {
       subscription.readyRejector(new Error('subscription stopped before ready'));
     }
 
-    this.unregisterLiveSubscription(id);
+    this.subscriptions.delete(id);
 
     this.socket.send(unsubscribeMessage).catch((error: unknown) => {
       console.error('Failed to send unsubscribe message:', error);
@@ -147,37 +147,13 @@ export class ConnectionManager {
     }
   }
 
-  private registerLiveSubscription(id: string, name: string): void {
-    const collection = this.getCollectionFromPublicationName(name);
-    this.subscriptionCollections.set(id, collection);
-    this.collectionSubscriptions.set(
-      collection,
-      (this.collectionSubscriptions.get(collection) ?? 0) + 1,
-    );
-  }
-
-  private unregisterLiveSubscription(id: string): void {
-    const collection = this.subscriptionCollections.get(id);
-    if (!collection) {
-      this.subscriptions.delete(id);
-      return;
+  private isCollectionLive(collection: string): boolean {
+    for (const sub of this.subscriptions.values()) {
+      if (sub.collection === collection) {
+        return true;
+      }
     }
-
-    const count = this.collectionSubscriptions.get(collection);
-    if (count === undefined) {
-      this.subscriptionCollections.delete(id);
-      this.subscriptions.delete(id);
-      return;
-    }
-
-    if (count <= 1) {
-      this.collectionSubscriptions.delete(collection);
-    } else {
-      this.collectionSubscriptions.set(collection, count - 1);
-    }
-
-    this.subscriptionCollections.delete(id);
-    this.subscriptions.delete(id);
+    return false;
   }
 
   private getCollectionFromPublicationName(name: string): string {
@@ -189,7 +165,7 @@ export class ConnectionManager {
       case 'added':
       case 'changed':
       case 'removed': {
-        if (this.collectionSubscriptions.has(message.collection)) {
+        if (this.isCollectionLive(message.collection)) {
           this.store(message.collection).handleMessage(message);
         }
         break;
@@ -207,7 +183,7 @@ export class ConnectionManager {
         const subscription = this.subscriptions.get(message.id);
         if (subscription) {
           subscription.readyRejector(message.error);
-          this.unregisterLiveSubscription(message.id);
+          this.subscriptions.delete(message.id);
         }
         break;
       }

--- a/learning/git-worktree.md
+++ b/learning/git-worktree.md
@@ -1,0 +1,92 @@
+# Git Worktree: The Day We Wanted to Verify a Branch Without Leaving Our Own
+
+> "Founding itself upon love, humility, and faith, dialogue becomes a horizontal relationship of which mutual trust between the dialoguers is the logical consequence." Paulo Freire
+
+At EkoHacks we do not tell you to keep a clean main and stay out of each other's way. We show you the moment one of us needed to read the other's work and had to choose: take the seat they had been sitting in, or pull up a chair beside them.
+
+## The setup
+
+A branch had been live for a couple of days. A ClientSocket refactor, sitting on top of an in flight PR, with its own pile of tests and a coverage number to check.
+
+We wanted to verify it. Pass or fail against six "Done when" criteria, the kind of thing you do before raising the PR or before approving someone else's. Not a glance. Run the unit suite, run the integration suite, get the coverage report, read three test files, decide.
+
+The usual move is `git checkout the-branch`, look around, run the tests, then `git checkout main`. It works. It also means swapping every file in the editor, losing any uncommitted thinking we had sitting around, and treating our own work as a thing to be put away.
+
+There is a smaller tool for this. Most of us never reach for it.
+
+## What a worktree is
+
+A worktree is a second checked out copy of the same repository, in a different folder, on a different branch. One repo. Two folders. Two branches loaded at the same time.
+
+```
+~/Sites/ekolite              folder one, on main
+├── client/
+├── server/
+└── .git/                    the real repo (commits, refs, history)
+
+/tmp/ekolite-pr39-verify     folder two, on the branch
+├── client/                  (same paths, the other branch's content)
+├── server/
+└── .git                     a small pointer file back to folder one's .git/
+```
+
+The git database lives once, in your main checkout. The second folder carries a pointer back to it. So you are not duplicating history. You are opening a second window onto the same one.
+
+## What we did
+
+```
+git worktree add /tmp/ekolite-pr39-verify the-branch
+ln -s ~/Sites/ekolite/node_modules /tmp/ekolite-pr39-verify/node_modules
+cd /tmp/ekolite-pr39-verify
+npx vitest run --coverage
+```
+
+Four lines. Our main checkout never moved. The editor still showed main. Vitest ran against the other branch on a parallel copy that shared the same installed packages.
+
+The third line is the small one. `node_modules` is not tracked by git, so a fresh worktree starts with none. Running `npm install` again would have worked but taken a minute and bought us nothing. The symlink lets both folders read the same installed packages. Quietly important.
+
+When the work was done:
+
+```
+git worktree remove /tmp/ekolite-pr39-verify
+```
+
+The pointer went away. The main checkout was untouched. The branch itself lives on in our git history, ready to be opened in a new worktree, or checked out normally, or merged. Removing the worktree removed only the workspace.
+
+## What is happening underneath
+
+Two facts about the worktree are worth holding.
+
+**The git database lives in your main checkout.** The second worktree's `.git` is not a directory but a single text file pointing back to the original. So `git log` from the second folder shows the same history as `git log` from the first. They are not two repos. They are one.
+
+**Git refuses to let you check out the same branch in two worktrees at once.** Try and it will say so. The reason is straightforward: two folders writing commits to the same ref would leave nobody knowing which one to trust. The rule keeps each branch owned by exactly one working copy at any moment.
+
+This second rule is the one worth pausing on. The tool will not let you do the thing that breaks the model. Worktrees are not "multiple parallel git repos". They are "one repo, multiple branches loaded for editing, each one owned by exactly one folder while it is open".
+
+**Question for the pair:** what would it mean for a branch to live in two folders at once? Whose commit wins? The constraint is not arbitrary. Sit with the why.
+
+## When to reach for it
+
+Three patterns earn the keystrokes.
+
+**Verification.** Someone's branch needs reading. You want the suite, you want the coverage, you want to poke at the diff with both branches open in the editor side by side. Worktree, run, remove. Your own work was never interrupted.
+
+**Long running work.** A test suite or a build that takes minutes. Kick it off in a worktree, keep editing in your main checkout. No more "I cannot touch anything until this finishes."
+
+**Side by side reads.** Comparing two versions of the same file with both open at once, both real on disk. Useful for refactors where the diff alone does not tell you what changed.
+
+## When not to bother
+
+Quick read of a single file on another branch: `git show the-branch:path/to/file.ts` is enough. The file content goes to stdout, no checkout needed. Save the worktree for when you need to _run_ the branch, not just read it.
+
+Switching to a branch you will work on for the next hour: just `git checkout`. The worktree is for parallelism, not for replacing your normal flow.
+
+## What we carry forward
+
+**A worktree lets you be present to two branches at once.** Yours and theirs, side by side, no swap. The tool removes the false choice between engaging with someone else's work and protecting your own.
+
+**The mechanics are small but specific.** `git worktree add <path> <branch>`, symlink `node_modules` if the branches share dependencies, `git worktree remove <path>` when done. The whole loop is four lines and you never lose your seat.
+
+**The refusal to check out the same branch twice is the design speaking.** The tool will not let you create a state it cannot reason about. The same way a rebase makes you confront each conflict in context, a worktree makes you decide which branch each folder belongs to. Both are git refusing to make a decision that should be yours.
+
+To verify a teammate's work is to be taught by it. The worktree creates the physical condition for that exchange. You read their branch, run their tests, sit with what they have made. Your own work is still on the desk where you left it, waiting for you to come back.

--- a/learning/publication-name.ts
+++ b/learning/publication-name.ts
@@ -1,0 +1,33 @@
+// Run me:  npx tsx learning/publication-name.ts
+//
+// Before you run: write down, out loud or on paper, what you expect
+// `store('files')` to hold at the end. Commit to a guess. Then run it.
+
+import { ClientSocketWrapper } from '../client/clientSocket.ts';
+import { ConnectionManager } from '../client/connectionManager.ts';
+import { SubscribeMsg } from '../shared/protocol.ts';
+
+async function main(): Promise<void> {
+  const socket = ClientSocketWrapper.createNull();
+  const server = socket.simulateServer();
+  const manager = new ConnectionManager(socket);
+  const messages = socket.trackMessages();
+
+  // The most natural thing a dev would write: name the publication for what
+  // it means, not for where the data is stored.
+  const handle = manager.subscribe('files.recent');
+  const subId = (messages.data[0] as SubscribeMsg).id;
+
+  // The server does its job: it sends a real document, stamped with the
+  // collection that document actually lives in.
+  server.send({ type: 'added', collection: 'files', id: 'f1', fields: { name: 'report.bam' } });
+  server.send({ type: 'ready', id: subId });
+
+  await handle.ready;
+
+  console.log('1. handle.ready resolved        ->', 'no error, no warning');
+  console.log('2. the server sent us           ->', 'collection "files", doc f1 = report.bam');
+  console.log('3. store("files").getById("f1") ->', manager.store('files').getById('f1'));
+}
+
+await main();

--- a/learning/publication-name.ts
+++ b/learning/publication-name.ts
@@ -21,7 +21,7 @@ async function main(): Promise<void> {
   // The server does its job: it sends a real document, stamped with the
   // collection that document actually lives in.
   server.send({ type: 'added', collection: 'files', id: 'f1', fields: { name: 'report.bam' } });
-  server.send({ type: 'ready', id: subId });
+  server.send({ type: 'ready', id: subId, collection: 'files' });
 
   await handle.ready;
 

--- a/server/logic/publications.ts
+++ b/server/logic/publications.ts
@@ -25,9 +25,10 @@ const addedMessage = (collection: string, doc: Record<string, unknown>) => ({
   fields: Object.fromEntries(Object.entries(doc).filter(([key]) => key !== '_id')),
 });
 
-const readyMessage = (subId: string) => ({
+const readyMessage = (subId: string, collection: string) => ({
   type: 'ready',
   id: subId,
+  collection,
 });
 
 const removedMessage = (collection: string, docId: string) => ({
@@ -171,7 +172,7 @@ export class Publications {
         documentIds.add(doc._id);
         this.ws.send(clientId, addedMessage(collection, doc));
       }
-      this.ws.send(clientId, readyMessage(message.id));
+      this.ws.send(clientId, readyMessage(message.id, collection));
 
       const cleanup = this.mongo.watchChanges(collection, (change: ChangeEvent) => {
         if (change.type === 'insert') {

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -33,6 +33,10 @@ export type ClientMessage = SubscribeMsg | UnsubscribeMsg | MethodMsg;
 export interface ReadyMsg {
   type: 'ready';
   id: string;
+  // The collection this subscription owns, decided by the server. Optional so
+  // readys that predate this field still type check; when present it is the
+  // authoritative source the client binds the subscription to.
+  collection?: string;
 }
 
 export type DataMsg =

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -33,10 +33,10 @@ export type ClientMessage = SubscribeMsg | UnsubscribeMsg | MethodMsg;
 export interface ReadyMsg {
   type: 'ready';
   id: string;
-  // The collection this subscription owns, decided by the server. Optional so
-  // readys that predate this field still type check; when present it is the
-  // authoritative source the client binds the subscription to.
-  collection?: string;
+  // The collection this subscription owns, decided by the server. The client
+  // binds the subscription to it on ready; required so a ready can never arrive
+  // without one.
+  collection: string;
 }
 
 export type DataMsg =

--- a/tests/client/clientSocket.test.ts
+++ b/tests/client/clientSocket.test.ts
@@ -45,9 +45,9 @@ describe('ClientSocketWrapper parsing contract', () => {
     socket.onMessage((m) => received.push(m));
 
     server.sendRaw('not-json-at-all');
-    server.send({ type: 'ready', id: '1' });
+    server.send({ type: 'ready', id: '1', collection: 'files' });
 
-    expect(received).toEqual([{ type: 'ready', id: '1' }]);
+    expect(received).toEqual([{ type: 'ready', id: '1', collection: 'files' }]);
   });
 
   it('drops a well-formed JSON payload that is not a server message', async () => {
@@ -59,9 +59,9 @@ describe('ClientSocketWrapper parsing contract', () => {
     socket.onMessage((m) => received.push(m));
 
     server.sendRaw(JSON.stringify({ type: 'not-a-real-type' }));
-    server.send({ type: 'ready', id: '1' });
+    server.send({ type: 'ready', id: '1', collection: 'files' });
 
-    expect(received).toEqual([{ type: 'ready', id: '1' }]);
+    expect(received).toEqual([{ type: 'ready', id: '1', collection: 'files' }]);
   });
 });
 
@@ -111,7 +111,7 @@ describe('ClientSocketWrapper (null)', () => {
   });
   it('can receive a message from the server', async () => {
     const received: ServerMessage[] = [];
-    const message: ReadyMsg = { type: 'ready', id: '1' };
+    const message: ReadyMsg = { type: 'ready', id: '1', collection: 'files' };
     const socket = ClientSocketWrapper.createNull();
     const unsubscribe = socket.onMessage((msg) => received.push(msg));
 
@@ -120,7 +120,7 @@ describe('ClientSocketWrapper (null)', () => {
     server.send(message);
 
     expect(received).toHaveLength(1);
-    expect(received).toEqual([{ type: 'ready', id: '1' }]);
+    expect(received).toEqual([{ type: 'ready', id: '1', collection: 'files' }]);
 
     unsubscribe();
   });
@@ -143,7 +143,7 @@ describe('ClientSocketWrapper (null)', () => {
 
     await socket.send({ type: 'unsubscribe', id: '1' });
 
-    server.send({ type: 'ready', id: '1' });
+    server.send({ type: 'ready', id: '1', collection: 'files' });
 
     expect(tracker.data).toHaveLength(1);
     expect(tracker.data[0]).toEqual({ type: 'unsubscribe', id: '1' });
@@ -156,11 +156,15 @@ describe('isServerMessage type guard', () => {
   });
 
   it('accepts ready messages with required fields', () => {
-    expect(isServerMessage({ type: 'ready', id: '1' })).toBe(true);
+    expect(isServerMessage({ type: 'ready', id: '1', collection: 'files' })).toBe(true);
   });
 
   it('rejects ready messages without id', () => {
-    expect(isServerMessage({ type: 'ready' })).toBe(false);
+    expect(isServerMessage({ type: 'ready', collection: 'files' })).toBe(false);
+  });
+
+  it('rejects ready messages without a collection', () => {
+    expect(isServerMessage({ type: 'ready', id: '1' })).toBe(false);
   });
 
   it('accepts added messages with required fields', () => {

--- a/tests/client/connectionManager.collectionGate.test.ts
+++ b/tests/client/connectionManager.collectionGate.test.ts
@@ -10,7 +10,7 @@ import { SubscribeMsg } from '../../shared/protocol.ts';
 // collection is dropped on the floor with no error. Both tests are RED on the
 // branch and turn GREEN once the client stops guessing the collection.
 describe('ConnectionManager collection gate', () => {
-  it.fails('routes data when the publication name is not the collection name', async () => {
+  it('routes data when the publication name is not the collection name', async () => {
     const socket = ClientSocketWrapper.createNull();
     const server = socket.simulateServer();
     const manager = new ConnectionManager(socket);
@@ -38,7 +38,7 @@ describe('ConnectionManager collection gate', () => {
     expect(store.getById('1')).toEqual({ _id: '1', name: 'existing.bam' });
   });
 
-  it.fails('routes data when the name prefix differs from the collection', async () => {
+  it('routes data when the name prefix differs from the collection', async () => {
     const socket = ClientSocketWrapper.createNull();
     const server = socket.simulateServer();
     const manager = new ConnectionManager(socket);
@@ -60,5 +60,99 @@ describe('ConnectionManager collection gate', () => {
     await handle.ready;
 
     expect(store.getById('1')).toEqual({ _id: '1', name: 'old.bam' });
+  });
+
+  // The single-sub tests above prove the name guess loses data. This one pins
+  // the contract the gate needs once more than one subscription is in flight at
+  // the same time: with two pending subs over two different collections, the
+  // manager can only learn which sub owns which collection from the server, and
+  // the only signal that ties a run of `added`s back to a sub is that sub's
+  // `ready`. So the server flushes a sub's documents and then its `ready`; every
+  // `added` seen since the previous `ready` belongs to the sub now becoming
+  // ready. Once both collections are learned, stopping one sub must close the
+  // gate for its collection alone and leave the other sub's collection live.
+  // RED on the branch: the name guess (name.split('.')[0]) maps neither sub onto
+  // its real collection, so both collections read as not-live and the first
+  // `added` is dropped before we ever reach the stop.
+  it('stopping one of two live subscriptions gates only that collection, not the other', async () => {
+    const socket = ClientSocketWrapper.createNull();
+    const server = socket.simulateServer();
+    const manager = new ConnectionManager(socket);
+    const messages = socket.trackMessages();
+    const files = manager.store('files');
+    const archive = manager.store('archive');
+
+    // Both subscriptions are outstanding before any server reply, and neither
+    // publication name starts with the collection it actually reads from.
+    const filesHandle = manager.subscribe('recentFiles');
+    const archiveHandle = manager.subscribe('oldArchive');
+    const filesSubId = (messages.data[0] as SubscribeMsg).id;
+    const archiveSubId = (messages.data[1] as SubscribeMsg).id;
+
+    // ready is the delimiter: the 'files' added belongs to the sub readied
+    // right after it, the 'archive' added to the next one.
+    server.send({ type: 'added', collection: 'files', id: 'f1', fields: { name: 'a.bam' } });
+    server.send({ type: 'ready', id: filesSubId });
+    server.send({ type: 'added', collection: 'archive', id: 'a1', fields: { name: 'b.bam' } });
+    server.send({ type: 'ready', id: archiveSubId });
+
+    await filesHandle.ready;
+    await archiveHandle.ready;
+
+    // Both collections were learned from the server and routed to their store.
+    expect(files.getById('f1')).toEqual({ _id: 'f1', name: 'a.bam' });
+    expect(archive.getById('a1')).toEqual({ _id: 'a1', name: 'b.bam' });
+
+    // Stop the files subscription only. archive stays live.
+    filesHandle.stop();
+
+    // Late data for the stopped collection is gated...
+    server.send({ type: 'changed', collection: 'files', id: 'f1', fields: { name: 'late.bam' } });
+    // ...while data for the still-live collection keeps flowing.
+    server.send({
+      type: 'changed',
+      collection: 'archive',
+      id: 'a1',
+      fields: { name: 'fresh.bam' },
+    });
+
+    expect(files.getById('f1')).toEqual({ _id: 'f1', name: 'a.bam' });
+    expect(archive.getById('a1')).toEqual({ _id: 'a1', name: 'fresh.bam' });
+  });
+});
+
+// The tests above let the client learn the collection from inbound data. This
+// pins the protocol decision instead: `ready` carries the collection the
+// subscription owns, and that is the authoritative source. Here the
+// publication's initial result set is empty, so there is no `added` to learn
+// from, and the name ('recentFiles') is not the collection ('files'). The only
+// place the collection can come from is `ready.collection`. That also rules out
+// a purely client-side buffer that learns from the first `added`: no `added`
+// arrives before `ready`, so such a client could never bind the collection.
+// RED until the client reads `ready.collection`.
+describe('ConnectionManager learns its collection from ready', () => {
+  it('routes live data using the collection named in ready, with no initial data', async () => {
+    const socket = ClientSocketWrapper.createNull();
+    const server = socket.simulateServer();
+    const manager = new ConnectionManager(socket);
+    const messages = socket.trackMessages();
+    const store = manager.store('files');
+
+    const handle = manager.subscribe('recentFiles');
+    const subId = (messages.data[0] as SubscribeMsg).id;
+
+    // ready names the collection. The extra `collection` field is the protocol
+    // change this test drives; sent through a variable so it type checks against
+    // today's ReadyMsg, and it collapses to a plain literal once ReadyMsg carries
+    // `collection`.
+    const ready = { type: 'ready' as const, id: subId, collection: 'files' };
+    server.send(ready);
+    await handle.ready;
+
+    // A document enters the result set live, after ready. It can only route if
+    // the sub already learned it owns 'files' from the ready message.
+    server.send({ type: 'added', collection: 'files', id: 'x', fields: { name: 'live.bam' } });
+
+    expect(store.getById('x')).toEqual({ _id: 'x', name: 'live.bam' });
   });
 });

--- a/tests/client/connectionManager.collectionGate.test.ts
+++ b/tests/client/connectionManager.collectionGate.test.ts
@@ -29,7 +29,7 @@ describe('ConnectionManager collection gate', () => {
       id: '1',
       fields: { name: 'existing.bam' },
     });
-    server.send({ type: 'ready', id: subId });
+    server.send({ type: 'ready', id: subId, collection: 'files' });
 
     // ready resolves, so the app believes the subscription is healthy. That is
     // what makes the data loss silent.
@@ -56,24 +56,18 @@ describe('ConnectionManager collection gate', () => {
       id: '1',
       fields: { name: 'old.bam' },
     });
-    server.send({ type: 'ready', id: subId });
+    server.send({ type: 'ready', id: subId, collection: 'archive' });
     await handle.ready;
 
     expect(store.getById('1')).toEqual({ _id: '1', name: 'old.bam' });
   });
 
   // The single-sub tests above prove the name guess loses data. This one pins
-  // the contract the gate needs once more than one subscription is in flight at
-  // the same time: with two pending subs over two different collections, the
-  // manager can only learn which sub owns which collection from the server, and
-  // the only signal that ties a run of `added`s back to a sub is that sub's
-  // `ready`. So the server flushes a sub's documents and then its `ready`; every
-  // `added` seen since the previous `ready` belongs to the sub now becoming
-  // ready. Once both collections are learned, stopping one sub must close the
-  // gate for its collection alone and leave the other sub's collection live.
-  // RED on the branch: the name guess (name.split('.')[0]) maps neither sub onto
-  // its real collection, so both collections read as not-live and the first
-  // `added` is dropped before we ever reach the stop.
+  // the contract once more than one subscription is in flight: two subs over
+  // two different collections, each learning its own collection from its own
+  // `ready`. Stopping one sub must close the gate for its collection alone and
+  // leave the other sub's collection live, so late data for the stopped
+  // collection is dropped while the live one keeps flowing.
   it('stopping one of two live subscriptions gates only that collection, not the other', async () => {
     const socket = ClientSocketWrapper.createNull();
     const server = socket.simulateServer();
@@ -89,12 +83,12 @@ describe('ConnectionManager collection gate', () => {
     const filesSubId = (messages.data[0] as SubscribeMsg).id;
     const archiveSubId = (messages.data[1] as SubscribeMsg).id;
 
-    // ready is the delimiter: the 'files' added belongs to the sub readied
-    // right after it, the 'archive' added to the next one.
+    // Each ready names the collection its sub owns, so the two stay distinct
+    // regardless of how their data interleaves on the wire.
     server.send({ type: 'added', collection: 'files', id: 'f1', fields: { name: 'a.bam' } });
-    server.send({ type: 'ready', id: filesSubId });
+    server.send({ type: 'ready', id: filesSubId, collection: 'files' });
     server.send({ type: 'added', collection: 'archive', id: 'a1', fields: { name: 'b.bam' } });
-    server.send({ type: 'ready', id: archiveSubId });
+    server.send({ type: 'ready', id: archiveSubId, collection: 'archive' });
 
     await filesHandle.ready;
     await archiveHandle.ready;
@@ -129,7 +123,6 @@ describe('ConnectionManager collection gate', () => {
 // place the collection can come from is `ready.collection`. That also rules out
 // a purely client-side buffer that learns from the first `added`: no `added`
 // arrives before `ready`, so such a client could never bind the collection.
-// RED until the client reads `ready.collection`.
 describe('ConnectionManager learns its collection from ready', () => {
   it('routes live data using the collection named in ready, with no initial data', async () => {
     const socket = ClientSocketWrapper.createNull();
@@ -141,12 +134,9 @@ describe('ConnectionManager learns its collection from ready', () => {
     const handle = manager.subscribe('recentFiles');
     const subId = (messages.data[0] as SubscribeMsg).id;
 
-    // ready names the collection. The extra `collection` field is the protocol
-    // change this test drives; sent through a variable so it type checks against
-    // today's ReadyMsg, and it collapses to a plain literal once ReadyMsg carries
-    // `collection`.
-    const ready = { type: 'ready' as const, id: subId, collection: 'files' };
-    server.send(ready);
+    // ready names the collection the sub owns. With no initial `added`, this is
+    // the only place the collection can come from.
+    server.send({ type: 'ready', id: subId, collection: 'files' });
     await handle.ready;
 
     // A document enters the result set live, after ready. It can only route if

--- a/tests/client/connectionManager.collectionGate.test.ts
+++ b/tests/client/connectionManager.collectionGate.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { ClientSocketWrapper } from '../../client/clientSocket.ts';
+import { ConnectionManager } from '../../client/connectionManager.ts';
+import { SubscribeMsg } from '../../shared/protocol.ts';
+
+// These tests pin the contract the gate quietly depends on: the collection a
+// subscription owns is decided by the server, not by the shape of the
+// publication name. The gate currently guesses the collection from the name
+// (name.split('.')[0]), so a publication whose name does not start with its
+// collection is dropped on the floor with no error. Both tests are RED on the
+// branch and turn GREEN once the client stops guessing the collection.
+describe('ConnectionManager collection gate', () => {
+  it.fails('routes data when the publication name is not the collection name', async () => {
+    const socket = ClientSocketWrapper.createNull();
+    const server = socket.simulateServer();
+    const manager = new ConnectionManager(socket);
+    const messages = socket.trackMessages();
+    const store = manager.store('files');
+
+    // A publication named for what it returns, not for its collection. On the
+    // server this maps to { collection: 'files', query: {...} }.
+    const handle = manager.subscribe('recentFiles');
+    const subId = (messages.data[0] as SubscribeMsg).id;
+
+    // The server publishes into the collection it actually owns: 'files'.
+    server.send({
+      type: 'added',
+      collection: 'files',
+      id: '1',
+      fields: { name: 'existing.bam' },
+    });
+    server.send({ type: 'ready', id: subId });
+
+    // ready resolves, so the app believes the subscription is healthy. That is
+    // what makes the data loss silent.
+    await handle.ready;
+
+    expect(store.getById('1')).toEqual({ _id: '1', name: 'existing.bam' });
+  });
+
+  it.fails('routes data when the name prefix differs from the collection', async () => {
+    const socket = ClientSocketWrapper.createNull();
+    const server = socket.simulateServer();
+    const manager = new ConnectionManager(socket);
+    const messages = socket.trackMessages();
+    const store = manager.store('archive');
+
+    // Dotted name, but the first segment ('files') is not the collection the
+    // publication reads from ('archive').
+    const handle = manager.subscribe('files.archived');
+    const subId = (messages.data[0] as SubscribeMsg).id;
+
+    server.send({
+      type: 'added',
+      collection: 'archive',
+      id: '1',
+      fields: { name: 'old.bam' },
+    });
+    server.send({ type: 'ready', id: subId });
+    await handle.ready;
+
+    expect(store.getById('1')).toEqual({ _id: '1', name: 'old.bam' });
+  });
+});

--- a/tests/client/connectionManager.socketClose.test.ts
+++ b/tests/client/connectionManager.socketClose.test.ts
@@ -11,7 +11,7 @@ describe('ConnectionManager - after socket dies', () => {
     const messages = socket.trackMessages();
 
     const handle = manager.subscribe('files.all');
-    server.send({ type: 'ready', id: (messages.data[0] as SubscribeMsg).id });
+    server.send({ type: 'ready', id: (messages.data[0] as SubscribeMsg).id, collection: 'files' });
     await handle.ready;
 
     server.simulateClose();

--- a/tests/client/connectionManager.test.ts
+++ b/tests/client/connectionManager.test.ts
@@ -190,7 +190,7 @@ describe('ConnectionManager', () => {
       id: '1',
     });
 
-    expect(store.getById('1')).toBeUndefined();
+    expect(store.getById('1')).toEqual({ _id: '1', name: 'existing.bam' });
   });
 
   it('does not route a late changed message into the store after stop()', async () => {

--- a/tests/client/connectionManager.test.ts
+++ b/tests/client/connectionManager.test.ts
@@ -193,6 +193,38 @@ describe('ConnectionManager', () => {
     expect(store.getById('1')).toBeUndefined();
   });
 
+  it('does not route a late changed message into the store after stop()', async () => {
+    const socket = ClientSocketWrapper.createNull();
+    const server = socket.simulateServer();
+    const manager = new ConnectionManager(socket);
+    const messages = socket.trackMessages();
+    const store = manager.store('files');
+
+    const handle = manager.subscribe('files.all');
+    const subId = (messages.data[0] as SubscribeMsg).id;
+
+    server.send({
+      type: 'added',
+      collection: 'files',
+      id: '1',
+      fields: { name: 'existing.bam' },
+    });
+    server.send({ type: 'ready', id: subId });
+    await handle.ready;
+
+    handle.stop();
+
+    // A message that arrives after the unsubscribe must not leak into the store.
+    server.send({
+      type: 'changed',
+      collection: 'files',
+      id: '1',
+      fields: { name: 'late.bam' },
+    });
+
+    expect(store.getById('1')).toEqual({ _id: '1', name: 'existing.bam' });
+  });
+
   it('handle.ready settles when stop() is called before the server responds', async () => {
     const socket = ClientSocketWrapper.createNull();
     const manager = new ConnectionManager(socket);

--- a/tests/client/connectionManager.test.ts
+++ b/tests/client/connectionManager.test.ts
@@ -193,7 +193,7 @@ describe('ConnectionManager', () => {
     expect(store.getById('1')).toBeUndefined();
   });
 
-  it.fails('does not route a late changed message into the store after stop()', async () => {
+  it('does not route a late changed message into the store after stop()', async () => {
     const socket = ClientSocketWrapper.createNull();
     const server = socket.simulateServer();
     const manager = new ConnectionManager(socket);

--- a/tests/client/connectionManager.test.ts
+++ b/tests/client/connectionManager.test.ts
@@ -25,7 +25,7 @@ describe('ConnectionManager', () => {
       id: '1',
       fields: { name: 'existing.bam' },
     });
-    server.send({ type: 'ready', id: sent.id });
+    server.send({ type: 'ready', id: sent.id, collection: 'files' });
 
     await handle.ready;
 
@@ -48,7 +48,7 @@ describe('ConnectionManager', () => {
     expect(sent.params).toEqual({ folderId: 'folder-a' });
 
     // Simulate the server responding.
-    server.send({ type: 'ready', id: sent.id });
+    server.send({ type: 'ready', id: sent.id, collection: 'files' });
 
     await handle.ready;
   });
@@ -86,7 +86,7 @@ describe('ConnectionManager', () => {
       id: '1',
       fields: { name: 'existing.bam' },
     });
-    server.send({ type: 'ready', id: subId });
+    server.send({ type: 'ready', id: subId, collection: 'files' });
     await handle.ready;
 
     handle.stop();
@@ -115,7 +115,7 @@ describe('ConnectionManager', () => {
     const store = manager.store('files');
 
     const handle = manager.subscribe('files.all');
-    server.send({ type: 'ready', id: (messages.data[0] as SubscribeMsg).id });
+    server.send({ type: 'ready', id: (messages.data[0] as SubscribeMsg).id, collection: 'files' });
     await handle.ready;
 
     manager.dispose();
@@ -151,7 +151,7 @@ describe('ConnectionManager', () => {
       id: '1',
       fields: { name: 'test.bam' },
     });
-    server.send({ type: 'ready', id: subId });
+    server.send({ type: 'ready', id: subId, collection: 'files' });
 
     await handle.ready;
 
@@ -174,7 +174,7 @@ describe('ConnectionManager', () => {
       id: '1',
       fields: { name: 'existing.bam' },
     });
-    server.send({ type: 'ready', id: subId });
+    server.send({ type: 'ready', id: subId, collection: 'files' });
 
     await handle.ready;
 
@@ -209,7 +209,7 @@ describe('ConnectionManager', () => {
       id: '1',
       fields: { name: 'existing.bam' },
     });
-    server.send({ type: 'ready', id: subId });
+    server.send({ type: 'ready', id: subId, collection: 'files' });
     await handle.ready;
 
     handle.stop();

--- a/tests/client/connectionManager.test.ts
+++ b/tests/client/connectionManager.test.ts
@@ -193,7 +193,7 @@ describe('ConnectionManager', () => {
     expect(store.getById('1')).toBeUndefined();
   });
 
-  it('does not route a late changed message into the store after stop()', async () => {
+  it.fails('does not route a late changed message into the store after stop()', async () => {
     const socket = ClientSocketWrapper.createNull();
     const server = socket.simulateServer();
     const manager = new ConnectionManager(socket);

--- a/tests/logic/publications.collectionNaming.test.ts
+++ b/tests/logic/publications.collectionNaming.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { Publications } from '../../server/logic/publications.ts';
+import { MongoWrapper } from '../../server/infrastructure/mongo.ts';
+import { WebSocketWrapper } from '../../server/infrastructure/websocket.ts';
+
+// Characterisation test (passes today). It documents the premise the client
+// gate leans on but the server never promised: the collection a publication
+// emits is whatever its query function returns, decided independently of the
+// publication name. Here a publication named 'recentFiles' emits into 'files'.
+// The client's name.split('.')[0] would read 'recentFiles' and miss every doc.
+describe('Publications: name and collection are independent', () => {
+  it('emits the collection returned by the query function, not the publication name', async () => {
+    const mongo = MongoWrapper.createNull({
+      find: [[{ _id: '1', name: 'existing.bam' }]],
+    });
+    const ws = WebSocketWrapper.createNull();
+    const client = ws.simulateConnection();
+    const pubs = new Publications(mongo, ws);
+
+    pubs.define('recentFiles', () => ({ collection: 'files', query: {} }));
+
+    await pubs.handleMessage(client.id, {
+      type: 'subscribe',
+      id: 'sub1',
+      name: 'recentFiles',
+    });
+
+    expect(client.messages).toContainEqual({
+      type: 'added',
+      collection: 'files',
+      id: '1',
+      fields: { name: 'existing.bam' },
+    });
+  });
+});

--- a/tests/logic/publications.test.ts
+++ b/tests/logic/publications.test.ts
@@ -188,6 +188,7 @@ describe('Publications', () => {
     expect(client.messages).toContainEqual({
       type: 'ready',
       id: 'sub1',
+      collection: 'files',
     });
   });
 
@@ -218,6 +219,7 @@ describe('Publications', () => {
       {
         type: 'ready',
         id: 'sub1',
+        collection: 'files',
       },
     ]);
   });
@@ -239,7 +241,7 @@ describe('Publications', () => {
     });
 
     expect(client.messages).toHaveLength(1);
-    expect(client.messages[0]).toEqual({ type: 'ready', id: 'sub1' });
+    expect(client.messages[0]).toEqual({ type: 'ready', id: 'sub1', collection: 'files' });
   });
 
   it('pushes live changes to subscribed clients', async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,14 @@
     "noFallthroughCasesInSwitch": true,
     "exactOptionalPropertyTypes": true
   },
-  "include": ["server", "client", "shared", "tests", "*.config.ts", "*.config.mts"],
+  "include": [
+    "server",
+    "client",
+    "shared",
+    "tests",
+    "*.config.ts",
+    "*.config.mts",
+    "learning/**/*.ts"
+  ],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Closes the gap left by 3.C.1's Definition of Done point 6: after `handle.stop()`, late `added` / `changed` / `removed` messages for a stopped subscription should not leak into the store.

- **problem:** `ConnectionManager.handleServerMessage` routes data into `store(collection)` with no liveness check. The only guard is the manager-wide `disposed` flag, so after a single `stop()` a late message for that collection still mutates the store.
- **test (red):** a late `changed` after `stop()` must not mutate the store (`tests/client/connectionManager.test.ts`). Currently `it.fails`, pinning the contract until the gate lands.
- **fix (green):** a per-collection liveness gate. `subscribe` marks the collection live, `stopSubscription` clears it once no live subscription remains, and `handleServerMessage` ignores data for a collection with no live subscription. The gate keys on collection, not subscription id, because `DataMsg` carries no id.

**A decision this forces.** 3.C.1 never had to say what happens to a message that arrives *after* `stop()`. Now we do, and two tests currently expect the opposite:

- the new test sends a late `changed` and expects the store **left alone** (the late message is ignored),
- the existing lifecycle test (`connectionManager.test.ts:161`) sends a late `removed` and expects the doc **deleted** (the late message is applied).

A single gate cannot do both: if it ignores the late `changed`, it ignores the late `removed` too.

This PR chooses **ignore every message after `stop()`**. Once a subscription is stopped, nothing more touches the store, and whatever was already cached stays put. It is the simpler rule and matches EkoLite having dropped the server-side merge box. The consequence: the lifecycle test changes so that after `stop()` the late `removed` no longer clears the doc, and the doc remains.

**Out of scope:** client-side eviction of a stopped subscription's docs, the server-side merge box / refcounted ownership (dropped by design, tracked as the `publications.refcount` gap), and reconnect.

EKO-279 · https://linear.app/ekohacks/issue/EKO-279/3c4-gate-late-messages-after-stop
