### PR TITLE
Eko 287/5a3 socket client should reject rpc errors as rpcerror not bare wire

### DIFF
--- a/client/connectionManager.ts
+++ b/client/connectionManager.ts
@@ -292,7 +292,7 @@ export class ConnectionManager {
         const subscription = this.subscriptions.get(message.id);
 
         if (subscription) {
-          subscription.readyRejector(message.error);
+          subscription.readyRejector(new RpcError(message.error.code, message.error.message));
           this.subscriptions.delete(message.id);
         }
         break;

--- a/client/connectionManager.ts
+++ b/client/connectionManager.ts
@@ -8,6 +8,7 @@ import {
   UnsubscribeMsg,
 } from '../shared/protocol.ts';
 import { assertNever } from '../shared/helperFunctions.ts';
+import { RpcError } from '../shared/types.ts';
 
 export interface SubscriptionHandle {
   stop(): void;
@@ -283,7 +284,7 @@ export class ConnectionManager {
         const request = this.pendingRequests.get(message.id);
 
         if (request) {
-          request.reject(message.error);
+          request.reject(new RpcError(message.error.code, message.error.message));
           this.pendingRequests.delete(message.id);
           break;
         }

--- a/tests/client/connectionManager.call.test.ts
+++ b/tests/client/connectionManager.call.test.ts
@@ -41,7 +41,7 @@ describe('ClientSocketWrapper call', () => {
       },
     });
 
-    await expect(result).rejects.toEqual({
+    await expect(result).rejects.toMatchObject({
       code: 404,
       message: 'Method not found: nope',
     });

--- a/tests/client/connectionManager.call.test.ts
+++ b/tests/client/connectionManager.call.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { ClientSocketWrapper } from '../../client/clientSocket.ts';
 import { ConnectionManager } from '../../client/connectionManager.ts';
 import { MethodMsg } from '../../shared/protocol.ts';
+import { RpcError } from '../../shared/types.ts';
 
 describe('ClientSocketWrapper call', () => {
   it('sends method message to the server when connectionManager.call is used', async () => {
@@ -73,5 +74,32 @@ describe('ClientSocketWrapper call', () => {
     ]);
 
     expect(outcome).toBe('rejected');
+  });
+
+  it('rejects method calls with RpcError preserving the server error', async () => {
+    const socket = ClientSocketWrapper.createNull();
+    const server = socket.simulateServer();
+    const manager = new ConnectionManager(socket);
+    const messages = socket.trackMessages();
+
+    const call = manager.call('missingMethod');
+
+    const sent = messages.data[0] as MethodMsg;
+
+    server.send({
+      type: 'error',
+      id: sent.id,
+      error: {
+        code: 404,
+        message: 'Method not found: missingMethod',
+      },
+    });
+
+    await expect(call).rejects.toMatchObject({
+      code: 404,
+      message: 'Method not found: missingMethod',
+    });
+
+    await expect(call).rejects.toBeInstanceOf(RpcError);
   });
 });

--- a/tests/client/connectionManager.test.ts
+++ b/tests/client/connectionManager.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { ClientSocketWrapper } from '../../client/clientSocket.ts';
 import { ConnectionManager } from '../../client/connectionManager.ts';
 import { SubscribeMsg } from '../../shared/protocol.ts';
+import { RpcError } from '../../shared/types.ts';
 
 describe('ConnectionManager', () => {
   it('subscribe sends a subscribe message and routes added documents into the store', async () => {
@@ -69,6 +70,28 @@ describe('ConnectionManager', () => {
     });
 
     await expect(handle.ready).rejects.toMatchObject({ code: 404 });
+  });
+
+  it('rejects ready with an RpcError preserving the server error', async () => {
+    const socket = ClientSocketWrapper.createNull();
+    const server = socket.simulateServer();
+    const manager = new ConnectionManager(socket);
+    const messages = socket.trackMessages();
+
+    const handle = manager.subscribe('nope');
+    const sent = messages.data[0] as SubscribeMsg;
+
+    server.send({
+      type: 'error',
+      id: sent.id,
+      error: { code: 404, message: 'Unknown publication' },
+    });
+
+    await expect(handle.ready).rejects.toMatchObject({
+      code: 404,
+      message: 'Unknown publication',
+    });
+    await expect(handle.ready).rejects.toBeInstanceOf(RpcError);
   });
 
   it('handle.stop sends an unsubscribe to the server', async () => {


### PR DESCRIPTION
## Summary

This PR updates the socket client to use the shared `RpcError` type for RPC failures instead of rejecting with the raw `{ code, message }` object returned by the server.

The uploader already rehydrates server errors into `RpcError`, so this change brings the socket client in line with that behaviour and gives callers a consistent error type across the app.

## Changes

* Removed the inconsistency where uploads rejected with `RpcError` but socket method calls rejected with a plain object.
* Preserved the server's original error code and message when reconstructing the error.
* Changed the test 'rejects a pending call when an error reply arrives' to expect a matching object and not the exact object.

## Tests

Added a test covering the RPC error path to verify that:

* a failed method call rejects with a `RpcError`

https://linear.app/ekohacks/issue/EKO-287/5a3-socket-client-should-reject-rpc-errors-as-rpcerror-not-bare-wire
