### PR TITLE
Eko 205/5c1 post apiupload route

### DIFF
--- a/client/uploader.ts
+++ b/client/uploader.ts
@@ -2,6 +2,12 @@ import { EventEmitter, OutputTracker } from '../server/infrastructure/outputTrac
 
 const REQUEST_EVENT = 'request';
 
+interface UploadRequest {
+  method: string;
+  url: string;
+  body: FormData;
+}
+
 interface UploadResponse {
   id: string;
   name: string;
@@ -104,22 +110,44 @@ export class Uploader {
   }
 
   async upload(file: File): Promise<UploadResponse> {
-    return new Promise((resolve, reject) => {
-      const form = new FormData();
-      form.append('file', file);
+    const request = this.buildRequest(file);
 
-      this.request.open('POST', '/api/files');
+    this.emitter.emit(REQUEST_EVENT, {
+      method: request.method,
+      url: request.url,
+    });
+
+    return this.execute(request);
+  }
+
+  private buildRequest(file: File): UploadRequest {
+    const body = new FormData();
+    body.append('file', file);
+
+    return {
+      method: 'POST',
+      url: '/api/files',
+      body,
+    };
+  }
+
+  private parseResponse(): UploadResponse {
+    const parsed: unknown = JSON.parse(this.request.responseText);
+
+    if (!isUploadResponse(parsed)) {
+      throw new Error('Invalid upload response');
+    }
+
+    return parsed;
+  }
+
+  private execute(request: UploadRequest): Promise<UploadResponse> {
+    return new Promise((resolve, reject) => {
+      this.request.open(request.method, request.url);
 
       this.request.onload = () => {
         if (this.request.status >= 200 && this.request.status < 300) {
-          const parsed: unknown = JSON.parse(this.request.responseText);
-
-          if (!isUploadResponse(parsed)) {
-            reject(new Error('Invalid upload response'));
-            return;
-          }
-
-          resolve(parsed);
+          resolve(this.parseResponse());
         } else {
           reject(new Error(`Upload failed (${String(this.request.status)})`));
         }
@@ -129,12 +157,7 @@ export class Uploader {
         reject(new Error('Upload failed'));
       };
 
-      this.request.send(form);
-
-      this.emitter.emit(REQUEST_EVENT, {
-        method: 'POST',
-        url: '/api/files',
-      });
+      this.request.send(request.body);
     });
   }
 

--- a/client/uploader.ts
+++ b/client/uploader.ts
@@ -1,0 +1,144 @@
+import { EventEmitter, OutputTracker } from '../server/infrastructure/outputTracker.ts';
+
+const REQUEST_EVENT = 'request';
+
+interface UploadResponse {
+  id: string;
+  name: string;
+}
+
+function isUploadResponse(data: unknown): data is UploadResponse {
+  if (typeof data !== 'object' || data === null) {
+    return false;
+  }
+
+  const response = data as Record<string, unknown>;
+
+  return typeof response.id === 'string' && typeof response.name === 'string';
+}
+
+interface NullUploaderOptions {
+  response: {
+    status: number;
+    body: UploadResponse;
+  };
+}
+
+interface RequestLike {
+  open(method: string, url: string): void;
+  send(body: FormData): void;
+
+  onload: (() => void) | null;
+  onerror: (() => void) | null;
+
+  status: number;
+  responseText: string;
+}
+
+class RealRequest implements RequestLike {
+  private readonly xhr = new XMLHttpRequest();
+
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor() {
+    this.xhr.onload = () => this.onload?.();
+    this.xhr.onerror = () => this.onerror?.();
+  }
+
+  open(method: string, url: string): void {
+    this.xhr.open(method, url);
+  }
+
+  send(body: FormData): void {
+    this.xhr.send(body);
+  }
+
+  get status(): number {
+    return this.xhr.status;
+  }
+
+  get responseText(): string {
+    return this.xhr.responseText;
+  }
+}
+
+class NullRequest implements RequestLike {
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  status: number;
+  responseText: string;
+
+  method = '';
+  url = '';
+
+  constructor(private readonly response: NullUploaderOptions['response']) {
+    this.status = response.status;
+    this.responseText = JSON.stringify(response.body);
+  }
+
+  open(method: string, url: string): void {
+    this.method = method;
+    this.url = url;
+  }
+
+  send(_body: FormData): void {
+    queueMicrotask(() => {
+      this.onload?.();
+    });
+  }
+}
+
+export class Uploader {
+  private readonly emitter = new EventEmitter();
+
+  private constructor(private readonly request: RequestLike) {}
+
+  static create(): Uploader {
+    return new Uploader(new RealRequest());
+  }
+
+  static createNull(options: NullUploaderOptions): Uploader {
+    return new Uploader(new NullRequest(options.response));
+  }
+
+  async upload(file: File): Promise<UploadResponse> {
+    return new Promise((resolve, reject) => {
+      const form = new FormData();
+      form.append('file', file);
+
+      this.request.open('POST', '/api/files');
+
+      this.request.onload = () => {
+        if (this.request.status >= 200 && this.request.status < 300) {
+          const parsed: unknown = JSON.parse(this.request.responseText);
+
+          if (!isUploadResponse(parsed)) {
+            reject(new Error('Invalid upload response'));
+            return;
+          }
+
+          resolve(parsed);
+        } else {
+          reject(new Error(`Upload failed (${String(this.request.status)})`));
+        }
+      };
+
+      this.request.onerror = () => {
+        reject(new Error('Upload failed'));
+      };
+
+      this.request.send(form);
+
+      this.emitter.emit(REQUEST_EVENT, {
+        method: 'POST',
+        url: '/api/files',
+      });
+    });
+  }
+
+  trackRequests(): OutputTracker {
+    return new OutputTracker(this.emitter, REQUEST_EVENT);
+  }
+}

--- a/client/uploader.ts
+++ b/client/uploader.ts
@@ -73,7 +73,7 @@ class NullRequest implements RequestLike {
   method = '';
   url = '';
 
-  constructor(private readonly response: NullUploaderOptions['response']) {
+  constructor(response: NullUploaderOptions['response']) {
     this.status = response.status;
     this.responseText = JSON.stringify(response.body);
   }

--- a/client/uploader.ts
+++ b/client/uploader.ts
@@ -26,7 +26,7 @@ function isUploadResponse(data: unknown): data is UploadResponse {
 interface NullUploaderOptions {
   response: {
     status: number;
-    body: UploadResponse;
+    body: unknown;
   };
 }
 
@@ -40,6 +40,8 @@ interface RequestLike {
   status: number;
   responseText: string;
 }
+
+type RequestFactory = () => RequestLike;
 
 class RealRequest implements RequestLike {
   private readonly xhr = new XMLHttpRequest();
@@ -99,14 +101,14 @@ class NullRequest implements RequestLike {
 export class Uploader {
   private readonly emitter = new EventEmitter();
 
-  private constructor(private readonly request: RequestLike) {}
+  private constructor(private readonly createRequest: RequestFactory) {}
 
   static create(): Uploader {
-    return new Uploader(new RealRequest());
+    return new Uploader(() => new RealRequest());
   }
 
   static createNull(options: NullUploaderOptions): Uploader {
-    return new Uploader(new NullRequest(options.response));
+    return new Uploader(() => new NullRequest(options.response));
   }
 
   async upload(file: File): Promise<UploadResponse> {
@@ -115,6 +117,7 @@ export class Uploader {
     this.emitter.emit(REQUEST_EVENT, {
       method: request.method,
       url: request.url,
+      filename: file.name,
     });
 
     return this.execute(request);
@@ -131,8 +134,8 @@ export class Uploader {
     };
   }
 
-  private parseResponse(): UploadResponse {
-    const parsed: unknown = JSON.parse(this.request.responseText);
+  private parseResponse(request: RequestLike): UploadResponse {
+    const parsed: unknown = JSON.parse(request.responseText);
 
     if (!isUploadResponse(parsed)) {
       throw new Error('Invalid upload response');
@@ -141,23 +144,29 @@ export class Uploader {
     return parsed;
   }
 
-  private execute(request: UploadRequest): Promise<UploadResponse> {
-    return new Promise((resolve, reject) => {
-      this.request.open(request.method, request.url);
+  private execute(upload: UploadRequest): Promise<UploadResponse> {
+    const request = this.createRequest();
 
-      this.request.onload = () => {
-        if (this.request.status >= 200 && this.request.status < 300) {
-          resolve(this.parseResponse());
+    return new Promise((resolve, reject) => {
+      request.open(upload.method, upload.url);
+
+      request.onload = () => {
+        if (request.status >= 200 && request.status < 300) {
+          try {
+            resolve(this.parseResponse(request));
+          } catch (error) {
+            reject(error instanceof Error ? error : new Error(String(error)));
+          }
         } else {
-          reject(new Error(`Upload failed (${String(this.request.status)})`));
+          reject(new Error(`Upload failed (${String(request.status)})`));
         }
       };
 
-      this.request.onerror = () => {
+      request.onerror = () => {
         reject(new Error('Upload failed'));
       };
 
-      this.request.send(request.body);
+      request.send(upload.body);
     });
   }
 

--- a/tests/client/uploader.test.ts
+++ b/tests/client/uploader.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+describe('Uploader (null)', () => {
+    it.fails('sends the bytes and resolves with what server stored', async () => {
+        const uploader = Uploader.createNull({
+            response: { status: 201, body: { id: 'f1', name: 'sample.bam' } },
+        });
+        const requests = uploader.trackRequests();
+
+        const bam = new File([Buffer.from('BAMDATA')], 'sample.bam');
+        const stored = await uploader.upload(bam);
+
+        expect(requests.data).toContainEqual(
+        expect.objectContaining({ method: 'POST', url: '/api/files' }),
+        );
+        expect(stored).toEqual({ id: 'f1', name: 'sample.bam' });
+
+    })
+})

--- a/tests/client/uploader.test.ts
+++ b/tests/client/uploader.test.ts
@@ -16,4 +16,46 @@ describe('Uploader (null)', () => {
     );
     expect(stored).toEqual({ id: 'f1', name: 'sample.bam' });
   });
+
+  it('completes every upload when two run concurrently', async () => {
+    const uploader = Uploader.createNull({
+      response: { status: 201, body: { id: 'f1', name: 'sample.bam' } },
+    });
+    const requests = uploader.trackRequests();
+
+    const first = uploader.upload(new File([Buffer.from('A')], 'a.bam'));
+    const second = uploader.upload(new File([Buffer.from('B')], 'b.bam'));
+
+    const [a, b] = await Promise.all([first, second]);
+
+    expect(a).toEqual({ id: 'f1', name: 'sample.bam' });
+    expect(b).toEqual({ id: 'f1', name: 'sample.bam' });
+    expect(requests.data).toHaveLength(2);
+  }, 2000);
+
+  it('records which file went out, not just the route', async () => {
+    const uploader = Uploader.createNull({
+      response: { status: 201, body: { id: 'f1', name: 'sample.bam' } },
+    });
+    const requests = uploader.trackRequests();
+
+    await uploader.upload(new File([Buffer.from('BAMDATA')], 'sample.bam'));
+
+    expect(requests.data).toContainEqual(
+      expect.objectContaining({ method: 'POST', url: '/api/files', filename: 'sample.bam' }),
+    );
+  });
+
+  it('rejects, rather than hanging, when a 2xx body is the wrong shape', async () => {
+    const uploader = Uploader.createNull({
+      response: {
+        status: 201,
+        body: { wrong: 'shape' } as unknown as { id: string; name: string },
+      },
+    });
+
+    await expect(uploader.upload(new File([Buffer.from('x')], 'x.bam'))).rejects.toThrow(
+      'Invalid upload response',
+    );
+  }, 2000);
 });

--- a/tests/client/uploader.test.ts
+++ b/tests/client/uploader.test.ts
@@ -1,19 +1,19 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from 'vitest';
+import { Uploader } from '../../client/uploader.ts';
 
 describe('Uploader (null)', () => {
-    it.fails('sends the bytes and resolves with what server stored', async () => {
-        const uploader = Uploader.createNull({
-            response: { status: 201, body: { id: 'f1', name: 'sample.bam' } },
-        });
-        const requests = uploader.trackRequests();
+  it('sends the bytes and resolves with what server stored', async () => {
+    const uploader = Uploader.createNull({
+      response: { status: 201, body: { id: 'f1', name: 'sample.bam' } },
+    });
+    const requests = uploader.trackRequests();
 
-        const bam = new File([Buffer.from('BAMDATA')], 'sample.bam');
-        const stored = await uploader.upload(bam);
+    const bam = new File([Buffer.from('BAMDATA')], 'sample.bam');
+    const stored = await uploader.upload(bam);
 
-        expect(requests.data).toContainEqual(
-        expect.objectContaining({ method: 'POST', url: '/api/files' }),
-        );
-        expect(stored).toEqual({ id: 'f1', name: 'sample.bam' });
-
-    })
-})
+    expect(requests.data).toContainEqual(
+      expect.objectContaining({ method: 'POST', url: '/api/files' }),
+    );
+    expect(stored).toEqual({ id: 'f1', name: 'sample.bam' });
+  });
+});

--- a/tests/client/uploader.test.ts
+++ b/tests/client/uploader.test.ts
@@ -50,7 +50,7 @@ describe('Uploader (null)', () => {
     const uploader = Uploader.createNull({
       response: {
         status: 201,
-        body: { wrong: 'shape' } as unknown as { id: string; name: string },
+        body: { wrong: 'shape' },
       },
     });
 


### PR DESCRIPTION
## Summary

Adds a reusable `Uploader` client for file uploads backed by `XMLHttpRequest`.

The uploader exposes an `upload(file)` API that submits a file as multipart form data to `POST /api/files` and resolves with the stored file metadata (`{ id, name }`) on successful responses. It follows the existing nullable infrastructure pattern by providing `create()` for the real transport and `createNull()` for a stubbed transport used in tests.

The null implementation records outgoing upload requests and returns a configurable response, allowing the upload flow to be exercised without making network requests. The upload logic was also separated from the transport implementation to provide a seam for future upload progress and error handling.

## Tests

Added `tests/client/uploader.test.ts` to verify that:

* `upload(file)` sends a `POST` request to `/api/files`.
* The upload request is recorded by the null transport.
* A successful upload resolves with the server's `{ id, name }` response.
* The upload flow is exercised entirely through the null transport without performing network requests.


https://linear.app/ekohacks/issue/EKO-205/5c1-post-apiupload-route
