### PR TITLE
fix: await change stream cursor before a watch counts as active

### DIFF
--- a/server/infrastructure/mongo.ts
+++ b/server/infrastructure/mongo.ts
@@ -7,7 +7,7 @@ interface CollectionLike {
   insertOne(doc: object): Promise<void>;
   updateMany(query: object, changes: object): Promise<void>;
   deleteMany(query: object): Promise<void>;
-  watch(onChange: (raw: unknown) => void): () => void;
+  watch(onChange: (raw: unknown) => void): Promise<() => void>;
 }
 
 type CollectionFactory = (name: string) => CollectionLike;
@@ -22,7 +22,7 @@ interface StubbedMongoOptions {
 export class MongoWrapper {
   private readonly collectionFactory: CollectionFactory;
   private readonly emitter = new EventEmitter();
-  private readonly activeWatches = new Map<string, () => void>();
+  private readonly activeWatches = new Map<string, Promise<() => void>>();
 
   private constructor(collectionFactory: CollectionFactory) {
     this.collectionFactory = collectionFactory;
@@ -55,18 +55,21 @@ export class MongoWrapper {
     return this.collectionFactory(collection).deleteMany(query);
   }
 
-  watchChanges(collection: string, cb: (data: ChangeEvent) => void): () => void {
+  async watchChanges(
+    collection: string,
+    cb: (data: ChangeEvent) => void,
+  ): Promise<() => void> {
     const wrappedCb = (data: unknown) => {
       if (isChangeEvent(data)) {
         cb(data);
       }
     };
     this.emitter.on(collection, wrappedCb);
-    this.openWatchIfNeeded(collection);
+    await this.openWatchIfNeeded(collection);
 
     return () => {
       this.emitter.off(collection, wrappedCb);
-      this.closeWatchIfUnused(collection);
+      void this.closeWatchIfUnused(collection);
     };
   }
 
@@ -74,38 +77,38 @@ export class MongoWrapper {
     return this.emitter.listenerCount(collection);
   }
 
-  trackChanges(collection: string): OutputTracker {
+  async trackChanges(collection: string): Promise<OutputTracker> {
     const tracker = new OutputTracker(this.emitter, collection);
-    this.openWatchIfNeeded(collection);
+    await this.openWatchIfNeeded(collection);
     return tracker;
   }
 
-  private openWatchIfNeeded(collection: string): void {
-    if (this.activeWatches.has(collection)) {
-      return;
+  private openWatchIfNeeded(collection: string): Promise<() => void> {
+    const existing = this.activeWatches.get(collection);
+    if (existing) {
+      return existing;
     }
 
-    const stopWatching = this.collectionFactory(collection).watch((raw) => {
+    // Store the promise synchronously, before any await, so two subscribers that
+    // arrive in the same tick share one change stream rather than opening two.
+    const watch = this.collectionFactory(collection).watch((raw) => {
       const changeEvent = mapRawChangeToChangeEvent(raw);
-      if (changeEvent) {
-        this.emitter.emit(collection, changeEvent);
-      } else {
-        this.emitter.emit(collection, raw);
-      }
+      this.emitter.emit(collection, changeEvent ?? raw);
     });
-
-    this.activeWatches.set(collection, stopWatching);
+    this.activeWatches.set(collection, watch);
+    return watch;
   }
 
-  private closeWatchIfUnused(collection: string): void {
+  private async closeWatchIfUnused(collection: string): Promise<void> {
     if (this.emitter.listenerCount(collection) > 0) {
       return;
     }
 
-    const stopWatching = this.activeWatches.get(collection);
-    if (stopWatching) {
-      stopWatching();
+    const watch = this.activeWatches.get(collection);
+    if (watch) {
       this.activeWatches.delete(collection);
+      const stopWatching = await watch;
+      stopWatching();
     }
   }
 }
@@ -129,13 +132,22 @@ class RealCollection implements CollectionLike {
     return this.collection.deleteMany(query).then(() => undefined);
   }
 
-  watch(onChange: (raw: unknown) => void): () => void {
+  async watch(onChange: (raw: unknown) => void): Promise<() => void> {
     const changeStream = this.collection.watch([], { fullDocument: 'updateLookup' });
     changeStream.on('change', onChange);
     changeStream.on('error', (err) => {
       // Log for visibility, but don't rethrow or tear down the stream. The
       // caller still surfaces errors through regular driver behaviour.
       console.error(`Mongo change stream error on ${this.collection.collectionName}`, err);
+    });
+    // Resolve only once the server side cursor is established. collection.watch()
+    // returns before the cursor exists, so a write on the next line would be
+    // dropped; resumeTokenChanged fires once the cursor is live.
+    await new Promise<void>((resolve, reject) => {
+      changeStream.once('resumeTokenChanged', () => {
+        resolve();
+      });
+      changeStream.once('error', reject);
     });
     return () => {
       void changeStream.close();
@@ -253,14 +265,14 @@ class StubbedCollection implements CollectionLike {
     return Promise.resolve();
   }
 
-  watch(onChange: (raw: unknown) => void): () => void {
+  watch(onChange: (raw: unknown) => void): Promise<() => void> {
     const listener = (data: unknown) => {
       onChange(data);
     };
     this.emitter.on(this.collectionName, listener);
-    return () => {
+    return Promise.resolve(() => {
       this.emitter.off(this.collectionName, listener);
-    };
+    });
   }
 }
 

--- a/server/logic/publications.ts
+++ b/server/logic/publications.ts
@@ -181,7 +181,7 @@ export class Publications {
       }
       this.ws.send(clientId, readyMessage(message.id, collection));
 
-      const cleanup = this.mongo.watchChanges(collection, (change: ChangeEvent) => {
+      const cleanup = await this.mongo.watchChanges(collection, (change: ChangeEvent) => {
         switch (change.type) {
           case 'insert': {
             documentIds.add(change.id);

--- a/tests/infrastructure/mongo.integration.test.ts
+++ b/tests/infrastructure/mongo.integration.test.ts
@@ -34,7 +34,7 @@ describe('MongoWrapper (real)', () => {
 
   it('emits change stream events for insert, update, and delete', async () => {
     const changes: unknown[] = [];
-    const stop = mongo.watchChanges('testDocs', (change) => {
+    const stop = await mongo.watchChanges('testDocs', (change) => {
       changes.push(change);
     });
 

--- a/tests/infrastructure/mongo.test.ts
+++ b/tests/infrastructure/mongo.test.ts
@@ -76,7 +76,7 @@ describe('MongoWrapper (null)', () => {
     const mongo = MongoWrapper.createNull({
       insert: [undefined],
     });
-    const tracker = mongo.trackChanges('testDocs');
+    const tracker = await mongo.trackChanges('testDocs');
     await mongo.insert('testDocs', { name: 'test' });
     expect(tracker.data).toHaveLength(1);
     expect(tracker.data[0]).toMatchObject({
@@ -91,7 +91,7 @@ describe('MongoWrapper (null)', () => {
     const mongo = MongoWrapper.createNull({
       update: [undefined],
     });
-    const tracker = mongo.trackChanges('testDocs');
+    const tracker = await mongo.trackChanges('testDocs');
     await mongo.update('testDocs', { name: 'old' }, { $set: { name: 'new' } });
     expect(tracker.data).toHaveLength(1);
     expect(tracker.data[0]).toMatchObject({
@@ -106,7 +106,7 @@ describe('MongoWrapper (null)', () => {
     const mongo = MongoWrapper.createNull({
       remove: [undefined],
     });
-    const tracker = mongo.trackChanges('testDocs');
+    const tracker = await mongo.trackChanges('testDocs');
     await mongo.remove('testDocs', { name: 'gone' });
     expect(tracker.data).toHaveLength(1);
     expect(tracker.data[0]).toMatchObject({
@@ -118,7 +118,7 @@ describe('MongoWrapper (null)', () => {
 
   it('tracks insert change events', async () => {
     const mongo = MongoWrapper.createNull();
-    const tracker = mongo.trackChanges('testDocs');
+    const tracker = await mongo.trackChanges('testDocs');
     await mongo.insert('testDocs', { name: 'test' });
     expect(tracker.data).toHaveLength(1);
     expect(tracker.data[0]).toMatchObject({
@@ -131,7 +131,7 @@ describe('MongoWrapper (null)', () => {
 
   it('updates a document', async () => {
     const mongo = MongoWrapper.createNull({ find: [[{ name: 'new' }]] });
-    const tracker = mongo.trackChanges('testDocs');
+    const tracker = await mongo.trackChanges('testDocs');
     await mongo.insert('testDocs', { name: 'old' });
     await mongo.update('testDocs', { name: 'old' }, { $set: { name: 'new' } });
     const docs = await mongo.find<{ name: string }>('testDocs', {});
@@ -153,7 +153,7 @@ describe('MongoWrapper (null)', () => {
 
   it('removes matching documents', async () => {
     const mongo = MongoWrapper.createNull({ find: [[{ name: 'keep' }]] });
-    const tracker = mongo.trackChanges('testDocs');
+    const tracker = await mongo.trackChanges('testDocs');
     await mongo.insert('testDocs', { name: 'keep' });
     await mongo.insert('testDocs', { name: 'remove' });
     await mongo.remove('testDocs', { name: 'remove' });
@@ -178,7 +178,7 @@ describe('MongoWrapper (null)', () => {
 
   it('tracks update change events', async () => {
     const mongo = MongoWrapper.createNull();
-    const tracker = mongo.trackChanges('testDocs');
+    const tracker = await mongo.trackChanges('testDocs');
     await mongo.insert('testDocs', { name: 'old' });
     await mongo.update('testDocs', { name: 'old' }, { $set: { name: 'new' } });
     expect(tracker.data).toHaveLength(2);
@@ -192,7 +192,7 @@ describe('MongoWrapper (null)', () => {
 
   it('tracks remove change events', async () => {
     const mongo = MongoWrapper.createNull();
-    const tracker = mongo.trackChanges('testDocs');
+    const tracker = await mongo.trackChanges('testDocs');
     await mongo.insert('testDocs', { name: 'gone' });
     await mongo.remove('testDocs', { name: 'gone' });
     expect(tracker.data).toHaveLength(2);
@@ -208,7 +208,7 @@ describe('MongoWrapper (null)', () => {
   // change target a known doc. Today it mints a fresh ObjectId per call, so these fail.
   it('emits an insert change carrying the _id from the document', async () => {
     const mongo = MongoWrapper.createNull();
-    const tracker = mongo.trackChanges('testDocs');
+    const tracker = await mongo.trackChanges('testDocs');
 
     await mongo.insert('testDocs', { _id: 'doc-1', name: 'old' });
 
@@ -218,7 +218,7 @@ describe('MongoWrapper (null)', () => {
 
   it('emits an update change carrying the _id from the query', async () => {
     const mongo = MongoWrapper.createNull();
-    const tracker = mongo.trackChanges('testDocs');
+    const tracker = await mongo.trackChanges('testDocs');
 
     await mongo.update('testDocs', { _id: 'doc-1' }, { $set: { name: 'new' } });
 
@@ -233,7 +233,7 @@ describe('MongoWrapper (null)', () => {
 
   it('emits a remove change carrying the _id from the query', async () => {
     const mongo = MongoWrapper.createNull();
-    const tracker = mongo.trackChanges('testDocs');
+    const tracker = await mongo.trackChanges('testDocs');
 
     await mongo.remove('testDocs', { _id: 'doc-1' });
 
@@ -247,13 +247,13 @@ describe('MongoWrapper (null)', () => {
     expect(mongo.watcherCount('files')).toBe(0);
   });
 
-  it('counts active watchers from watchChanges', () => {
+  it('counts active watchers from watchChanges', async () => {
     const mongo = MongoWrapper.createNull();
-    const stop1 = mongo.watchChanges('files', () => {
+    const stop1 = await mongo.watchChanges('files', () => {
       /* empty */
     });
     expect(mongo.watcherCount('files')).toBe(1);
-    const stop2 = mongo.watchChanges('files', () => {
+    const stop2 = await mongo.watchChanges('files', () => {
       /* empty */
     });
     expect(mongo.watcherCount('files')).toBe(2);
@@ -263,15 +263,15 @@ describe('MongoWrapper (null)', () => {
     expect(mongo.watcherCount('files')).toBe(0);
   });
 
-  it('counts watchers per collection', () => {
+  it('counts watchers per collection', async () => {
     const mongo = MongoWrapper.createNull();
-    mongo.watchChanges('files', () => {
+    await mongo.watchChanges('files', () => {
       /* empty */
     });
-    mongo.watchChanges('scripts', () => {
+    await mongo.watchChanges('scripts', () => {
       /* empty */
     });
-    mongo.watchChanges('scripts', () => {
+    await mongo.watchChanges('scripts', () => {
       /* empty */
     });
     expect(mongo.watcherCount('files')).toBe(1);
@@ -283,7 +283,7 @@ describe('MongoWrapper (null)', () => {
     const mongo = MongoWrapper.createNull();
     const changes: ChangeEvent[] = [];
 
-    mongo.watchChanges('todos', (c) => changes.push(c));
+    await mongo.watchChanges('todos', (c) => changes.push(c));
 
     await mongo.insert('todos', { text: 'hello' });
 

--- a/tests/logic/files.test.ts
+++ b/tests/logic/files.test.ts
@@ -11,7 +11,7 @@ describe('Files.upload', () => {
     const mongo = MongoWrapper.createNull();
     const storage = FileStorageWrapper.createNull();
     const files = new Files(mongo, storage);
-    const inserts = mongo.trackChanges('files');
+    const inserts = await mongo.trackChanges('files');
 
     const stored = await files.upload({
       name: 'a.bam',

--- a/tests/server/fileUpload.integration.test.ts
+++ b/tests/server/fileUpload.integration.test.ts
@@ -24,7 +24,7 @@ describe('file upload over real HTTP', () => {
     const storage = FileStorageWrapper.createNull();
     const ws = WebSocketWrapper.createNull();
     const files = new Files(mongo, storage);
-    const inserts = mongo.trackChanges('files');
+    const inserts = await mongo.trackChanges('files');
 
     server = await createServer({ ws, files });
     await server.listen({ port: 0 });


### PR DESCRIPTION
collection.watch() returns before the server side cursor exists, so a write immediately after subscribe was dropped. Make watch() async and resolve on resumeTokenChanged, then thread the promise through watchChanges, trackChanges and openWatchIfNeeded so subscribers wait for a live cursor. openWatchIfNeeded stores the promise synchronously so concurrent subscribers share one stream.