### PR TITLE
feat: wire live pub/sub over a real websocket

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -3,9 +3,12 @@ import Fastify from 'fastify';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { WebSocketWrapper } from './infrastructure/websocket.ts';
+import { type Publications } from './logic/publications.ts';
+import { type ClientMessage } from '../shared/protocol.ts';
 
 export interface ServerOptions {
   ws: WebSocketWrapper;
+  publications?: Publications;
 }
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -17,5 +20,13 @@ export async function createServer(options: ServerOptions) {
     root: resolve(__dirname, '..', 'dist', 'client'),
   });
   await options.ws.attach(server);
+
+  const publications = options.publications;
+  if (publications) {
+    options.ws.onMessage((clientId, message) => {
+      void publications.handleMessage(clientId, message as ClientMessage);
+    });
+  }
+
   return server;
 }

--- a/server/infrastructure/websocket.ts
+++ b/server/infrastructure/websocket.ts
@@ -126,6 +126,18 @@ export class WebSocketWrapper implements WebSocketInterface {
     };
   }
 
+  onMessage(cb: (clientId: string, message: unknown) => void): () => void {
+    const listener = (data: unknown): void => {
+      if (isClientMessagePayload(data)) {
+        cb(data.clientId, data.message);
+      }
+    };
+    this.emitter.on(MESSAGE_EVENT, listener);
+    return () => {
+      this.emitter.off(MESSAGE_EVENT, listener);
+    };
+  }
+
   trackConnections(): OutputTracker {
     return new OutputTracker(this.emitter, CONNECTION_EVENT);
   }
@@ -169,6 +181,14 @@ function isClientIdPayload(data: unknown): data is { clientId: string } {
   return typeof (data as Record<string, unknown>).clientId === 'string';
 }
 
+function isClientMessagePayload(data: unknown): data is { clientId: string; message: unknown } {
+  if (data === null || typeof data !== 'object') {
+    return false;
+  }
+
+  return typeof (data as Record<string, unknown>).clientId === 'string' && 'message' in data;
+}
+
 class WsConnectionSource implements ConnectionSource {
   private wss: WebSocketServer | null = null;
   private listeners: ((socket: ServerSocketLike) => string)[] = [];
@@ -196,6 +216,11 @@ class WsConnectionSource implements ConnectionSource {
             socket.close();
           },
           onClose: (cb: () => void) => socket.on('close', cb),
+          onMessage(cb: (message: unknown) => void) {
+            socket.on('message', (data: Buffer) => {
+              cb(JSON.parse(data.toString()));
+            });
+          },
         };
         for (const l of this.listeners) {
           l(wrapped);
@@ -237,6 +262,11 @@ class FastifyConnectionSource implements ConnectionSource {
           connection.close();
         },
         onClose: (cb: () => void) => connection.on('close', cb),
+        onMessage(cb: (message: unknown) => void) {
+          connection.on('message', (data: Buffer) => {
+            cb(JSON.parse(data.toString()));
+          });
+        },
       };
       for (const l of this.listeners) {
         l(wrapped);

--- a/server/start.ts
+++ b/server/start.ts
@@ -1,7 +1,37 @@
 import { createServer } from './index.ts';
+import { MongoWrapper } from './infrastructure/mongo.ts';
 import { WebSocketWrapper } from './infrastructure/websocket.ts';
+import { Publications } from './logic/publications.ts';
 
+// Real boot. The same pieces the end-to-end test wires by hand, wired here for a
+// live process: a Mongo connection, a websocket server, and the pub/sub engine
+// that turns subscriptions into live document streams.
+const mongoUri = process.env.MONGO_URI ?? 'mongodb://localhost:27017/ekolite';
+const port = Number(process.env.PORT ?? 3001);
+
+const mongo = MongoWrapper.create(mongoUri);
 const ws = WebSocketWrapper.create();
+const publications = new Publications(mongo, ws);
 
-const server = await createServer({ ws });
-await server.listen({ port: 3001 });
+// One publication to start with: every document in the files collection, kept in
+// sync with the client as Mongo changes.
+publications.define('files.all', () => ({ collection: 'files', query: {} }));
+
+// Dev convenience: seed a couple of files so a fresh Mongo is not a blank page.
+// Idempotent (only seeds an empty collection) and best-effort (a missing Mongo
+// should not stop the server booting; subscriptions just come back empty).
+try {
+  const existing = await mongo.find('files', {});
+  if (existing.length === 0) {
+    await mongo.insert('files', { _id: 'seed-1', name: 'welcome.txt' });
+    await mongo.insert('files', { _id: 'seed-2', name: 'getting-started.md' });
+    console.warn('seeded files with 2 documents');
+  }
+} catch (err) {
+  console.warn('skipped seeding (is Mongo running?):', err instanceof Error ? err.message : err);
+}
+
+const server = await createServer({ ws, publications });
+await server.listen({ port, host: '0.0.0.0' });
+
+console.warn(`EkoLite listening on http://localhost:${String(port)} (ws at /ws)`);

--- a/tests/infrastructure/websocket-inbound.integration.test.ts
+++ b/tests/infrastructure/websocket-inbound.integration.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import Fastify from 'fastify';
+import WebSocket from 'ws';
+import { WebSocketWrapper } from '../../server/infrastructure/websocket.ts';
+
+// Tighter red for wire 1 only: the real Fastify socket must forward inbound client
+// frames into the wrapper so the rest of the stack can act on them. Today
+// FastifyConnectionSource wraps the socket with send/close/onClose and no onMessage,
+// so anything a real client sends is dropped on the floor.
+//
+// This gap is invisible to the nullable tests: NullServerSocket already implements
+// onMessage, so simulateConnection().send() forwards fine. Only a real socket
+// exercises the missing wire, which is why this one has to be an integration test.
+
+describe('WebSocketWrapper forwards inbound frames from a real socket', () => {
+  let ws: WebSocketWrapper;
+  let client: WebSocket;
+
+  afterEach(async () => {
+    client.close();
+    await ws.close();
+  });
+
+  it('records a message the client sends over the wire', async () => {
+    const fastify = Fastify();
+    ws = WebSocketWrapper.create();
+    await ws.attach(fastify);
+    await fastify.listen({ port: 0 });
+    const port = String(fastify.addresses()[0].port);
+
+    const inbound = ws.trackMessages();
+
+    client = new WebSocket(`ws://localhost:${port}/ws`);
+    await new Promise((resolve, reject) => {
+      client.on('open', resolve);
+      client.on('error', reject);
+    });
+
+    client.send(JSON.stringify({ type: 'subscribe', id: 's1', name: 'files.all' }));
+
+    await vi.waitFor(() => {
+      expect(inbound.data.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/tests/server/createServerRouting.test.ts
+++ b/tests/server/createServerRouting.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createServer } from '../../server/index.ts';
+import { WebSocketWrapper } from '../../server/infrastructure/websocket.ts';
+import { MongoWrapper } from '../../server/infrastructure/mongo.ts';
+import { Publications } from '../../server/logic/publications.ts';
+
+// Tighter red for wires 2 and 3 only, with no real socket in sight. Everything is
+// nulled: a null ws lets us simulate a connection and an inbound subscribe, a null
+// mongo hands back a fixed document. The seam under test is purely 'does createServer
+// route an inbound message into the pub/sub engine and send the reply back out'.
+//
+// Red today because:
+//   - ServerOptions is { ws }, so { ws, publications } is rejected (wire 2), and
+//   - nothing in createServer pumps ws inbound messages into publications.handleMessage,
+//     so the stubbed client hears nothing back (wire 3).
+//
+// It says nothing about the real Fastify socket: the null path already forwards
+// inbound frames, so this test passes straight through that seam. The real-socket
+// gap is rung 2's job. Keeping them apart is the whole point of tighter reds.
+
+describe('createServer routes inbound subscriptions into publications', () => {
+  it('a simulated subscribe yields added + ready back to the client', async () => {
+    const mongo = MongoWrapper.createNull({
+      find: [[{ _id: '1', name: 'existing.bam' }]],
+    });
+    const ws = WebSocketWrapper.createNull();
+    const publications = new Publications(mongo, ws);
+    publications.define('files.all', () => ({ collection: 'files', query: {} }));
+
+    await createServer({ ws, publications });
+
+    const client = ws.simulateConnection();
+    client.send({ type: 'subscribe', id: 'sub1', name: 'files.all' });
+
+    await vi.waitFor(() => {
+      expect(client.messages).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ type: 'added', id: '1', fields: { name: 'existing.bam' } }),
+          expect.objectContaining({ type: 'ready', id: 'sub1', collection: 'files' }),
+        ]),
+      );
+    });
+  });
+});

--- a/tests/server/livePubsub.integration.test.ts
+++ b/tests/server/livePubsub.integration.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createServer } from '../../server/index.ts';
+import { WebSocketWrapper } from '../../server/infrastructure/websocket.ts';
+import { MongoWrapper } from '../../server/infrastructure/mongo.ts';
+import { Publications } from '../../server/logic/publications.ts';
+import { ClientSocketWrapper } from '../../client/clientSocket.ts';
+import { ConnectionManager } from '../../client/connectionManager.ts';
+
+const withReadyTimeout = <T>(promise: Promise<T>): Promise<T> => {
+  return Promise.race([
+    promise,
+    new Promise<T>((_resolve, reject) =>
+      setTimeout(() => {
+        reject(
+          new Error('subscription never became ready: the live socket is not wired end to end'),
+        );
+      }, 1000),
+    ),
+  ]);
+};
+
+describe('live pub/sub over a real socket', () => {
+  let server: Awaited<ReturnType<typeof createServer>>;
+  let socket: ClientSocketWrapper;
+
+  afterEach(async () => {
+    await socket.close();
+    await server.close();
+  });
+
+  it('a real client subscription fills its store from the server', async () => {
+    const mongo = MongoWrapper.createNull({
+      find: [[{ _id: '1', name: 'existing.bam' }]],
+    });
+    const ws = WebSocketWrapper.create();
+    const publications = new Publications(mongo, ws);
+    publications.define('files.all', () => ({ collection: 'files', query: {} }));
+
+    // Target API: the boot path hands its publications to the server so inbound
+    // subscribes get routed to the engine. ServerOptions has to grow to accept this.
+    server = await createServer({ ws, publications });
+    await server.listen({ port: 0 });
+    const port = String(server.addresses()[0].port);
+
+    socket = ClientSocketWrapper.create(`ws://localhost:${port}/ws`);
+    await socket.connect();
+    const manager = new ConnectionManager(socket);
+
+    const handle = manager.subscribe('files.all');
+    await withReadyTimeout(handle.ready);
+
+    expect(manager.store('files').getById('1')).toEqual({ _id: '1', name: 'existing.bam' });
+  });
+});


### PR DESCRIPTION
## What

A real browser client can now subscribe over a real socket and have its store
stream from the server. Until this, pub/sub only worked through the in-memory
Null transport in tests.

This PR is the server and test side. The runnable browser page that shows it off
lives in a stacked demo PR (`demo/live-socket-and-uploads`).

## The three wires

1. **Inbound forwarding.** The real Fastify socket (`FastifyConnectionSource`)
   only had `send`, `close` and `onClose`. This adds `onMessage`, so a client's
   `subscribe` actually reaches the server. Frames are parsed to objects so the
   real and Null paths hand routing the same shape.
2. **A way to consume them.** `WebSocketWrapper.onMessage(cb)` exposes inbound
   messages with their `clientId`, mirroring the existing `onDisconnect`.
3. **Routing.** `createServer` now takes an optional `publications` and pipes
   every inbound message into `publications.handleMessage`. Keeping it optional
   leaves the existing `createServer({ ws })` callers untouched.

`server/start.ts` now builds Mongo, websocket and publications for a real boot,
and seeds two `files` on first boot so a fresh database is not a blank page.

## Driven by tests, innermost first

- `tests/server/createServerRouting.test.ts`: nullable and fast. A simulated
  subscribe yields `added` then `ready`. Drives wires 2 and 3.
- `tests/infrastructure/websocket-inbound.integration.test.ts`: real socket. A
  client frame reaches the server. Drives wire 1.
- `tests/server/livePubsub.integration.test.ts`: full end to end over a real
  socket. A real client subscription fills its store. Goes green once all three
  wires land.

Linear: https://linear.app/ekohacks/issue/EKO-282/3c7-wire-live-pubsub-over-a-real-socket

## Out of scope

Writing from the browser needs the methods/RPC path, which is the next piece. The
browser demo (stacked) is read-only for now.
