### PR TITLE
feat: file storage over HTTP (upload + download)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,16 @@ EkoLite is a public, work in progress rebuild of Meteor's core ideas with delibe
 ## What works today
 
 - **Nullable infrastructure wrappers**, each with `create()` and `createNull()` factories: MongoDB (`MongoWrapper`), WebSocket server (`WebSocketWrapper`), file storage (`FileStorageWrapper`) and script runner (`ScriptRunnerWrapper`)
-- **Pub/sub engine** (`Publications`): define a publication on the server, subscribe over the socket, receive `ready` and data messages, with reference counted teardown
+- **Pub/sub engine** (`Publications`): define a publication on the server, subscribe over a live socket, receive `ready` and data messages, with reference counted teardown. Wired end to end now: a real browser client subscribes over a real socket and its store fills from Mongo
+- **File storage over HTTP** (`Files`): `POST /api/files` saves the bytes and inserts a document that streams into the live list through pub/sub; `GET /api/files/:id` streams them back
 - **Client stack**: `ClientSocketWrapper` (nullable WebSocket client), `ConnectionManager` (subscription lifecycle) and `ReactiveStore` (client side collection state)
 - **Mini DDP protocol** ([`shared/protocol.ts`](shared/protocol.ts)): six message types, typed end to end
+- **Live boot** (`start.ts`): real Mongo, websocket, publications and file store, with a runnable browser demo at [`client/demo/live.html`](client/demo/live.html)
 
 ## What is planned, not yet built
 
 - A server side method registry (RPC). The `method`, `result` and `error` message types already exist in the protocol; the registry that handles them is the next epic.
-- File uploads and asset resolution as product features. The infrastructure wrappers exist; nothing user facing sits on them yet.
+- Reconnect and resubscribe after a dropped socket, and auth on the HTTP routes. Today a closed socket disposes and stays disposed, and the file routes are open.
 
 ## Quick start
 
@@ -35,8 +37,8 @@ npm test
 ```
 ekolite/
 ├── server/
-│   ├── index.ts                  # createServer: Fastify + static + websocket
-│   ├── start.ts                  # Entry point
+│   ├── index.ts                  # createServer: Fastify, static, websocket, pub/sub + file routes
+│   ├── start.ts                  # Entry point: real Mongo, ws, publications, file store
 │   ├── infrastructure/
 │   │   ├── mongo.ts              # MongoWrapper, create() / createNull()
 │   │   ├── websocket.ts          # WebSocketWrapper, create() / createNull()
@@ -44,7 +46,8 @@ ekolite/
 │   │   ├── scriptRunner.ts       # ScriptRunnerWrapper
 │   │   └── outputTracker.ts      # EventEmitter + OutputTracker
 │   └── logic/
-│       └── publications.ts       # Pub/sub engine
+│       ├── publications.ts       # Pub/sub engine
+│       └── files.ts              # Files: upload and read over storage + Mongo
 ├── client/
 │   ├── clientSocket.ts           # ClientSocketWrapper, nullable WebSocket client
 │   ├── connectionManager.ts      # Subscriptions and lifecycle

--- a/server/index.ts
+++ b/server/index.ts
@@ -46,6 +46,17 @@ export async function createServer(options: ServerOptions) {
       });
       return reply.status(201).send({ id: stored._id, name: stored.name });
     });
+
+    server.get('/api/files/:id', async (request, reply) => {
+      const { id } = request.params as { id: string };
+      const result = await files.read(id);
+      if (!result) {
+        return reply.status(404).send({ error: 'file not found' });
+      }
+      reply.header('content-type', 'application/octet-stream');
+      reply.header('content-disposition', `attachment; filename="${result.file.name}"`);
+      return reply.send(result.data);
+    });
   }
 
   return server;

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,14 +1,17 @@
+import fastifyMultipart from '@fastify/multipart';
 import fastifyStatic from '@fastify/static';
 import Fastify from 'fastify';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { WebSocketWrapper } from './infrastructure/websocket.ts';
 import { type Publications } from './logic/publications.ts';
+import { type Files } from './logic/files.ts';
 import { type ClientMessage } from '../shared/protocol.ts';
 
 export interface ServerOptions {
   ws: WebSocketWrapper;
   publications?: Publications;
+  files?: Files;
 }
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -25,6 +28,23 @@ export async function createServer(options: ServerOptions) {
   if (publications) {
     options.ws.onMessage((clientId, message) => {
       void publications.handleMessage(clientId, message as ClientMessage);
+    });
+  }
+
+  const files = options.files;
+  if (files) {
+    await server.register(fastifyMultipart);
+    server.post('/api/files', async (request, reply) => {
+      const upload = await request.file();
+      if (!upload) {
+        return reply.status(400).send({ error: 'no file in request' });
+      }
+      const stored = await files.upload({
+        name: upload.filename,
+        type: upload.mimetype,
+        data: await upload.toBuffer(),
+      });
+      return reply.status(201).send({ id: stored._id, name: stored.name });
     });
   }
 

--- a/server/infrastructure/fileStorage.ts
+++ b/server/infrastructure/fileStorage.ts
@@ -1,4 +1,4 @@
-import { access, mkdir, unlink, writeFile } from 'node:fs/promises';
+import { access, mkdir, readFile, unlink, writeFile } from 'node:fs/promises';
 import { dirname, resolve as pathResolve } from 'node:path';
 import { ConfigurableResponse, EventEmitter, OutputTracker } from './outputTracker.ts';
 
@@ -6,6 +6,7 @@ const CHANGE_EVENT = 'change';
 
 interface FileSystemLike {
   writeFile(path: string, data: Buffer): Promise<void>;
+  readFile(path: string): Promise<Buffer>;
   access(path: string): Promise<boolean>;
   unlink(path: string): Promise<void>;
   resolve(name: string): string;
@@ -49,6 +50,10 @@ export class FileStorageWrapper {
 
   async remove(name: string): Promise<void> {
     return this.adapter.unlink(name);
+  }
+
+  async read(name: string): Promise<Buffer> {
+    return this.adapter.readFile(name);
   }
 
   resolve(name: string): string {
@@ -103,6 +108,10 @@ class RealFileSystem implements FileSystemLike {
     await mkdir(dirname(fullPath), { recursive: true });
     await writeFile(fullPath, data);
     this.emitter.emit(CHANGE_EVENT, { type: 'save', name, data });
+  }
+
+  async readFile(name: string): Promise<Buffer> {
+    return readFile(this.resolve(name));
   }
 
   async access(name: string): Promise<boolean> {
@@ -164,6 +173,14 @@ class StubbedFileStorage implements FileSystemLike {
     this.store.set(this.resolve(name), data);
     this.emitter.emit(CHANGE_EVENT, { type: 'save', name, data });
     return Promise.resolve();
+  }
+
+  readFile(name: string): Promise<Buffer> {
+    const data = this.store.get(this.resolve(name));
+    if (!data) {
+      return Promise.reject(new Error(`No such file: ${name}`));
+    }
+    return Promise.resolve(data);
   }
 
   access(name: string): Promise<boolean> {

--- a/server/logic/files.ts
+++ b/server/logic/files.ts
@@ -34,4 +34,14 @@ export class Files {
     await this.mongo.insert('files', stored);
     return stored;
   }
+
+  async read(id: string): Promise<{ file: StoredFile; data: Buffer } | null> {
+    const docs = await this.mongo.find<StoredFile>('files', { _id: id });
+    if (docs.length === 0) {
+      return null;
+    }
+    const file = docs[0];
+    const data = await this.storage.read(file.name);
+    return { file, data };
+  }
 }

--- a/server/logic/files.ts
+++ b/server/logic/files.ts
@@ -1,0 +1,37 @@
+import { extname } from 'node:path';
+import { MongoWrapper } from '../infrastructure/mongo.ts';
+import { FileStorageWrapper } from '../infrastructure/fileStorage.ts';
+import { StoredFile } from '../../shared/types.ts';
+
+export interface UploadInput {
+  name: string;
+  type: string;
+  data: Buffer;
+}
+
+// Files sits over the two infrastructure wrappers the way Publications sits over
+// Mongo and the websocket: the route stays thin and the logic is testable on
+// nullables. Upload writes the bytes, then records a document describing them so
+// the same document streams to subscribers through publications.
+export class Files {
+  constructor(
+    private readonly mongo: MongoWrapper,
+    private readonly storage: FileStorageWrapper,
+  ) {}
+
+  async upload(input: UploadInput): Promise<StoredFile> {
+    await this.storage.save(input.name, input.data);
+
+    const stored: StoredFile = {
+      _id: globalThis.crypto.randomUUID(),
+      name: input.name,
+      path: this.storage.resolve(input.name),
+      size: input.data.length,
+      extension: extname(input.name).replace(/^\./, ''),
+      uploadedAt: new Date(),
+    };
+
+    await this.mongo.insert('files', stored);
+    return stored;
+  }
+}

--- a/server/start.ts
+++ b/server/start.ts
@@ -1,17 +1,22 @@
 import { createServer } from './index.ts';
 import { MongoWrapper } from './infrastructure/mongo.ts';
 import { WebSocketWrapper } from './infrastructure/websocket.ts';
+import { FileStorageWrapper } from './infrastructure/fileStorage.ts';
 import { Publications } from './logic/publications.ts';
+import { Files } from './logic/files.ts';
 
 // Real boot. The same pieces the end-to-end test wires by hand, wired here for a
-// live process: a Mongo connection, a websocket server, and the pub/sub engine
-// that turns subscriptions into live document streams.
+// live process: a Mongo connection, a websocket server, the pub/sub engine that
+// turns subscriptions into live document streams, and the file store behind uploads.
 const mongoUri = process.env.MONGO_URI ?? 'mongodb://localhost:27017/ekolite';
+const fileDir = process.env.FILE_DIR ?? './uploads';
 const port = Number(process.env.PORT ?? 3001);
 
 const mongo = MongoWrapper.create(mongoUri);
 const ws = WebSocketWrapper.create();
+const storage = FileStorageWrapper.create(fileDir);
 const publications = new Publications(mongo, ws);
+const files = new Files(mongo, storage);
 
 // One publication to start with: every document in the files collection, kept in
 // sync with the client as Mongo changes.
@@ -31,7 +36,7 @@ try {
   console.warn('skipped seeding (is Mongo running?):', err instanceof Error ? err.message : err);
 }
 
-const server = await createServer({ ws, publications });
+const server = await createServer({ ws, publications, files });
 await server.listen({ port, host: '0.0.0.0' });
 
 console.warn(`EkoLite listening on http://localhost:${String(port)} (ws at /ws)`);

--- a/tests/infrastructure/fileStorageContract.ts
+++ b/tests/infrastructure/fileStorageContract.ts
@@ -11,6 +11,12 @@ export function fileStorageContract(makeStorage: () => FileStorageWrapper): void
     expect(await storage.exists('report.bam')).toBe(true);
   });
 
+  it('reads back the bytes it saved', async () => {
+    const storage = makeStorage();
+    await storage.save('report.bam', Buffer.from('payload'));
+    expect(await storage.read('report.bam')).toEqual(Buffer.from('payload'));
+  });
+
   it('reports a file that was never saved as absent', async () => {
     const storage = makeStorage();
     expect(await storage.exists('missing.bam')).toBe(false);

--- a/tests/logic/files.test.ts
+++ b/tests/logic/files.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { MongoWrapper } from '../../server/infrastructure/mongo.ts';
+import { FileStorageWrapper } from '../../server/infrastructure/fileStorage.ts';
+import { Files } from '../../server/logic/files.ts';
+
+// The files logic, in isolation, on nulled infrastructure. Upload writes the bytes
+// to the store and records a document describing the file, so the same document can
+// later stream to subscribers through publications.
+describe('Files.upload', () => {
+  it('saves the bytes and inserts a document describing the file', async () => {
+    const mongo = MongoWrapper.createNull();
+    const storage = FileStorageWrapper.createNull();
+    const files = new Files(mongo, storage);
+    const inserts = mongo.trackChanges('files');
+
+    const stored = await files.upload({
+      name: 'a.bam',
+      type: 'application/octet-stream',
+      data: Buffer.from('xyz'),
+    });
+
+    expect(await storage.exists('a.bam')).toBe(true);
+    expect(stored).toEqual(expect.objectContaining({ name: 'a.bam', size: 3, extension: 'bam' }));
+
+    const insert = inserts.data.find((event) => (event as { type?: unknown }).type === 'insert');
+    expect(insert).toBeDefined();
+    expect((insert as { fields: { name?: unknown } }).fields.name).toBe('a.bam');
+  });
+});

--- a/tests/logic/files.test.ts
+++ b/tests/logic/files.test.ts
@@ -27,3 +27,40 @@ describe('Files.upload', () => {
     expect((insert as { fields: { name?: unknown } }).fields.name).toBe('a.bam');
   });
 });
+
+// Read looks the document up by id, then hands back the stored bytes for it. The
+// document is the source of truth for the id to file name mapping.
+describe('Files.read', () => {
+  it('reads back the bytes and the document for a stored file', async () => {
+    const mongo = MongoWrapper.createNull({
+      find: [
+        [
+          {
+            _id: 'known',
+            name: 'a.txt',
+            path: '/x/a.txt',
+            size: 5,
+            extension: 'txt',
+            uploadedAt: new Date(),
+          },
+        ],
+      ],
+    });
+    const storage = FileStorageWrapper.createNull();
+    await storage.save('a.txt', Buffer.from('hello'));
+    const files = new Files(mongo, storage);
+
+    const result = await files.read('known');
+
+    expect(result?.file.name).toBe('a.txt');
+    expect(result?.data).toEqual(Buffer.from('hello'));
+  });
+
+  it('returns null when the file id is unknown', async () => {
+    const mongo = MongoWrapper.createNull();
+    const storage = FileStorageWrapper.createNull();
+    const files = new Files(mongo, storage);
+
+    expect(await files.read('nope')).toBeNull();
+  });
+});

--- a/tests/server/fileDownload.integration.test.ts
+++ b/tests/server/fileDownload.integration.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createServer } from '../../server/index.ts';
+import { WebSocketWrapper } from '../../server/infrastructure/websocket.ts';
+import { MongoWrapper } from '../../server/infrastructure/mongo.ts';
+import { FileStorageWrapper } from '../../server/infrastructure/fileStorage.ts';
+import { Files } from '../../server/logic/files.ts';
+
+// End to end over real HTTP: GET /api/files/:id looks the document up, reads the
+// bytes off the store, and streams them back. Storage and Mongo are nulled and
+// seeded here because this is about the route, not the disk.
+//
+// Red until Files.read and FileStorageWrapper.read exist and createServer serves
+// the GET /api/files/:id route.
+
+describe('file download over real HTTP', () => {
+  let server: Awaited<ReturnType<typeof createServer>>;
+
+  afterEach(async () => {
+    await server.close();
+  });
+
+  it('serves the stored bytes for a known file id', async () => {
+    const mongo = MongoWrapper.createNull({
+      find: [
+        [
+          {
+            _id: 'known',
+            name: 'a.txt',
+            path: '/x/a.txt',
+            size: 5,
+            extension: 'txt',
+            uploadedAt: new Date(),
+          },
+        ],
+      ],
+    });
+    const storage = FileStorageWrapper.createNull();
+    await storage.save('a.txt', Buffer.from('hello over http'));
+    const ws = WebSocketWrapper.createNull();
+    const files = new Files(mongo, storage);
+
+    server = await createServer({ ws, files });
+    await server.listen({ port: 0 });
+    const port = String(server.addresses()[0].port);
+
+    const res = await fetch(`http://localhost:${port}/api/files/known`);
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('hello over http');
+  });
+
+  it('returns 404 for an unknown file id', async () => {
+    const mongo = MongoWrapper.createNull();
+    const storage = FileStorageWrapper.createNull();
+    const ws = WebSocketWrapper.createNull();
+    const files = new Files(mongo, storage);
+
+    server = await createServer({ ws, files });
+    await server.listen({ port: 0 });
+    const port = String(server.addresses()[0].port);
+
+    const res = await fetch(`http://localhost:${port}/api/files/missing`);
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/server/fileUpload.integration.test.ts
+++ b/tests/server/fileUpload.integration.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createServer } from '../../server/index.ts';
+import { WebSocketWrapper } from '../../server/infrastructure/websocket.ts';
+import { MongoWrapper } from '../../server/infrastructure/mongo.ts';
+import { FileStorageWrapper } from '../../server/infrastructure/fileStorage.ts';
+import { Files } from '../../server/logic/files.ts';
+
+// End to end over real HTTP: a multipart upload lands bytes on the file store and a
+// document in the files collection (which is what makes it show up in the live list).
+// Storage and Mongo are nulled because this is about the HTTP wiring, not the disk.
+//
+// Red until: @fastify/multipart is registered, createServer accepts files, and a
+// POST /api/files route runs files.upload.
+
+describe('file upload over real HTTP', () => {
+  let server: Awaited<ReturnType<typeof createServer>>;
+
+  afterEach(async () => {
+    await server.close();
+  });
+
+  it('stores the bytes and inserts a files document', async () => {
+    const mongo = MongoWrapper.createNull();
+    const storage = FileStorageWrapper.createNull();
+    const ws = WebSocketWrapper.createNull();
+    const files = new Files(mongo, storage);
+    const inserts = mongo.trackChanges('files');
+
+    server = await createServer({ ws, files });
+    await server.listen({ port: 0 });
+    const port = String(server.addresses()[0].port);
+
+    const form = new FormData();
+    form.append(
+      'file',
+      new Blob([Buffer.from('hello there')], { type: 'text/plain' }),
+      'greeting.txt',
+    );
+    const res = await fetch(`http://localhost:${port}/api/files`, { method: 'POST', body: form });
+
+    expect(res.status).toBe(201);
+    expect(await storage.exists('greeting.txt')).toBe(true);
+
+    const insert = inserts.data.find((event) => (event as { type?: unknown }).type === 'insert');
+    expect(insert).toBeDefined();
+    expect((insert as { fields: { name?: unknown } }).fields.name).toBe('greeting.txt');
+  });
+});


### PR DESCRIPTION
## What

File storage over HTTP, end to end. Upload bytes and download them back, with
the stored document flowing into the live files list through the pub/sub already
wired. Stacked on #64 (the live socket); this PR is the server and test side, plus
the README update that documents both features.

The browser controls that drive these routes (a file input and Upload button)
land in the stacked demo PR (`demo/live-socket-and-uploads`).

## Surface

- `POST /api/files` (multipart) saves the bytes to the file store and inserts a
  files document, so an upload appears in the live list.
- `GET /api/files/:id` looks the document up, reads the bytes off the store and
  streams them back with a download disposition (404 when the id is unknown).

## Shape

- A `Files` logic class over `MongoWrapper` and `FileStorageWrapper`, the same
  way `Publications` sits over Mongo and the websocket. Routes stay thin.
- `FileStorageWrapper.read` added and held to the same contract as the real
  adapter, so the null cannot drift.
- `createServer` registers `@fastify/multipart` and the two routes only when
  given `files`, so existing `createServer({ ws })` callers are untouched.
- `start.ts` builds the file store (`FILE_DIR`, default `./uploads`).

## Driven by tests

- `tests/logic/files.test.ts`: nullable. Upload save and insert, read roundtrip,
  unknown id.
- `tests/infrastructure/fileStorageContract.ts`: read roundtrip, run against null
  and real.
- `tests/server/fileUpload.integration.test.ts` and
  `fileDownload.integration.test.ts`: real HTTP.

## Notes

- An uploaded file appears in an already-open page live only with a replica-set
  Mongo (change streams). On a standalone it shows on refresh. The transport is
  wired either way.
- Out of scope: delete over HTTP, content-type from the stored document (download
  is octet-stream for now), and auth.

Linear: https://linear.app/ekohacks/issue/EKO-283/3c8-wire-file-uploads-over-http
