### PR TITLE
Eko 208/5b1 store file and insert metadata

### DIFF
--- a/server/logic/files.ts
+++ b/server/logic/files.ts
@@ -9,6 +9,19 @@ export interface UploadInput {
   data: Buffer;
 }
 
+// The document recorded for an uploaded file. Pulled out so `upload` reads as
+// save, build, insert, with the field-by-field shape in one named place.
+function buildStoredFile(input: UploadInput, path: string): StoredFile {
+  return {
+    _id: globalThis.crypto.randomUUID(),
+    name: input.name,
+    path,
+    size: input.data.length,
+    extension: extname(input.name).replace(/^\./, ''),
+    uploadedAt: new Date(),
+  };
+}
+
 // Files sits over the two infrastructure wrappers the way Publications sits over
 // Mongo and the websocket: the route stays thin and the logic is testable on
 // nullables. Upload writes the bytes, then records a document describing them so
@@ -22,14 +35,7 @@ export class Files {
   async upload(input: UploadInput): Promise<StoredFile> {
     await this.storage.save(input.name, input.data);
 
-    const stored: StoredFile = {
-      _id: globalThis.crypto.randomUUID(),
-      name: input.name,
-      path: this.storage.resolve(input.name),
-      size: input.data.length,
-      extension: extname(input.name).replace(/^\./, ''),
-      uploadedAt: new Date(),
-    };
+    const stored = buildStoredFile(input, this.storage.resolve(input.name));
 
     await this.mongo.insert('files', stored);
     return stored;

--- a/tests/logic/files.test.ts
+++ b/tests/logic/files.test.ts
@@ -21,6 +21,7 @@ describe('Files.upload', () => {
 
     expect(await storage.exists('a.bam')).toBe(true);
     expect(stored).toEqual(expect.objectContaining({ name: 'a.bam', size: 3, extension: 'bam' }));
+    expect(stored.path).toBe(storage.resolve('a.bam'));
 
     const insert = inserts.data.find((event) => (event as { type?: unknown }).type === 'insert');
     expect(insert).toBeDefined();


### PR DESCRIPTION
Completes 5.B.1. The store-and-insert behaviour shipped in #70 (`Files.upload` and `files.test.ts`); the open item was the **Refactor** step from the story: lifting `StoredFile` construction out of the `upload` body.

`upload` now reads as save, build, insert, with the field-by-field shape in a named `buildStoredFile(input, path)`. Pure refactor, no behaviour change: `files.test.ts` stays green, typecheck and lint clean.

https://linear.app/ekohacks/issue/EKO-208/5b1-store-file-and-insert-metadata
