### PR TITLE
feat: live demo for socket streaming and file uploads

### DIFF
--- a/client/demo/README.md
+++ b/client/demo/README.md
@@ -1,0 +1,93 @@
+# EkoLite client demo
+
+A runnable demo of the client stack with no backend. It drives the real
+`ConnectionManager`, `SubscriptionHandle` and `ReactiveStore` through a stubbed
+server, so you can watch subscriptions and the reactive store update live without
+Mongo or a running server.
+
+## Run it
+
+```bash
+npm run dev:client
+```
+
+Vite prints a local URL such as `http://localhost:5173/`. Open the demo at the
+`/demo/` path (the trailing slash matters):
+
+```
+http://localhost:5173/demo/
+```
+
+If port 5173 is busy Vite picks the next one (5174 and so on), so use whatever it
+prints. The root URL `/` is the placeholder page and has no buttons; the demo is
+under `/demo/`.
+
+## What you see
+
+- A status line: connecting, then connected and subscription ready.
+- A files list, seeded with two documents once the subscription is ready.
+- Four buttons that play the part of server messages:
+  - **Add file** sends an `added` message, a new row appears.
+  - **Rename first** sends a `changed` message, the first row updates in place.
+  - **Remove first** sends a `removed` message, the first row disappears.
+  - **Disconnect** closes the socket, which disposes the `ConnectionManager` and
+    disables the buttons.
+- A log of the messages the stubbed server sent.
+
+## The point
+
+The demo wires a null socket:
+
+```ts
+const socket = ClientSocketWrapper.createNull();
+```
+
+Swap that one line for a real connection and the same `ConnectionManager` and
+`ReactiveStore` code talks to a live server:
+
+```ts
+const socket = ClientSocketWrapper.create('wss://your-host/ws');
+```
+
+That is the Nullables payoff: the code in the demo and the code in production are
+the same; only the socket changes.
+
+## Run it live (against a real server)
+
+`live.ts` is the same client code with that one line swapped for a real socket,
+pointed at a running server. You need MongoDB on `localhost:27017` and a server.
+
+```bash
+# 1. start the server (Mongo + websocket + publications)
+npm run dev:server
+
+# 2. in another terminal, start vite and open the live page
+npm run dev:client
+#    http://localhost:5173/demo/live.html
+```
+
+The server seeds two files on first boot, so a fresh Mongo is not a blank page.
+The list then streams straight from Mongo. To watch it update live, change the
+collection in another window and the page reacts:
+
+```js
+// mongosh
+use ekolite
+db.files.insertOne({ name: 'hello.txt' })
+db.files.updateOne({ name: 'hello.txt' }, { $set: { name: 'renamed.txt' } })
+db.files.deleteOne({ name: 'renamed.txt' })
+```
+
+Live streaming uses Mongo change streams, which need a replica set. A standalone
+Mongo still serves the initial documents (so the page is not empty); it just will
+not push later changes. For live updates run Mongo as a single-node replica set.
+
+There are no buttons on the live page: writing from the browser needs the
+methods/RPC path, which is the next epic. For now the browser reads, and writes
+happen in Mongo.
+
+## Note
+
+The full browser to Mongo round trip is wired now (see `server/start.ts` and the
+end-to-end test at `tests/server/livePubsub.integration.test.ts`). See the client
+API reference in [`docs/api/`](../../docs/api/connection-manager.md).

--- a/client/demo/live.html
+++ b/client/demo/live.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>EkoLite live demo</title>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        max-width: 40rem;
+        margin: 2rem auto;
+        padding: 0 1rem;
+        color: #1a1a1a;
+      }
+      h1 {
+        margin-bottom: 0.25rem;
+      }
+      .lede {
+        color: #555;
+        margin-top: 0;
+      }
+      #status {
+        font-weight: 600;
+        padding: 0.4rem 0.6rem;
+        background: #eef;
+        border-radius: 0.4rem;
+        display: inline-block;
+      }
+      .controls {
+        display: flex;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+        align-items: center;
+        margin: 1rem 0;
+      }
+      button {
+        padding: 0.4rem 0.8rem;
+        border: 1px solid #99c;
+        border-radius: 0.4rem;
+        background: #fff;
+        cursor: pointer;
+      }
+      button:disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+      }
+      ul {
+        padding-left: 1.2rem;
+      }
+      li {
+        padding: 0.15rem 0;
+      }
+      #log {
+        font-family: ui-monospace, monospace;
+        font-size: 0.85rem;
+        color: #444;
+        background: #f6f6f6;
+        border-radius: 0.4rem;
+        padding: 0.6rem;
+        max-height: 12rem;
+        overflow: auto;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>EkoLite live demo</h1>
+      <p class="lede">
+        The real ConnectionManager and ReactiveStore, talking to a live server at
+        ws://localhost:3001/ws. The files list streams from Mongo. Pick a file and upload
+        it; it lands on the server and streams back into the list. Start the server with
+        npm run dev:server first.
+      </p>
+      <p id="status">connecting…</p>
+
+      <div class="controls">
+        <input type="file" id="file" />
+        <button id="upload">Upload</button>
+      </div>
+
+      <h2>files</h2>
+      <ul id="list"></ul>
+
+      <h2>messages</h2>
+      <div id="log"></div>
+    </main>
+    <script type="module" src="./live.ts"></script>
+  </body>
+</html>

--- a/client/demo/live.ts
+++ b/client/demo/live.ts
@@ -1,0 +1,123 @@
+// EkoLite live demo — the same client stack as demo.ts, but talking to a real
+// server over a real socket instead of a stubbed one.
+//
+// The only line that differs from the stubbed demo is the socket: createNull()
+// becomes create('ws://localhost:3001/ws'). Everything else (ConnectionManager,
+// SubscriptionHandle, ReactiveStore) is identical. That is the Nullables payoff.
+//
+// It shows the read side (subscribe, see the documents, watch the list update as the
+// files collection changes) plus one write: uploading a file. The upload is a plain
+// HTTP POST to /api/files, which stores the bytes and inserts a document, so the file
+// then streams back into the list through the same subscription.
+
+import { ClientSocketWrapper } from '../clientSocket.ts';
+import { ConnectionManager } from '../connectionManager.ts';
+
+function el(id: string): HTMLElement {
+  const node = document.getElementById(id);
+  if (!node) {
+    throw new Error(`Missing #${id}`);
+  }
+  return node;
+}
+
+function input(id: string): HTMLInputElement {
+  const node = el(id);
+  if (!(node instanceof HTMLInputElement)) {
+    throw new Error(`#${id} is not an input`);
+  }
+  return node;
+}
+
+function button(id: string): HTMLButtonElement {
+  const node = el(id);
+  if (!(node instanceof HTMLButtonElement)) {
+    throw new Error(`#${id} is not a button`);
+  }
+  return node;
+}
+
+const statusEl = el('status');
+const listEl = el('list');
+const logEl = el('log');
+
+function log(line: string): void {
+  const entry = document.createElement('div');
+  entry.textContent = line;
+  logEl.prepend(entry);
+}
+
+// 1. Wire the client to the real server. Swap this URL for your host in production.
+const socket = ClientSocketWrapper.create('ws://localhost:3001/ws');
+
+try {
+  await socket.connect();
+} catch {
+  statusEl.textContent = 'could not connect — is the server running? (npm run dev:server)';
+  throw new Error('connection failed');
+}
+
+statusEl.textContent = 'connected · subscribing…';
+const manager = new ConnectionManager(socket);
+
+// 2. Subscribe to a publication the server defines (see server/start.ts).
+const handle = manager.subscribe('files.all');
+log('out: subscribe files.all');
+
+await handle.ready;
+statusEl.textContent = 'connected · subscription ready';
+log('in: ready');
+
+// 3. Read the store and re-render on every change. Real documents, live from Mongo.
+const files = manager.store('files');
+
+function render(): void {
+  const docs = files.getAll();
+  listEl.replaceChildren(
+    ...docs.map((doc) => {
+      const item = document.createElement('li');
+      const name = typeof doc.name === 'string' ? doc.name : '';
+      item.textContent = `${doc._id} · ${name}`;
+      return item;
+    }),
+  );
+}
+
+render();
+files.onChange(() => {
+  log('in: store changed');
+  render();
+});
+
+// 4. Upload a file over HTTP. It hits the server, lands on disk and inserts a
+// document, which streams back into the list above through the subscription.
+const fileInput = input('file');
+const uploadBtn = button('upload');
+
+uploadBtn.addEventListener('click', () => {
+  const file = fileInput.files?.[0];
+  if (!file) {
+    log('pick a file first');
+    return;
+  }
+  const form = new FormData();
+  form.append('file', file, file.name);
+  log(`out: upload ${file.name}`);
+  // POST through the vite proxy (/api → :3001) so it stays same-origin, no CORS.
+  void fetch('/api/files', { method: 'POST', body: form })
+    .then((res) => {
+      log(res.ok ? `in: stored ${file.name}` : `upload failed: ${String(res.status)}`);
+      if (res.ok) {
+        fileInput.value = '';
+      }
+    })
+    .catch((err: unknown) => {
+      log(`upload error: ${err instanceof Error ? err.message : String(err)}`);
+    });
+});
+
+socket.onClose(() => {
+  statusEl.textContent = 'disconnected · ConnectionManager disposed';
+  uploadBtn.disabled = true;
+  log('socket closed → dispose()');
+});


### PR DESCRIPTION
## What

The runnable browser demo for the live stack: subscribe over a real socket, watch
the files list stream from Mongo, and upload a file over HTTP and see it appear.
This is the visible surface of #64 (live socket) and #66 (file storage), kept on
its own so those two stay server and test only.

Stacked on #66.

## Contents

- `client/demo/live.html` and `client/demo/live.ts`: the page and its script. A
  files list bound to a `ReactiveStore` over a live subscription, plus a file
  input and Upload button that POST through the vite proxy.
- `client/demo/README.md`: how to run it and what to expect.

## Run it

```bash
npm run dev:server          # Mongo, ws and publications on :3001
npm run dev:client          # then open http://localhost:5173/demo/live.html
```

The files list streams from Mongo (seeded on first boot). Mutate the collection
in mongosh, or upload through the page, and it reacts. Live updates need a
replica-set Mongo (change streams); a standalone serves the initial documents and
shows uploads on refresh.

## Notes

Read plus upload only. Writing arbitrary documents from the browser waits on the
methods/RPC path.
