### PR TITLE
Eko 202/5d1 report upload progress

### DIFF
--- a/client/uploader.ts
+++ b/client/uploader.ts
@@ -55,11 +55,7 @@ interface NullUploaderOptions {
     body: unknown;
   };
 
-  progress?: {
-    loaded: number;
-    total: number;
-    lengthComputable?: boolean;
-  }[];
+  progress?: ProgressEventLike[];
 }
 
 interface RequestLike {
@@ -126,7 +122,7 @@ class NullRequest implements RequestLike {
 
   constructor(
     response: NullUploaderOptions['response'],
-    private readonly progress: NullUploaderOptions['progress'] = [],
+    private readonly progress: ProgressEventLike[] = [],
   ) {
     this.status = response.status;
     this.responseText = JSON.stringify(response.body);
@@ -139,14 +135,12 @@ class NullRequest implements RequestLike {
 
   send(_body: FormData): void {
     queueMicrotask(() => {
-      if (this.progress) {
-        for (const step of this.progress) {
-          this.onprogress?.({
-            loaded: step.loaded,
-            total: step.total,
-            lengthComputable: step.lengthComputable ?? true,
-          });
-        }
+      for (const step of this.progress) {
+        this.onprogress?.({
+          loaded: step.loaded,
+          total: step.total,
+          lengthComputable: step.lengthComputable ?? true,
+        });
       }
 
       this.onload?.();

--- a/client/uploader.ts
+++ b/client/uploader.ts
@@ -246,7 +246,7 @@ export class Uploader {
     }
 
     return {
-      percent: Math.round((event.loaded / event.total) * 100),
+      percent: Math.min(100, Math.round((event.loaded / event.total) * 100)),
     };
   }
 

--- a/client/uploader.ts
+++ b/client/uploader.ts
@@ -14,6 +14,20 @@ function isUploadError(data: unknown): data is EkoLiteError {
   return typeof error.code === 'number' && typeof error.message === 'string';
 }
 
+interface UploadProgress {
+  percent: number;
+}
+
+interface UploadOptions {
+  onProgress?: (progress: UploadProgress) => void;
+}
+
+interface ProgressEventLike {
+  loaded: number;
+  total: number;
+  lengthComputable?: boolean;
+}
+
 interface UploadRequest {
   method: string;
   url: string;
@@ -40,6 +54,12 @@ interface NullUploaderOptions {
     status: number;
     body: unknown;
   };
+
+  progress?: {
+    loaded: number;
+    total: number;
+    lengthComputable?: boolean;
+  }[];
 }
 
 interface RequestLike {
@@ -48,6 +68,8 @@ interface RequestLike {
 
   onload: (() => void) | null;
   onerror: (() => void) | null;
+
+  onprogress: ((event: ProgressEventLike) => void) | null;
 
   status: number;
   responseText: string;
@@ -61,9 +83,18 @@ class RealRequest implements RequestLike {
   onload: (() => void) | null = null;
   onerror: (() => void) | null = null;
 
+  onprogress: ((event: ProgressEventLike) => void) | null = null;
+
   constructor() {
     this.xhr.onload = () => this.onload?.();
     this.xhr.onerror = () => this.onerror?.();
+    this.xhr.upload.onprogress = (event) => {
+      this.onprogress?.({
+        loaded: event.loaded,
+        total: event.total,
+        lengthComputable: event.lengthComputable,
+      });
+    };
   }
 
   open(method: string, url: string): void {
@@ -86,14 +117,17 @@ class RealRequest implements RequestLike {
 class NullRequest implements RequestLike {
   onload: (() => void) | null = null;
   onerror: (() => void) | null = null;
-
+  onprogress: ((event: ProgressEventLike) => void) | null = null;
   status: number;
   responseText: string;
 
   method = '';
   url = '';
 
-  constructor(response: NullUploaderOptions['response']) {
+  constructor(
+    response: NullUploaderOptions['response'],
+    private readonly progress: NullUploaderOptions['progress'] = [],
+  ) {
     this.status = response.status;
     this.responseText = JSON.stringify(response.body);
   }
@@ -105,6 +139,16 @@ class NullRequest implements RequestLike {
 
   send(_body: FormData): void {
     queueMicrotask(() => {
+      if (this.progress) {
+        for (const step of this.progress) {
+          this.onprogress?.({
+            loaded: step.loaded,
+            total: step.total,
+            lengthComputable: step.lengthComputable ?? true,
+          });
+        }
+      }
+
       this.onload?.();
     });
   }
@@ -120,10 +164,10 @@ export class Uploader {
   }
 
   static createNull(options: NullUploaderOptions): Uploader {
-    return new Uploader(() => new NullRequest(options.response));
+    return new Uploader(() => new NullRequest(options.response, options.progress));
   }
 
-  async upload(file: File): Promise<UploadResponse> {
+  async upload(file: File, options?: UploadOptions): Promise<UploadResponse> {
     const request = this.buildRequest(file);
 
     this.emitter.emit(REQUEST_EVENT, {
@@ -132,7 +176,7 @@ export class Uploader {
       filename: file.name,
     });
 
-    return this.execute(request);
+    return this.execute(request, options?.onProgress);
   }
 
   private buildRequest(file: File): UploadRequest {
@@ -164,11 +208,18 @@ export class Uploader {
     throw new RpcError(parsed.code, parsed.message);
   }
 
-  private execute(upload: UploadRequest): Promise<UploadResponse> {
+  private execute(
+    upload: UploadRequest,
+    onProgress?: (progress: UploadProgress) => void,
+  ): Promise<UploadResponse> {
     const request = this.createRequest();
 
     return new Promise((resolve, reject) => {
       request.open(upload.method, upload.url);
+
+      request.onprogress = (event) => {
+        onProgress?.(this.normalizeProgress(event));
+      };
 
       request.onload = () => {
         try {
@@ -184,6 +235,16 @@ export class Uploader {
 
       request.send(upload.body);
     });
+  }
+
+  private normalizeProgress(event: ProgressEventLike): UploadProgress {
+    if (!event.lengthComputable || event.total === 0) {
+      return { percent: 0 };
+    }
+
+    return {
+      percent: Math.round((event.loaded / event.total) * 100),
+    };
   }
 
   trackRequests(): OutputTracker {

--- a/client/uploader.ts
+++ b/client/uploader.ts
@@ -56,6 +56,7 @@ interface NullUploaderOptions {
   };
 
   progress?: ProgressEventLike[];
+  networkError?: boolean;
 }
 
 interface RequestLike {
@@ -123,6 +124,7 @@ class NullRequest implements RequestLike {
   constructor(
     response: NullUploaderOptions['response'],
     private readonly progress: ProgressEventLike[] = [],
+    private readonly networkError = false,
   ) {
     this.status = response.status;
     this.responseText = JSON.stringify(response.body);
@@ -143,6 +145,11 @@ class NullRequest implements RequestLike {
         });
       }
 
+      if (this.networkError) {
+        this.onerror?.();
+        return;
+      }
+
       this.onload?.();
     });
   }
@@ -158,7 +165,9 @@ export class Uploader {
   }
 
   static createNull(options: NullUploaderOptions): Uploader {
-    return new Uploader(() => new NullRequest(options.response, options.progress));
+    return new Uploader(
+      () => new NullRequest(options.response, options.progress, options.networkError),
+    );
   }
 
   async upload(file: File, options?: UploadOptions): Promise<UploadResponse> {

--- a/tests/client/uploader.test.ts
+++ b/tests/client/uploader.test.ts
@@ -93,6 +93,7 @@ describe('Uploader (null)', () => {
     });
 
     const percents: number[] = [];
+
     await uploader.upload(new File([Buffer.from('BAMDATA')], 'big.bam'), {
       onProgress: ({ percent }) => percents.push(percent),
     });

--- a/tests/client/uploader.test.ts
+++ b/tests/client/uploader.test.ts
@@ -127,4 +127,22 @@ describe('Uploader (null)', () => {
 
     expect(percents).toEqual([0]);
   });
+
+  it('rejects when the network drops after progress has been reported', async () => {
+    const uploader = Uploader.createNull({
+      response: { status: 201, body: { id: 'f1', name: 'big.bam' } },
+      progress: [{ loaded: 25, total: 100 }],
+      networkError: true,
+    });
+
+    const percents: number[] = [];
+
+    await expect(
+      uploader.upload(new File([Buffer.from('BAMDATA')], 'big.bam'), {
+        onProgress: ({ percent }) => percents.push(percent),
+      }),
+    ).rejects.toThrow('Upload failed');
+
+    expect(percents).toEqual([25]);
+  });
 });

--- a/tests/client/uploader.test.ts
+++ b/tests/client/uploader.test.ts
@@ -82,4 +82,21 @@ describe('Uploader (null)', () => {
       'Invalid upload response',
     );
   }, 2000);
+
+  it('reports progress as the bytes go up', async () => {
+    const uploader = Uploader.createNull({
+      response: { status: 201, body: { id: 'f1', name: 'big.bam' } },
+      progress: [
+        { loaded: 25, total: 100 },
+        { loaded: 100, total: 100 },
+      ],
+    });
+
+    const percents: number[] = [];
+    await uploader.upload(new File([Buffer.from('BAMDATA')], 'big.bam'), {
+      onProgress: ({ percent }) => percents.push(percent),
+    });
+
+    expect(percents).toEqual([25, 100]);
+  });
 });

--- a/tests/client/uploader.test.ts
+++ b/tests/client/uploader.test.ts
@@ -100,4 +100,31 @@ describe('Uploader (null)', () => {
 
     expect(percents).toEqual([25, 100]);
   });
+
+  it('reports zero percent when total is unknown', async () => {
+    const uploader = Uploader.createNull({
+      response: {
+        status: 201,
+        body: {
+          id: 'f1',
+          name: 'big.bam',
+        },
+      },
+      progress: [
+        {
+          loaded: 50,
+          total: 0,
+          lengthComputable: false,
+        },
+      ],
+    });
+
+    const percents: number[] = [];
+
+    await uploader.upload(new File([Buffer.from('BAMDATA')], 'big.bam'), {
+      onProgress: ({ percent }) => percents.push(percent),
+    });
+
+    expect(percents).toEqual([0]);
+  });
 });

--- a/tests/client/uploader.test.ts
+++ b/tests/client/uploader.test.ts
@@ -145,4 +145,19 @@ describe('Uploader (null)', () => {
 
     expect(percents).toEqual([25]);
   });
+
+  it('never reports more than one hundred percent', async () => {
+    const uploader = Uploader.createNull({
+      response: { status: 201, body: { id: 'f1', name: 'big.bam' } },
+      progress: [{ loaded: 150, total: 100 }],
+    });
+
+    const percents: number[] = [];
+
+    await uploader.upload(new File([Buffer.from('BAMDATA')], 'big.bam'), {
+      onProgress: ({ percent }) => percents.push(percent),
+    });
+
+    expect(percents).toEqual([100]);
+  });
 });


### PR DESCRIPTION
## Summary

This PR adds upload progress reporting to the client uploader while keeping the upload transport reusable.

The uploader now exposes an optional `onProgress` callback that reports upload progress as a normalized `{ percent }` value. The real implementation is wired to `XMLHttpRequest.upload.onprogress`, while the null uploader can replay configured progress events so the behaviour can be tested without making a real network request.

## What changed

* Added upload progress support to the uploader API via an optional `onProgress` callback.
* Extended `RequestLike` with a progress handler so both the real and null implementations expose the same interface.
* Wired `RealRequest` to `XMLHttpRequest.upload.onprogress`.
* Updated `NullRequest` to replay configured progress events before completing the upload, allowing progress behaviour to be tested without a browser.
* Moved progress normalization into a single helper that converts the raw `loaded` and `total` values into a `{ percent }` object.
* Added a guard for uploads where the total size is unknown (`lengthComputable === false`) to avoid dividing by zero and to keep progress reporting consistent.

## Tests

Added tests covering the new upload progress behaviour:

* Upload progress callbacks are fired as progress events are received.
* Progress values are reported as normalized percentages.
* The null uploader replays configured progress events before resolving the upload.
* Uploads whose total size is unknown (`lengthComputable === false`) do not attempt to calculate a percentage and still complete successfully.

https://linear.app/ekohacks/issue/EKO-202/5d1-report-upload-progress

