### PR TITLE
Eko 217/4b1 route method call and return result

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -6,11 +6,13 @@ import { fileURLToPath } from 'node:url';
 import { WebSocketWrapper } from './infrastructure/websocket.ts';
 import { type Publications } from './logic/publications.ts';
 import { type Files } from './logic/files.ts';
+import { type RpcHandler } from './logic/rpcHandler.ts';
 import { type ClientMessage } from '../shared/protocol.ts';
 
 export interface ServerOptions {
   ws: WebSocketWrapper;
   publications?: Publications;
+  rpcHandler?: RpcHandler;
   files?: Files;
 }
 
@@ -25,9 +27,27 @@ export async function createServer(options: ServerOptions) {
   await options.ws.attach(server);
 
   const publications = options.publications;
-  if (publications) {
+  const rpcHandler = options.rpcHandler;
+
+  if (publications || rpcHandler) {
     options.ws.onMessage((clientId, message) => {
-      void publications.handleMessage(clientId, message as ClientMessage);
+      const clientMessage = message as ClientMessage;
+
+      switch (clientMessage.type) {
+        case 'method':
+          if (rpcHandler) {
+            void rpcHandler.handleMessage(clientId, clientMessage);
+          }
+          break;
+        case 'subscribe':
+        case 'unsubscribe':
+          if (publications) {
+            void publications.handleMessage(clientId, clientMessage);
+          }
+          break;
+        default:
+          break;
+      }
     });
   }
 

--- a/server/logic/rpcHandler.ts
+++ b/server/logic/rpcHandler.ts
@@ -1,0 +1,22 @@
+import { MethodMsg } from '../../shared/protocol.ts';
+import { WebSocketWrapper } from '../infrastructure/websocket.ts';
+import { Methods } from './methods.ts';
+
+export class RpcHandler {
+  private methods: Methods;
+  private ws: WebSocketWrapper;
+
+  constructor(methods: Methods, ws: WebSocketWrapper) {
+    this.methods = methods;
+    this.ws = ws;
+  }
+
+  async handleMessage(clientId: string, message: MethodMsg): Promise<void> {
+    const result = await this.methods.call(message.name, message.params);
+    this.ws.send(clientId, {
+      type: 'result',
+      id: message.id,
+      result,
+    });
+  }
+}

--- a/server/start.ts
+++ b/server/start.ts
@@ -3,6 +3,8 @@ import { MongoWrapper } from './infrastructure/mongo.ts';
 import { WebSocketWrapper } from './infrastructure/websocket.ts';
 import { FileStorageWrapper } from './infrastructure/fileStorage.ts';
 import { Publications } from './logic/publications.ts';
+import { RpcHandler } from './logic/rpcHandler.ts';
+import { Methods } from './logic/methods.ts';
 import { Files } from './logic/files.ts';
 
 // Real boot. The same pieces the end-to-end test wires by hand, wired here for a
@@ -15,6 +17,8 @@ const port = Number(process.env.PORT ?? 3001);
 const mongo = MongoWrapper.create(mongoUri);
 const ws = WebSocketWrapper.create();
 const storage = FileStorageWrapper.create(fileDir);
+const methods = new Methods();
+const rpcHandler = new RpcHandler(methods, ws);
 const publications = new Publications(mongo, ws);
 const files = new Files(mongo, storage);
 
@@ -36,7 +40,7 @@ try {
   console.warn('skipped seeding (is Mongo running?):', err instanceof Error ? err.message : err);
 }
 
-const server = await createServer({ ws, publications, files });
+const server = await createServer({ ws, publications, rpcHandler, files });
 await server.listen({ port, host: '0.0.0.0' });
 
 console.warn(`EkoLite listening on http://localhost:${String(port)} (ws at /ws)`);

--- a/tests/logic/rpcHandler.test.ts
+++ b/tests/logic/rpcHandler.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { Methods } from '../../server/logic/methods.ts';
+import { RpcHandler } from '../../server/logic/rpcHandler.ts';
+import { WebSocketWrapper } from '../../server/infrastructure/websocket.ts';
+
+describe('RpcHandler', () => {
+  it('runs a named method and sends the result back to the caller', async () => {
+    const ws = WebSocketWrapper.createNull();
+    const methods = new Methods();
+    methods.define('echo', (msg) => Promise.resolve(`echo: ${String(msg)}`));
+    const rpc = new RpcHandler(methods, ws);
+    const client = ws.simulateConnection();
+
+    await rpc.handleMessage(client.id, {
+      type: 'method',
+      id: 'm1',
+      name: 'echo',
+      params: ['hello'],
+    });
+
+    expect(client.messages).toContainEqual({
+      type: 'result',
+      id: 'm1',
+      result: 'echo: hello',
+    });
+  });
+});

--- a/tests/server/createServerRouting.test.ts
+++ b/tests/server/createServerRouting.test.ts
@@ -3,6 +3,8 @@ import { createServer } from '../../server/index.ts';
 import { WebSocketWrapper } from '../../server/infrastructure/websocket.ts';
 import { MongoWrapper } from '../../server/infrastructure/mongo.ts';
 import { Publications } from '../../server/logic/publications.ts';
+import { RpcHandler } from '../../server/logic/rpcHandler.ts';
+import { Methods } from '../../server/logic/methods.ts';
 
 // Tighter red for wires 2 and 3 only, with no real socket in sight. Everything is
 // nulled: a null ws lets us simulate a connection and an inbound subscribe, a null
@@ -39,6 +41,26 @@ describe('createServer routes inbound subscriptions into publications', () => {
           expect.objectContaining({ type: 'ready', id: 'sub1', collection: 'files' }),
         ]),
       );
+    });
+  });
+
+  it('routes method messages to the rpc handler and returns results to the same client', async () => {
+    const ws = WebSocketWrapper.createNull();
+    const methods = new Methods();
+    methods.define('echo', (msg) => Promise.resolve(`echo: ${String(msg)}`));
+    const rpcHandler = new RpcHandler(methods, ws);
+
+    await createServer({ ws, rpcHandler });
+
+    const client = ws.simulateConnection();
+    client.send({ type: 'method', id: 'm1', name: 'echo', params: ['hello'] });
+
+    await vi.waitFor(() => {
+      expect(client.messages).toContainEqual({
+        type: 'result',
+        id: 'm1',
+        result: 'echo: hello',
+      });
     });
   });
 });


### PR DESCRIPTION
### Summary

Implemented server side RPC handling for method calls over WebSocket.

### Changes
Added RpcHandler to process incoming method messages.
Connected method execution to the existing Methods registry.
Implemented RPC request/response flow:
Receives { type: 'method' } messages.
Executes the requested method with provided parameters.
Sends { type: 'result', id, result } back to the requesting client.
Preserves the original request id to allow client-side request matching.
Added routing logic in server/index.ts to dispatch messages based on message.type.
method → RpcHandler
subscribe / unsubscribe → Publications
Kept a single ws.onMessage entry point while separating handler responsibilities.
Added tests covering the successful RPC round-trip flow.

### Tested
Verified that a client can send a method message and receive the expected result response.
Verified that the response contains the same request id.
Verified message routing between RpcHandler and Publications.

### Notes
Error handling for missing methods or method execution failures is intentionally not included in this PR and will be addressed in 4.B.2.

https://linear.app/ekohacks/issue/EKO-217/4b1-route-method-call-and-return-result