### PR TITLE
Eko 273/3c5 forward live updates and deletes to subscribers

### DIFF
--- a/server/logic/publications.ts
+++ b/server/logic/publications.ts
@@ -1,5 +1,5 @@
 import { ClientMessage, PublicationsObserver, PublicationsReasons } from '../../shared/protocol.ts';
-import { hasMongoOperator } from '../../shared/helperFunctions.ts';
+import { assertNever, hasMongoOperator } from '../../shared/helperFunctions.ts';
 import { MongoWrapper } from '../infrastructure/mongo.ts';
 import { WebSocketWrapper } from '../infrastructure/websocket.ts';
 import { ChangeEvent } from '../../shared/types.ts';
@@ -182,14 +182,27 @@ export class Publications {
       this.ws.send(clientId, readyMessage(message.id, collection));
 
       const cleanup = this.mongo.watchChanges(collection, (change: ChangeEvent) => {
-        if (change.type === 'insert') {
-          documentIds.add(change.id);
-          this.ws.send(clientId, addedMessage(collection, { _id: change.id, ...change.fields }));
-        } else if (change.type === 'update') {
-          this.ws.send(clientId, changedMessage(collection, { _id: change.id, ...change.fields }));
-        } else if (change.type === 'remove') {
-          documentIds.delete(change.id);
-          this.ws.send(clientId, removedMessage(collection, change.id));
+        switch (change.type) {
+          case 'insert': {
+            documentIds.add(change.id);
+            this.ws.send(clientId, addedMessage(collection, { _id: change.id, ...change.fields }));
+            break;
+          }
+          case 'update': {
+            this.ws.send(
+              clientId,
+              changedMessage(collection, { _id: change.id, ...change.fields }),
+            );
+            break;
+          }
+          case 'remove': {
+            documentIds.delete(change.id);
+            this.ws.send(clientId, removedMessage(collection, change.id));
+            break;
+          }
+          default: {
+            assertNever(change);
+          }
         }
       });
 

--- a/server/logic/publications.ts
+++ b/server/logic/publications.ts
@@ -25,6 +25,13 @@ const addedMessage = (collection: string, doc: Record<string, unknown>) => ({
   fields: Object.fromEntries(Object.entries(doc).filter(([key]) => key !== '_id')),
 });
 
+const changedMessage = (collection: string, doc: Record<string, unknown>) => ({
+  type: 'changed',
+  collection,
+  id: doc._id,
+  fields: Object.fromEntries(Object.entries(doc).filter(([key]) => key !== '_id')),
+});
+
 const readyMessage = (subId: string, collection: string) => ({
   type: 'ready',
   id: subId,
@@ -178,6 +185,11 @@ export class Publications {
         if (change.type === 'insert') {
           documentIds.add(change.id);
           this.ws.send(clientId, addedMessage(collection, { _id: change.id, ...change.fields }));
+        } else if (change.type === 'update') {
+          this.ws.send(clientId, changedMessage(collection, { _id: change.id, ...change.fields }));
+        } else if (change.type === 'remove') {
+          documentIds.delete(change.id);
+          this.ws.send(clientId, removedMessage(collection, change.id));
         }
       });
 

--- a/tests/logic/publications.liveChanges.test.ts
+++ b/tests/logic/publications.liveChanges.test.ts
@@ -33,9 +33,9 @@ describe('Publications live updates and deletes', () => {
     await mongo.update('files', { name: 'old' }, { $set: { name: 'new' } });
 
     const [changed] = messagesOfType(client.messages, 'changed');
-    expect(changed?.collection).toBe('files');
-    expect(changed?.id).toBeTruthy();
-    expect(changed?.fields).toEqual({ name: 'new' });
+    expect(changed.collection).toBe('files');
+    expect(changed.id).toBeTruthy();
+    expect(changed.fields).toEqual({ name: 'new' });
   });
 
   it('forwards a watched delete to the client as a removed message', async () => {
@@ -44,8 +44,8 @@ describe('Publications live updates and deletes', () => {
     await mongo.remove('files', { name: 'gone' });
 
     const [removed] = messagesOfType(client.messages, 'removed');
-    expect(removed?.collection).toBe('files');
-    expect(removed?.id).toBeTruthy();
+    expect(removed.collection).toBe('files');
+    expect(removed.id).toBeTruthy();
   });
 
   it('delivers a watched update as exactly one changed message, never as an added', async () => {

--- a/tests/logic/publications.liveChanges.test.ts
+++ b/tests/logic/publications.liveChanges.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { MongoWrapper } from '../../server/infrastructure/mongo.ts';
+import { WebSocketWrapper } from '../../server/infrastructure/websocket.ts';
+import { Publications } from '../../server/logic/publications.ts';
+
+// RED: the live watcher in publications.ts only forwards 'insert' changes today
+// (see the change.type === 'insert' branch). 'update' and 'remove' changes are
+// dropped, so a subscribed client never hears about edits or deletions. These
+// pin the wire messages the watcher should send for each change type.
+
+const messagesOfType = (messages: unknown[], type: string) =>
+  messages.filter(
+    (m): m is { type: string; collection: string; id: string; fields?: Record<string, unknown> } =>
+      typeof m === 'object' && m !== null && (m as { type?: unknown }).type === type,
+  );
+
+const subscribeToFiles = async () => {
+  const mongo = MongoWrapper.createNull({ find: [[]] });
+  const ws = WebSocketWrapper.createNull();
+  const client = ws.simulateConnection();
+  const pubs = new Publications(mongo, ws);
+
+  pubs.define('files.all', () => ({ collection: 'files', query: {} }));
+  await pubs.handleMessage(client.id, { type: 'subscribe', id: 'sub1', name: 'files.all' });
+
+  return { mongo, client };
+};
+
+describe('Publications live updates and deletes', () => {
+  it('forwards a watched update to the client as a changed message', async () => {
+    const { mongo, client } = await subscribeToFiles();
+
+    await mongo.update('files', { name: 'old' }, { $set: { name: 'new' } });
+
+    const [changed] = messagesOfType(client.messages, 'changed');
+    expect(changed?.collection).toBe('files');
+    expect(changed?.id).toBeTruthy();
+    expect(changed?.fields).toEqual({ name: 'new' });
+  });
+
+  it('forwards a watched delete to the client as a removed message', async () => {
+    const { mongo, client } = await subscribeToFiles();
+
+    await mongo.remove('files', { name: 'gone' });
+
+    const [removed] = messagesOfType(client.messages, 'removed');
+    expect(removed?.collection).toBe('files');
+    expect(removed?.id).toBeTruthy();
+  });
+
+  it('delivers a watched update as exactly one changed message, never as an added', async () => {
+    const { mongo, client } = await subscribeToFiles();
+    const before = client.messages.length;
+
+    await mongo.update('files', {}, { $set: { name: 'renamed' } });
+
+    const delivered = client.messages.slice(before);
+    expect(delivered).toHaveLength(1);
+    expect((delivered[0] as { type?: string }).type).toBe('changed');
+  });
+});


### PR DESCRIPTION
Wires live `update` and `remove` changes through to subscribers, closing the reactive half of subscribe: a client now hears about edits and deletes, not just inserts.

### Why

The live watch in `server/logic/publications.ts` only forwarded `insert`. The `update` and `remove` `ChangeEvent`s already reached the callback (the nullable Mongo from #55 emits them) but were dropped, so a subscriber's cached doc went stale on the first edit or delete. The wire protocol and the client `ReactiveStore` already apply `changed` (merge fields) and `removed` (delete), so both ends were ready and only the server was silent. Meteor's equivalent is a publication pushing `added` / `changed` / `removed`; we had `added`, this adds the other two.

### What changed

- An `update` sends a `changed` with the updated fields; a `remove` sends a `removed` with the id.
- The branch chain is now a `switch (change.type)` closed by `default: assertNever(change)`, matching the exhaustiveness pattern already in `client/reactiveStore.ts` and `client/connectionManager.ts`. A future fourth `ChangeEvent` variant fails to compile here until it is handled.

### Tests

`tests/logic/publications.liveChanges.test.ts`, written red first, now green:

- a watched update reaches the client as a `changed` carrying the new fields
- a watched delete reaches the client as a `removed`
- a watched update is delivered as exactly one `changed`, never re-added

Full suite, typecheck and lint clean.

### Deferred to 3.C.6

The `remove` case already prunes the id from `documentIds`, but the rest of the bookkeeping (only forwarding a `remove` for a doc the client actually holds, and the matching unsubscribe behaviour so a `removed` is never double sent) is held back. It cannot be tested until the null Mongo emits `update` / `remove` events whose ids match previously inserted docs, which is its own change. Tracked as 3.C.6.

https://linear.app/ekohacks/issue/EKO-280/3c5-forward-live-updates-and-deletes-to-subscribers
