### PR TITLE
feat: wire live pub/sub over a real websocket

### DIFF
--- a/client/demo/README.md
+++ b/client/demo/README.md
@@ -1,0 +1,93 @@
+# EkoLite client demo
+
+A runnable demo of the client stack with no backend. It drives the real
+`ConnectionManager`, `SubscriptionHandle` and `ReactiveStore` through a stubbed
+server, so you can watch subscriptions and the reactive store update live without
+Mongo or a running server.
+
+## Run it
+
+```bash
+npm run dev:client
+```
+
+Vite prints a local URL such as `http://localhost:5173/`. Open the demo at the
+`/demo/` path (the trailing slash matters):
+
+```
+http://localhost:5173/demo/
+```
+
+If port 5173 is busy Vite picks the next one (5174 and so on), so use whatever it
+prints. The root URL `/` is the placeholder page and has no buttons; the demo is
+under `/demo/`.
+
+## What you see
+
+- A status line: connecting, then connected and subscription ready.
+- A files list, seeded with two documents once the subscription is ready.
+- Four buttons that play the part of server messages:
+  - **Add file** sends an `added` message, a new row appears.
+  - **Rename first** sends a `changed` message, the first row updates in place.
+  - **Remove first** sends a `removed` message, the first row disappears.
+  - **Disconnect** closes the socket, which disposes the `ConnectionManager` and
+    disables the buttons.
+- A log of the messages the stubbed server sent.
+
+## The point
+
+The demo wires a null socket:
+
+```ts
+const socket = ClientSocketWrapper.createNull();
+```
+
+Swap that one line for a real connection and the same `ConnectionManager` and
+`ReactiveStore` code talks to a live server:
+
+```ts
+const socket = ClientSocketWrapper.create('wss://your-host/ws');
+```
+
+That is the Nullables payoff: the code in the demo and the code in production are
+the same; only the socket changes.
+
+## Run it live (against a real server)
+
+`live.ts` is the same client code with that one line swapped for a real socket,
+pointed at a running server. You need MongoDB on `localhost:27017` and a server.
+
+```bash
+# 1. start the server (Mongo + websocket + publications)
+npm run dev:server
+
+# 2. in another terminal, start vite and open the live page
+npm run dev:client
+#    http://localhost:5173/demo/live.html
+```
+
+The server seeds two files on first boot, so a fresh Mongo is not a blank page.
+The list then streams straight from Mongo. To watch it update live, change the
+collection in another window and the page reacts:
+
+```js
+// mongosh
+use ekolite
+db.files.insertOne({ name: 'hello.txt' })
+db.files.updateOne({ name: 'hello.txt' }, { $set: { name: 'renamed.txt' } })
+db.files.deleteOne({ name: 'renamed.txt' })
+```
+
+Live streaming uses Mongo change streams, which need a replica set. A standalone
+Mongo still serves the initial documents (so the page is not empty); it just will
+not push later changes. For live updates run Mongo as a single-node replica set.
+
+There are no buttons on the live page: writing from the browser needs the
+methods/RPC path, which is the next epic. For now the browser reads, and writes
+happen in Mongo.
+
+## Note
+
+The full browser to Mongo round trip is wired now (see `server/start.ts` and the
+end-to-end test at `tests/server/livePubsub.integration.test.ts`). See the client
+API reference in [`docs/api/`](../../docs/api/connection-manager.md).

--- a/client/demo/live.html
+++ b/client/demo/live.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>EkoLite live demo</title>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        max-width: 40rem;
+        margin: 2rem auto;
+        padding: 0 1rem;
+        color: #1a1a1a;
+      }
+      h1 {
+        margin-bottom: 0.25rem;
+      }
+      .lede {
+        color: #555;
+        margin-top: 0;
+      }
+      #status {
+        font-weight: 600;
+        padding: 0.4rem 0.6rem;
+        background: #eef;
+        border-radius: 0.4rem;
+        display: inline-block;
+      }
+      ul {
+        padding-left: 1.2rem;
+      }
+      li {
+        padding: 0.15rem 0;
+      }
+      #log {
+        font-family: ui-monospace, monospace;
+        font-size: 0.85rem;
+        color: #444;
+        background: #f6f6f6;
+        border-radius: 0.4rem;
+        padding: 0.6rem;
+        max-height: 12rem;
+        overflow: auto;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>EkoLite live demo</h1>
+      <p class="lede">
+        The real ConnectionManager and ReactiveStore, talking to a live server at
+        ws://localhost:3001/ws. The files list streams from Mongo. Start the server with
+        npm run dev:server first.
+      </p>
+      <p id="status">connecting…</p>
+
+      <h2>files</h2>
+      <ul id="list"></ul>
+
+      <h2>messages</h2>
+      <div id="log"></div>
+    </main>
+    <script type="module" src="./live.ts"></script>
+  </body>
+</html>

--- a/client/demo/live.ts
+++ b/client/demo/live.ts
@@ -1,0 +1,79 @@
+// EkoLite live demo — the same client stack as demo.ts, but talking to a real
+// server over a real socket instead of a stubbed one.
+//
+// The only line that differs from the stubbed demo is the socket: createNull()
+// becomes create('ws://localhost:3001/ws'). Everything else (ConnectionManager,
+// SubscriptionHandle, ReactiveStore) is identical. That is the Nullables payoff.
+//
+// This shows the read side: subscribe, see the initial documents, and watch the
+// list update live as the files collection changes in Mongo. Writing from the
+// browser needs the methods/RPC path, which is not wired yet, so there are no
+// mutation buttons here. Change data with mongosh and watch it stream in.
+
+import { ClientSocketWrapper } from '../clientSocket.ts';
+import { ConnectionManager } from '../connectionManager.ts';
+
+function el(id: string): HTMLElement {
+  const node = document.getElementById(id);
+  if (!node) {
+    throw new Error(`Missing #${id}`);
+  }
+  return node;
+}
+
+const statusEl = el('status');
+const listEl = el('list');
+const logEl = el('log');
+
+function log(line: string): void {
+  const entry = document.createElement('div');
+  entry.textContent = line;
+  logEl.prepend(entry);
+}
+
+// 1. Wire the client to the real server. Swap this URL for your host in production.
+const socket = ClientSocketWrapper.create('ws://localhost:3001/ws');
+
+try {
+  await socket.connect();
+} catch {
+  statusEl.textContent = 'could not connect — is the server running? (npm run dev:server)';
+  throw new Error('connection failed');
+}
+
+statusEl.textContent = 'connected · subscribing…';
+const manager = new ConnectionManager(socket);
+
+// 2. Subscribe to a publication the server defines (see server/start.ts).
+const handle = manager.subscribe('files.all');
+log('out: subscribe files.all');
+
+await handle.ready;
+statusEl.textContent = 'connected · subscription ready';
+log('in: ready');
+
+// 3. Read the store and re-render on every change. Real documents, live from Mongo.
+const files = manager.store('files');
+
+function render(): void {
+  const docs = files.getAll();
+  listEl.replaceChildren(
+    ...docs.map((doc) => {
+      const item = document.createElement('li');
+      const name = typeof doc.name === 'string' ? doc.name : '';
+      item.textContent = `${doc._id} · ${name}`;
+      return item;
+    }),
+  );
+}
+
+render();
+files.onChange(() => {
+  log('in: store changed');
+  render();
+});
+
+socket.onClose(() => {
+  statusEl.textContent = 'disconnected · ConnectionManager disposed';
+  log('socket closed → dispose()');
+});

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,9 +3,12 @@ import Fastify from 'fastify';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { WebSocketWrapper } from './infrastructure/websocket.ts';
+import { type Publications } from './logic/publications.ts';
+import { type ClientMessage } from '../shared/protocol.ts';
 
 export interface ServerOptions {
   ws: WebSocketWrapper;
+  publications?: Publications;
 }
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -17,5 +20,13 @@ export async function createServer(options: ServerOptions) {
     root: resolve(__dirname, '..', 'dist', 'client'),
   });
   await options.ws.attach(server);
+
+  const publications = options.publications;
+  if (publications) {
+    options.ws.onMessage((clientId, message) => {
+      void publications.handleMessage(clientId, message as ClientMessage);
+    });
+  }
+
   return server;
 }

--- a/server/infrastructure/websocket.ts
+++ b/server/infrastructure/websocket.ts
@@ -126,6 +126,18 @@ export class WebSocketWrapper implements WebSocketInterface {
     };
   }
 
+  onMessage(cb: (clientId: string, message: unknown) => void): () => void {
+    const listener = (data: unknown): void => {
+      if (isClientMessagePayload(data)) {
+        cb(data.clientId, data.message);
+      }
+    };
+    this.emitter.on(MESSAGE_EVENT, listener);
+    return () => {
+      this.emitter.off(MESSAGE_EVENT, listener);
+    };
+  }
+
   trackConnections(): OutputTracker {
     return new OutputTracker(this.emitter, CONNECTION_EVENT);
   }
@@ -169,6 +181,14 @@ function isClientIdPayload(data: unknown): data is { clientId: string } {
   return typeof (data as Record<string, unknown>).clientId === 'string';
 }
 
+function isClientMessagePayload(data: unknown): data is { clientId: string; message: unknown } {
+  if (data === null || typeof data !== 'object') {
+    return false;
+  }
+
+  return typeof (data as Record<string, unknown>).clientId === 'string' && 'message' in data;
+}
+
 class WsConnectionSource implements ConnectionSource {
   private wss: WebSocketServer | null = null;
   private listeners: ((socket: ServerSocketLike) => string)[] = [];
@@ -196,6 +216,11 @@ class WsConnectionSource implements ConnectionSource {
             socket.close();
           },
           onClose: (cb: () => void) => socket.on('close', cb),
+          onMessage(cb: (message: unknown) => void) {
+            socket.on('message', (data: Buffer) => {
+              cb(JSON.parse(data.toString()));
+            });
+          },
         };
         for (const l of this.listeners) {
           l(wrapped);
@@ -237,6 +262,11 @@ class FastifyConnectionSource implements ConnectionSource {
           connection.close();
         },
         onClose: (cb: () => void) => connection.on('close', cb),
+        onMessage(cb: (message: unknown) => void) {
+          connection.on('message', (data: Buffer) => {
+            cb(JSON.parse(data.toString()));
+          });
+        },
       };
       for (const l of this.listeners) {
         l(wrapped);

--- a/server/start.ts
+++ b/server/start.ts
@@ -1,7 +1,37 @@
 import { createServer } from './index.ts';
+import { MongoWrapper } from './infrastructure/mongo.ts';
 import { WebSocketWrapper } from './infrastructure/websocket.ts';
+import { Publications } from './logic/publications.ts';
 
+// Real boot. The same pieces the end-to-end test wires by hand, wired here for a
+// live process: a Mongo connection, a websocket server, and the pub/sub engine
+// that turns subscriptions into live document streams.
+const mongoUri = process.env.MONGO_URI ?? 'mongodb://localhost:27017/ekolite';
+const port = Number(process.env.PORT ?? 3001);
+
+const mongo = MongoWrapper.create(mongoUri);
 const ws = WebSocketWrapper.create();
+const publications = new Publications(mongo, ws);
 
-const server = await createServer({ ws });
-await server.listen({ port: 3001 });
+// One publication to start with: every document in the files collection, kept in
+// sync with the client as Mongo changes.
+publications.define('files.all', () => ({ collection: 'files', query: {} }));
+
+// Dev convenience: seed a couple of files so a fresh Mongo is not a blank page.
+// Idempotent (only seeds an empty collection) and best-effort (a missing Mongo
+// should not stop the server booting; subscriptions just come back empty).
+try {
+  const existing = await mongo.find('files', {});
+  if (existing.length === 0) {
+    await mongo.insert('files', { _id: 'seed-1', name: 'welcome.txt' });
+    await mongo.insert('files', { _id: 'seed-2', name: 'getting-started.md' });
+    console.warn('seeded files with 2 documents');
+  }
+} catch (err) {
+  console.warn('skipped seeding (is Mongo running?):', err instanceof Error ? err.message : err);
+}
+
+const server = await createServer({ ws, publications });
+await server.listen({ port, host: '0.0.0.0' });
+
+console.warn(`EkoLite listening on http://localhost:${String(port)} (ws at /ws)`);

--- a/tests/infrastructure/websocket-inbound.integration.test.ts
+++ b/tests/infrastructure/websocket-inbound.integration.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import Fastify from 'fastify';
+import WebSocket from 'ws';
+import { WebSocketWrapper } from '../../server/infrastructure/websocket.ts';
+
+// Tighter red for wire 1 only: the real Fastify socket must forward inbound client
+// frames into the wrapper so the rest of the stack can act on them. Today
+// FastifyConnectionSource wraps the socket with send/close/onClose and no onMessage,
+// so anything a real client sends is dropped on the floor.
+//
+// This gap is invisible to the nullable tests: NullServerSocket already implements
+// onMessage, so simulateConnection().send() forwards fine. Only a real socket
+// exercises the missing wire, which is why this one has to be an integration test.
+
+describe('WebSocketWrapper forwards inbound frames from a real socket', () => {
+  let ws: WebSocketWrapper;
+  let client: WebSocket;
+
+  afterEach(async () => {
+    client.close();
+    await ws.close();
+  });
+
+  it('records a message the client sends over the wire', async () => {
+    const fastify = Fastify();
+    ws = WebSocketWrapper.create();
+    await ws.attach(fastify);
+    await fastify.listen({ port: 0 });
+    const port = String(fastify.addresses()[0].port);
+
+    const inbound = ws.trackMessages();
+
+    client = new WebSocket(`ws://localhost:${port}/ws`);
+    await new Promise((resolve, reject) => {
+      client.on('open', resolve);
+      client.on('error', reject);
+    });
+
+    client.send(JSON.stringify({ type: 'subscribe', id: 's1', name: 'files.all' }));
+
+    await vi.waitFor(() => {
+      expect(inbound.data.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/tests/server/createServerRouting.test.ts
+++ b/tests/server/createServerRouting.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createServer } from '../../server/index.ts';
+import { WebSocketWrapper } from '../../server/infrastructure/websocket.ts';
+import { MongoWrapper } from '../../server/infrastructure/mongo.ts';
+import { Publications } from '../../server/logic/publications.ts';
+
+// Tighter red for wires 2 and 3 only, with no real socket in sight. Everything is
+// nulled: a null ws lets us simulate a connection and an inbound subscribe, a null
+// mongo hands back a fixed document. The seam under test is purely 'does createServer
+// route an inbound message into the pub/sub engine and send the reply back out'.
+//
+// Red today because:
+//   - ServerOptions is { ws }, so { ws, publications } is rejected (wire 2), and
+//   - nothing in createServer pumps ws inbound messages into publications.handleMessage,
+//     so the stubbed client hears nothing back (wire 3).
+//
+// It says nothing about the real Fastify socket: the null path already forwards
+// inbound frames, so this test passes straight through that seam. The real-socket
+// gap is rung 2's job. Keeping them apart is the whole point of tighter reds.
+
+describe('createServer routes inbound subscriptions into publications', () => {
+  it('a simulated subscribe yields added + ready back to the client', async () => {
+    const mongo = MongoWrapper.createNull({
+      find: [[{ _id: '1', name: 'existing.bam' }]],
+    });
+    const ws = WebSocketWrapper.createNull();
+    const publications = new Publications(mongo, ws);
+    publications.define('files.all', () => ({ collection: 'files', query: {} }));
+
+    await createServer({ ws, publications });
+
+    const client = ws.simulateConnection();
+    client.send({ type: 'subscribe', id: 'sub1', name: 'files.all' });
+
+    await vi.waitFor(() => {
+      expect(client.messages).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ type: 'added', id: '1', fields: { name: 'existing.bam' } }),
+          expect.objectContaining({ type: 'ready', id: 'sub1', collection: 'files' }),
+        ]),
+      );
+    });
+  });
+});

--- a/tests/server/livePubsub.integration.test.ts
+++ b/tests/server/livePubsub.integration.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createServer } from '../../server/index.ts';
+import { WebSocketWrapper } from '../../server/infrastructure/websocket.ts';
+import { MongoWrapper } from '../../server/infrastructure/mongo.ts';
+import { Publications } from '../../server/logic/publications.ts';
+import { ClientSocketWrapper } from '../../client/clientSocket.ts';
+import { ConnectionManager } from '../../client/connectionManager.ts';
+
+const withReadyTimeout = <T>(promise: Promise<T>): Promise<T> => {
+  return Promise.race([
+    promise,
+    new Promise<T>((_resolve, reject) =>
+      setTimeout(() => {
+        reject(
+          new Error('subscription never became ready: the live socket is not wired end to end'),
+        );
+      }, 1000),
+    ),
+  ]);
+};
+
+describe('live pub/sub over a real socket', () => {
+  let server: Awaited<ReturnType<typeof createServer>>;
+  let socket: ClientSocketWrapper;
+
+  afterEach(async () => {
+    await socket.close();
+    await server.close();
+  });
+
+  it('a real client subscription fills its store from the server', async () => {
+    const mongo = MongoWrapper.createNull({
+      find: [[{ _id: '1', name: 'existing.bam' }]],
+    });
+    const ws = WebSocketWrapper.create();
+    const publications = new Publications(mongo, ws);
+    publications.define('files.all', () => ({ collection: 'files', query: {} }));
+
+    // Target API: the boot path hands its publications to the server so inbound
+    // subscribes get routed to the engine. ServerOptions has to grow to accept this.
+    server = await createServer({ ws, publications });
+    await server.listen({ port: 0 });
+    const port = String(server.addresses()[0].port);
+
+    socket = ClientSocketWrapper.create(`ws://localhost:${port}/ws`);
+    await socket.connect();
+    const manager = new ConnectionManager(socket);
+
+    const handle = manager.subscribe('files.all');
+    await withReadyTimeout(handle.ready);
+
+    expect(manager.store('files').getById('1')).toEqual({ _id: '1', name: 'existing.bam' });
+  });
+});


### PR DESCRIPTION
## What

A real browser client can now subscribe over a real socket and have its store
stream from the server. Until now pub/sub only worked through the in-memory Null
transport in tests.

## The three wires

1. **Inbound forwarding** — the real Fastify socket (`FastifyConnectionSource`)
   only had `send`/`close`/`onClose`. Added `onMessage`, so a client's `subscribe`
   actually reaches the server. Frames are parsed to objects so the real and Null
   paths hand routing the same shape.
2. **A way to consume them** — `WebSocketWrapper.onMessage(cb)` exposes inbound
   messages with their `clientId`, mirroring the existing `onDisconnect`.
3. **Routing** — `createServer` now takes an optional `publications` and pipes
   every inbound message into `publications.handleMessage`. Optional keeps the
   existing `createServer({ ws })` callers untouched.

`server/start.ts` now builds Mongo + websocket + publications for a real boot, and
seeds two `files` on first boot so a fresh database is not a blank page.

## Driven by tests, innermost first

- `tests/server/createServerRouting.test.ts` — nullable, fast: a simulated
  subscribe yields `added` + `ready`. Drives wires 2 and 3.
- `tests/infrastructure/websocket-inbound.integration.test.ts` — real socket:
  a client frame reaches the server. Drives wire 1.
- `tests/server/livePubsub.integration.test.ts` — full end to end over a real
  socket: a real client subscription fills its store. Goes green once all wires land.

## Run it live

```bash
npm run dev:server          # Mongo + ws + publications on :3001
npm run dev:client          # then open http://localhost:5173/demo/live.html
```

The files list streams from Mongo (seeded on first boot). Mutate the collection in
mongosh and the page reacts. Live streaming needs a replica-set Mongo; a standalone
serves the initial documents only. See `client/demo/README.md`.

## Out of scope

Writing from the browser needs the methods/RPC path, which is the next piece, so
the live demo is read-only for now.
