### PR TITLE
Register an echo method so the live method round trip works

### DIFF
--- a/server/start.ts
+++ b/server/start.ts
@@ -26,6 +26,11 @@ const files = new Files(mongo, storage);
 // sync with the client as Mongo changes.
 publications.define('files.all', () => ({ collection: 'files', query: {} }));
 
+// One method to start with: echo bounces its argument straight back, so a live
+// call('echo', 'hello') comes back 'echo: hello'. It gives the method round trip
+// something real to hit, the way files.all does for subscriptions.
+methods.define('echo', (message) => Promise.resolve(`echo: ${String(message)}`));
+
 // Dev convenience: seed a couple of files so a fresh Mongo is not a blank page.
 // Idempotent (only seeds an empty collection) and best-effort (a missing Mongo
 // should not stop the server booting; subscriptions just come back empty).


### PR DESCRIPTION
### Summary

Registers an `echo` method in the live server boot so a method call from the browser has a real endpoint to reach. Until now the running server's `Methods` registry was empty, so any `call` over the websocket came back as a 404 even though the whole path was already wired.

### Background

The method call path was built across three stories: 4.A added the `Methods` registry, 4.B routed `{ type: 'method' }` messages into it and sent `result` or `error` back, and 4.C added the client `call()`. The plumbing was complete, but `server/start.ts` constructed `new Methods()` and never defined anything on it. So a live call reached `methods.call(name, …)`, found nothing, and the server replied `{ type: 'error', code: 404 }`. The loop passed in tests (which register their own methods) but had nothing to run in a real process.

This adds the first registered method, the same `echo` the method tests use, so the round trip can be exercised from end to end against the live server. It is the method equivalent of the `files.all` publication defined just above it: that gives subscriptions a live target, this gives method calls one.

### Changes

- `server/start.ts`: define an `echo` method that returns its argument, next to the existing `files.all` publication.

```ts
methods.define('echo', (message) => Promise.resolve(`echo: ${String(message)}`));
```

### Try it locally

Start the server in one terminal:

```bash
npm run dev:server   # listens on :3001, websocket at /ws
```

Then make a call any of these ways:

```bash
# Node 22+ (built-in WebSocket), no dependencies
node --input-type=module -e 'const ws=new WebSocket("ws://localhost:3001/ws");ws.onopen=()=>ws.send(JSON.stringify({type:"method",id:"1",name:"echo",params:["hello"]}));ws.onmessage=e=>{console.log(e.data);process.exit(0)};setTimeout(()=>process.exit(1),4000)'
```

```bash
# Interactive, by hand
npx wscat -c ws://localhost:3001/ws
> {"type":"method","id":"1","name":"echo","params":["hello"]}
< {"type":"result","id":"1","result":"echo: hello"}
```

```js
// In the browser console, the real client path
const ws = new WebSocket('ws://localhost:3001/ws');
ws.onmessage = (e) => console.log(e.data);
ws.onopen = () => ws.send(JSON.stringify({ type: 'method', id: '1', name: 'echo', params: ['hello'] }));
```

### Tested

- Typecheck clean.
- Verified the live round trip over a real websocket against the running server:

```
→ { "type": "method", "id": "1", "name": "echo", "params": ["hello"] }
← { "type": "result", "id": "1", "result": "echo: hello" }
```

- The failure path is unchanged and still correct: an unregistered name returns `{ "type": "error", "error": { "code": 404, "message": "Method not found: <name>" } }`. Swap `"name":"echo"` for `"name":"nope"` in any of the calls above to see it.

### Notes

- `echo` is a smoke test endpoint, not an application method. It exists so the method transport has something real to answer; product methods get defined as features need them.
- No new infrastructure. `RpcHandler` and the message routing were already in place, this only fills the registry.

### Not in this PR

Application methods, and any auth or rate limiting on method calls. This is just the first endpoint so the round trip is demonstrable in a running server.
