### PR TITLE
Eko 204/5c2 route returns 400 for invalid files

### DIFF
--- a/client/uploader.ts
+++ b/client/uploader.ts
@@ -1,17 +1,8 @@
 import { EventEmitter, OutputTracker } from '../server/infrastructure/outputTracker.ts';
 import { EkoLiteError } from '../shared/protocol.ts';
+import { RpcError } from '../shared/types.ts';
 
 const REQUEST_EVENT = 'request';
-
-class UploadErrorResponse extends Error implements EkoLiteError {
-  constructor(
-    public readonly code: number,
-    message: string,
-  ) {
-    super(message);
-    this.name = 'UploadError';
-  }
-}
 
 function isUploadError(data: unknown): data is EkoLiteError {
   if (typeof data !== 'object' || data === null) {
@@ -170,7 +161,7 @@ export class Uploader {
       throw new Error('Invalid upload error');
     }
 
-    throw new UploadErrorResponse(parsed.code, parsed.message);
+    throw new RpcError(parsed.code, parsed.message);
   }
 
   private execute(upload: UploadRequest): Promise<UploadResponse> {

--- a/client/uploader.ts
+++ b/client/uploader.ts
@@ -2,6 +2,12 @@ import { EventEmitter, OutputTracker } from '../server/infrastructure/outputTrac
 
 const REQUEST_EVENT = 'request';
 
+interface UploadRequest {
+  method: string;
+  url: string;
+  body: FormData;
+}
+
 interface UploadResponse {
   id: string;
   name: string;
@@ -104,22 +110,44 @@ export class Uploader {
   }
 
   async upload(file: File): Promise<UploadResponse> {
-    return new Promise((resolve, reject) => {
-      const form = new FormData();
-      form.append('file', file);
+    const request = this.buildRequest(file);
 
-      this.request.open('POST', '/api/files');
+    this.emitter.emit(REQUEST_EVENT, {
+      method: request.method,
+      url: request.url,
+    });
+
+    return this.execute(request);
+  }
+
+  private buildRequest(file: File): UploadRequest {
+    const body = new FormData();
+    body.append('file', file);
+
+    return {
+      method: 'POST',
+      url: '/api/files',
+      body,
+    };
+  }
+
+  private parseResponse(): UploadResponse {
+    const parsed: unknown = JSON.parse(this.request.responseText);
+
+    if (!isUploadResponse(parsed)) {
+      throw new Error('Invalid upload response');
+    }
+
+    return parsed;
+  }
+
+  private execute(request: UploadRequest): Promise<UploadResponse> {
+    return new Promise((resolve, reject) => {
+      this.request.open(request.method, request.url);
 
       this.request.onload = () => {
         if (this.request.status >= 200 && this.request.status < 300) {
-          const parsed: unknown = JSON.parse(this.request.responseText);
-
-          if (!isUploadResponse(parsed)) {
-            reject(new Error('Invalid upload response'));
-            return;
-          }
-
-          resolve(parsed);
+          resolve(this.parseResponse());
         } else {
           reject(new Error(`Upload failed (${String(this.request.status)})`));
         }
@@ -129,12 +157,7 @@ export class Uploader {
         reject(new Error('Upload failed'));
       };
 
-      this.request.send(form);
-
-      this.emitter.emit(REQUEST_EVENT, {
-        method: 'POST',
-        url: '/api/files',
-      });
+      this.request.send(request.body);
     });
   }
 

--- a/client/uploader.ts
+++ b/client/uploader.ts
@@ -1,0 +1,144 @@
+import { EventEmitter, OutputTracker } from '../server/infrastructure/outputTracker.ts';
+
+const REQUEST_EVENT = 'request';
+
+interface UploadResponse {
+  id: string;
+  name: string;
+}
+
+function isUploadResponse(data: unknown): data is UploadResponse {
+  if (typeof data !== 'object' || data === null) {
+    return false;
+  }
+
+  const response = data as Record<string, unknown>;
+
+  return typeof response.id === 'string' && typeof response.name === 'string';
+}
+
+interface NullUploaderOptions {
+  response: {
+    status: number;
+    body: UploadResponse;
+  };
+}
+
+interface RequestLike {
+  open(method: string, url: string): void;
+  send(body: FormData): void;
+
+  onload: (() => void) | null;
+  onerror: (() => void) | null;
+
+  status: number;
+  responseText: string;
+}
+
+class RealRequest implements RequestLike {
+  private readonly xhr = new XMLHttpRequest();
+
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor() {
+    this.xhr.onload = () => this.onload?.();
+    this.xhr.onerror = () => this.onerror?.();
+  }
+
+  open(method: string, url: string): void {
+    this.xhr.open(method, url);
+  }
+
+  send(body: FormData): void {
+    this.xhr.send(body);
+  }
+
+  get status(): number {
+    return this.xhr.status;
+  }
+
+  get responseText(): string {
+    return this.xhr.responseText;
+  }
+}
+
+class NullRequest implements RequestLike {
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  status: number;
+  responseText: string;
+
+  method = '';
+  url = '';
+
+  constructor(private readonly response: NullUploaderOptions['response']) {
+    this.status = response.status;
+    this.responseText = JSON.stringify(response.body);
+  }
+
+  open(method: string, url: string): void {
+    this.method = method;
+    this.url = url;
+  }
+
+  send(_body: FormData): void {
+    queueMicrotask(() => {
+      this.onload?.();
+    });
+  }
+}
+
+export class Uploader {
+  private readonly emitter = new EventEmitter();
+
+  private constructor(private readonly request: RequestLike) {}
+
+  static create(): Uploader {
+    return new Uploader(new RealRequest());
+  }
+
+  static createNull(options: NullUploaderOptions): Uploader {
+    return new Uploader(new NullRequest(options.response));
+  }
+
+  async upload(file: File): Promise<UploadResponse> {
+    return new Promise((resolve, reject) => {
+      const form = new FormData();
+      form.append('file', file);
+
+      this.request.open('POST', '/api/files');
+
+      this.request.onload = () => {
+        if (this.request.status >= 200 && this.request.status < 300) {
+          const parsed: unknown = JSON.parse(this.request.responseText);
+
+          if (!isUploadResponse(parsed)) {
+            reject(new Error('Invalid upload response'));
+            return;
+          }
+
+          resolve(parsed);
+        } else {
+          reject(new Error(`Upload failed (${String(this.request.status)})`));
+        }
+      };
+
+      this.request.onerror = () => {
+        reject(new Error('Upload failed'));
+      };
+
+      this.request.send(form);
+
+      this.emitter.emit(REQUEST_EVENT, {
+        method: 'POST',
+        url: '/api/files',
+      });
+    });
+  }
+
+  trackRequests(): OutputTracker {
+    return new OutputTracker(this.emitter, REQUEST_EVENT);
+  }
+}

--- a/client/uploader.ts
+++ b/client/uploader.ts
@@ -73,7 +73,7 @@ class NullRequest implements RequestLike {
   method = '';
   url = '';
 
-  constructor(private readonly response: NullUploaderOptions['response']) {
+  constructor(response: NullUploaderOptions['response']) {
     this.status = response.status;
     this.responseText = JSON.stringify(response.body);
   }

--- a/client/uploader.ts
+++ b/client/uploader.ts
@@ -26,7 +26,7 @@ function isUploadResponse(data: unknown): data is UploadResponse {
 interface NullUploaderOptions {
   response: {
     status: number;
-    body: UploadResponse;
+    body: unknown;
   };
 }
 
@@ -40,6 +40,8 @@ interface RequestLike {
   status: number;
   responseText: string;
 }
+
+type RequestFactory = () => RequestLike;
 
 class RealRequest implements RequestLike {
   private readonly xhr = new XMLHttpRequest();
@@ -99,14 +101,14 @@ class NullRequest implements RequestLike {
 export class Uploader {
   private readonly emitter = new EventEmitter();
 
-  private constructor(private readonly request: RequestLike) {}
+  private constructor(private readonly createRequest: RequestFactory) {}
 
   static create(): Uploader {
-    return new Uploader(new RealRequest());
+    return new Uploader(() => new RealRequest());
   }
 
   static createNull(options: NullUploaderOptions): Uploader {
-    return new Uploader(new NullRequest(options.response));
+    return new Uploader(() => new NullRequest(options.response));
   }
 
   async upload(file: File): Promise<UploadResponse> {
@@ -115,6 +117,7 @@ export class Uploader {
     this.emitter.emit(REQUEST_EVENT, {
       method: request.method,
       url: request.url,
+      filename: file.name,
     });
 
     return this.execute(request);
@@ -131,8 +134,8 @@ export class Uploader {
     };
   }
 
-  private parseResponse(): UploadResponse {
-    const parsed: unknown = JSON.parse(this.request.responseText);
+  private parseResponse(request: RequestLike): UploadResponse {
+    const parsed: unknown = JSON.parse(request.responseText);
 
     if (!isUploadResponse(parsed)) {
       throw new Error('Invalid upload response');
@@ -141,23 +144,29 @@ export class Uploader {
     return parsed;
   }
 
-  private execute(request: UploadRequest): Promise<UploadResponse> {
-    return new Promise((resolve, reject) => {
-      this.request.open(request.method, request.url);
+  private execute(upload: UploadRequest): Promise<UploadResponse> {
+    const request = this.createRequest();
 
-      this.request.onload = () => {
-        if (this.request.status >= 200 && this.request.status < 300) {
-          resolve(this.parseResponse());
+    return new Promise((resolve, reject) => {
+      request.open(upload.method, upload.url);
+
+      request.onload = () => {
+        if (request.status >= 200 && request.status < 300) {
+          try {
+            resolve(this.parseResponse(request));
+          } catch (error) {
+            reject(error instanceof Error ? error : new Error(String(error)));
+          }
         } else {
-          reject(new Error(`Upload failed (${String(this.request.status)})`));
+          reject(new Error(`Upload failed (${String(request.status)})`));
         }
       };
 
-      this.request.onerror = () => {
+      request.onerror = () => {
         reject(new Error('Upload failed'));
       };
 
-      this.request.send(request.body);
+      request.send(upload.body);
     });
   }
 

--- a/client/uploader.ts
+++ b/client/uploader.ts
@@ -1,6 +1,27 @@
 import { EventEmitter, OutputTracker } from '../server/infrastructure/outputTracker.ts';
+import { EkoLiteError } from '../shared/protocol.ts';
 
 const REQUEST_EVENT = 'request';
+
+class UploadErrorResponse extends Error implements EkoLiteError {
+  constructor(
+    public readonly code: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'UploadError';
+  }
+}
+
+function isUploadError(data: unknown): data is EkoLiteError {
+  if (typeof data !== 'object' || data === null) {
+    return false;
+  }
+
+  const error = data as Record<string, unknown>;
+
+  return typeof error.code === 'number' && typeof error.message === 'string';
+}
 
 interface UploadRequest {
   method: string;
@@ -134,14 +155,22 @@ export class Uploader {
     };
   }
 
-  private parseResponse(request: RequestLike): UploadResponse {
+  private resolveUpload(request: RequestLike): UploadResponse {
     const parsed: unknown = JSON.parse(request.responseText);
 
-    if (!isUploadResponse(parsed)) {
-      throw new Error('Invalid upload response');
+    if (request.status >= 200 && request.status < 300) {
+      if (!isUploadResponse(parsed)) {
+        throw new Error('Invalid upload response');
+      }
+
+      return parsed;
     }
 
-    return parsed;
+    if (!isUploadError(parsed)) {
+      throw new Error('Invalid upload error');
+    }
+
+    throw new UploadErrorResponse(parsed.code, parsed.message);
   }
 
   private execute(upload: UploadRequest): Promise<UploadResponse> {
@@ -151,14 +180,10 @@ export class Uploader {
       request.open(upload.method, upload.url);
 
       request.onload = () => {
-        if (request.status >= 200 && request.status < 300) {
-          try {
-            resolve(this.parseResponse(request));
-          } catch (error) {
-            reject(error instanceof Error ? error : new Error(String(error)));
-          }
-        } else {
-          reject(new Error(`Upload failed (${String(request.status)})`));
+        try {
+          resolve(this.resolveUpload(request));
+        } catch (error) {
+          reject(error instanceof Error ? error : new Error(String(error)));
         }
       };
 

--- a/tests/client/uploader.test.ts
+++ b/tests/client/uploader.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+describe('Uploader (null)', () => {
+    it.fails('sends the bytes and resolves with what server stored', async () => {
+        const uploader = Uploader.createNull({
+            response: { status: 201, body: { id: 'f1', name: 'sample.bam' } },
+        });
+        const requests = uploader.trackRequests();
+
+        const bam = new File([Buffer.from('BAMDATA')], 'sample.bam');
+        const stored = await uploader.upload(bam);
+
+        expect(requests.data).toContainEqual(
+        expect.objectContaining({ method: 'POST', url: '/api/files' }),
+        );
+        expect(stored).toEqual({ id: 'f1', name: 'sample.bam' });
+
+    })
+})

--- a/tests/client/uploader.test.ts
+++ b/tests/client/uploader.test.ts
@@ -16,4 +16,46 @@ describe('Uploader (null)', () => {
     );
     expect(stored).toEqual({ id: 'f1', name: 'sample.bam' });
   });
+
+  it('completes every upload when two run concurrently', async () => {
+    const uploader = Uploader.createNull({
+      response: { status: 201, body: { id: 'f1', name: 'sample.bam' } },
+    });
+    const requests = uploader.trackRequests();
+
+    const first = uploader.upload(new File([Buffer.from('A')], 'a.bam'));
+    const second = uploader.upload(new File([Buffer.from('B')], 'b.bam'));
+
+    const [a, b] = await Promise.all([first, second]);
+
+    expect(a).toEqual({ id: 'f1', name: 'sample.bam' });
+    expect(b).toEqual({ id: 'f1', name: 'sample.bam' });
+    expect(requests.data).toHaveLength(2);
+  }, 2000);
+
+  it('records which file went out, not just the route', async () => {
+    const uploader = Uploader.createNull({
+      response: { status: 201, body: { id: 'f1', name: 'sample.bam' } },
+    });
+    const requests = uploader.trackRequests();
+
+    await uploader.upload(new File([Buffer.from('BAMDATA')], 'sample.bam'));
+
+    expect(requests.data).toContainEqual(
+      expect.objectContaining({ method: 'POST', url: '/api/files', filename: 'sample.bam' }),
+    );
+  });
+
+  it('rejects, rather than hanging, when a 2xx body is the wrong shape', async () => {
+    const uploader = Uploader.createNull({
+      response: {
+        status: 201,
+        body: { wrong: 'shape' } as unknown as { id: string; name: string },
+      },
+    });
+
+    await expect(uploader.upload(new File([Buffer.from('x')], 'x.bam'))).rejects.toThrow(
+      'Invalid upload response',
+    );
+  }, 2000);
 });

--- a/tests/client/uploader.test.ts
+++ b/tests/client/uploader.test.ts
@@ -1,19 +1,19 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from 'vitest';
+import { Uploader } from '../../client/uploader.ts';
 
 describe('Uploader (null)', () => {
-    it.fails('sends the bytes and resolves with what server stored', async () => {
-        const uploader = Uploader.createNull({
-            response: { status: 201, body: { id: 'f1', name: 'sample.bam' } },
-        });
-        const requests = uploader.trackRequests();
+  it('sends the bytes and resolves with what server stored', async () => {
+    const uploader = Uploader.createNull({
+      response: { status: 201, body: { id: 'f1', name: 'sample.bam' } },
+    });
+    const requests = uploader.trackRequests();
 
-        const bam = new File([Buffer.from('BAMDATA')], 'sample.bam');
-        const stored = await uploader.upload(bam);
+    const bam = new File([Buffer.from('BAMDATA')], 'sample.bam');
+    const stored = await uploader.upload(bam);
 
-        expect(requests.data).toContainEqual(
-        expect.objectContaining({ method: 'POST', url: '/api/files' }),
-        );
-        expect(stored).toEqual({ id: 'f1', name: 'sample.bam' });
-
-    })
-})
+    expect(requests.data).toContainEqual(
+      expect.objectContaining({ method: 'POST', url: '/api/files' }),
+    );
+    expect(stored).toEqual({ id: 'f1', name: 'sample.bam' });
+  });
+});

--- a/tests/client/uploader.test.ts
+++ b/tests/client/uploader.test.ts
@@ -50,7 +50,7 @@ describe('Uploader (null)', () => {
     const uploader = Uploader.createNull({
       response: {
         status: 201,
-        body: { wrong: 'shape' } as unknown as { id: string; name: string },
+        body: { wrong: 'shape' },
       },
     });
 

--- a/tests/client/uploader.test.ts
+++ b/tests/client/uploader.test.ts
@@ -16,4 +16,17 @@ describe('Uploader (null)', () => {
     );
     expect(stored).toEqual({ id: 'f1', name: 'sample.bam' });
   });
+
+  it('rejects with server error when the upload is refused', async () => {
+    const uploader = Uploader.createNull({
+      response: { status: 400, body: { code: 400, message: 'Unsupported file type: .txt' } },
+    });
+
+    const bad = new File([Buffer.from('notes')], 'bad.txt');
+
+    await expect(uploader.upload(bad)).rejects.toMatchObject({
+      code: 400,
+      message: 'Unsupported file type: .txt',
+    });
+  });
 });

--- a/tests/client/uploader.test.ts
+++ b/tests/client/uploader.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { Uploader } from '../../client/uploader.ts';
+import { RpcError } from '../../shared/types.ts';
 
 describe('Uploader (null)', () => {
   it('sends the bytes and resolves with what server stored', async () => {
@@ -28,6 +29,16 @@ describe('Uploader (null)', () => {
       code: 400,
       message: 'Unsupported file type: .txt',
     });
+  });
+
+  it('rejects with the shared RpcError the rest of the app already uses', async () => {
+    const uploader = Uploader.createNull({
+      response: { status: 400, body: { code: 400, message: 'Unsupported file type: .txt' } },
+    });
+
+    await expect(
+      uploader.upload(new File([Buffer.from('notes')], 'bad.txt')),
+    ).rejects.toBeInstanceOf(RpcError);
   });
 
   it('completes every upload when two run concurrently', async () => {


### PR DESCRIPTION
## Summary

This PR adds client side handling for failed file uploads by ensuring `Uploader.upload()` rejects with the server's error response instead of resolving successfully. The uploader now exposes the same `EkoLiteError` shape used by the socket client, allowing consumers to handle upload errors and RPC method errors consistently.

## What changed

### Error handling

* Updated the upload flow to inspect the HTTP response status after every upload.
* Successful (`2xx`) responses continue to resolve with the parsed upload response (`{ id, name }`).
* Non successful responses now parse the server's error body and reject the promise with the shared `EkoLiteError` shape (`{ code, message }`).

### Response handling refactor

* Refactored the upload completion logic so the success or failure decision is made in a single place after reading the response status.
* Removed the previous upload specific error type in favour of the shared error contract already used by the socket client.
* This keeps error handling consistent across different client transports and provides a single way for consumers to handle failures.

### Null uploader

* Updated the null uploader so it can simulate both successful and failed server responses.
* The response body is now typed as `unknown`, allowing tests to provide either a successful upload response or an error response without relying on the network.

## Tests

Added tests covering the upload error path.

### Successful upload

Verified that:

* `Uploader.createNull()` returns the configured successful response.
* `upload()` resolves with the stored file information.
* The request tracker records the outgoing upload request.

### Failed upload

Added a test to verify that when the server returns:

```ts
{
  status: 400,
  body: {
    code: 400,
    message: "Unsupported file type: .txt",
  },
}
```

* `upload()` rejects instead of resolving.
* The rejected value matches the shared `EkoLiteError` shape.
* The error contains the server supplied `code` and `message`.

https://linear.app/ekohacks/issue/EKO-204/5c2-route-returns-400-for-invalid-files