### PR TITLE
feat: show upload progress bar in the live demo

### DIFF
--- a/client/demo/live.html
+++ b/client/demo/live.html
@@ -44,6 +44,9 @@
         opacity: 0.4;
         cursor: not-allowed;
       }
+      progress {
+        width: 10rem;
+      }
       ul {
         padding-left: 1.2rem;
       }
@@ -76,6 +79,7 @@
       <div class="controls">
         <input type="file" id="file" />
         <button id="upload">Upload</button>
+        <progress id="progress" max="100" value="0" hidden></progress>
       </div>
 
       <h2>files</h2>

--- a/client/demo/live.ts
+++ b/client/demo/live.ts
@@ -6,12 +6,15 @@
 // SubscriptionHandle, ReactiveStore) is identical. That is the Nullables payoff.
 //
 // It shows the read side (subscribe, see the documents, watch the list update as the
-// files collection changes) plus one write: uploading a file. The upload is a plain
-// HTTP POST to /api/files, which stores the bytes and inserts a document, so the file
-// then streams back into the list through the same subscription.
+// files collection changes) plus one write: uploading a file through the real Uploader
+// surface. upload() POSTs to /api/files; on success the file streams back into the list
+// through the same subscription, and on a refusal it rejects with the server's error so
+// the demo can show it rather than swallow it.
 
 import { ClientSocketWrapper } from '../clientSocket.ts';
 import { ConnectionManager } from '../connectionManager.ts';
+import { Uploader } from '../uploader.ts';
+import { RpcError } from '../../shared/types.ts';
 
 function el(id: string): HTMLElement {
   const node = document.getElementById(id);
@@ -33,6 +36,14 @@ function button(id: string): HTMLButtonElement {
   const node = el(id);
   if (!(node instanceof HTMLButtonElement)) {
     throw new Error(`#${id} is not a button`);
+  }
+  return node;
+}
+
+function progressBar(id: string): HTMLProgressElement {
+  const node = el(id);
+  if (!(node instanceof HTMLProgressElement)) {
+    throw new Error(`#${id} is not a progress element`);
   }
   return node;
 }
@@ -89,10 +100,15 @@ files.onChange(() => {
   render();
 });
 
-// 4. Upload a file over HTTP. It hits the server, lands on disk and inserts a
-// document, which streams back into the list above through the subscription.
+// 4. Upload a file through the real Uploader surface. The same code runs in
+// production; only create() differs from the nulled uploader the tests drive. The
+// request goes to the relative /api/files, so it rides the vite proxy (/api → :3001)
+// and stays same-origin. The bar is fed by the { percent } signal from onProgress:
+// reset on each upload, filled as the bytes climb, cleared on success or refusal.
+const uploader = Uploader.create();
 const fileInput = input('file');
 const uploadBtn = button('upload');
+const uploadProgress = progressBar('progress');
 
 uploadBtn.addEventListener('click', () => {
   const file = fileInput.files?.[0];
@@ -100,19 +116,29 @@ uploadBtn.addEventListener('click', () => {
     log('pick a file first');
     return;
   }
-  const form = new FormData();
-  form.append('file', file, file.name);
   log(`out: upload ${file.name}`);
-  // POST through the vite proxy (/api → :3001) so it stays same-origin, no CORS.
-  void fetch('/api/files', { method: 'POST', body: form })
-    .then((res) => {
-      log(res.ok ? `in: stored ${file.name}` : `upload failed: ${String(res.status)}`);
-      if (res.ok) {
-        fileInput.value = '';
-      }
+  uploadProgress.value = 0;
+  uploadProgress.hidden = false;
+  void uploader
+    .upload(file, {
+      onProgress: ({ percent }) => {
+        uploadProgress.value = percent;
+        log(`upload progress: ${String(percent)}%`);
+      },
+    })
+    .then((stored) => {
+      log(`in: stored ${stored.name} (${stored.id})`);
+      fileInput.value = '';
     })
     .catch((err: unknown) => {
-      log(`upload error: ${err instanceof Error ? err.message : String(err)}`);
+      if (err instanceof RpcError) {
+        log(`upload refused: ${String(err.code)} ${err.message}`);
+      } else {
+        log(`upload error: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    })
+    .finally(() => {
+      uploadProgress.hidden = true;
     });
 });
 


### PR DESCRIPTION
## Summary

This PR makes upload progress visible in the live demo, fed by 5.D.1's `{ percent }` signal.

Complete and error were already covered by the 5.C promise: `upload()` resolves with `{ id, name }` and rejects with the shared `RpcError`, the same error type `call()` uses. So there were no new events to build here; the demo just needed a bar. Along the way the demo's upload moved off its hand-rolled `fetch` onto the real `Uploader` surface, so the demo now runs the same upload code as production, with only `create()` differing from the nulled uploader the tests drive.

## What changed

* The demo uploads through `Uploader.create()` instead of a raw `fetch` to `/api/files`.
* A `<progress>` element in `live.html`, hidden until an upload starts.
* The bar resets to zero on each new upload, fills from `onProgress`'s `{ percent }`, and clears when the upload settles, on success or refusal alike.
* Refusals surface as `upload refused: <code> <message>` in the demo log via the shared `RpcError`, instead of a bare HTTP status.
* Progress percentages also land in the demo log, so the numbers behind the bar stay inspectable.

## Verification

No unit tests: the demo is vanilla DOM in `live.ts` and sits outside the suite, like the rest of the demo. The progress signal itself is pinned by 5.D.1's nullable tests.

Verified by running the demo end to end: `npm run dev:server`, then `npm run dev:client`, open `/demo/live.html` and upload a real `.bam`. A local upload finishes too quickly to watch the bar move, so throttle the connection in DevTools (Network tab → throttling → a slow profile), and use a larger `.bam` so progress spans several ticks — then watch the bar climb, clear, and the file appear on disk and in the list. That's the Epic's pass criteria (progress → on disk → in the list) end to end.

https://linear.app/ekohacks/issue/EKO-201/5d2-show-upload-progress-in-the-demo
