### PR TITLE
feat: add `runCountC` method for script execution 

### DIFF
--- a/scripts/countC.py
+++ b/scripts/countC.py
@@ -1,0 +1,4 @@
+# Throwaway stand-in so runCountC has something real to shell out to.
+# The real analysis lands in a later story; for now this just prints the same
+# value the nullable test primes, so a live call returns it end to end.
+print("count: 42")

--- a/server/logic/analysis.ts
+++ b/server/logic/analysis.ts
@@ -1,0 +1,27 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { type Methods } from './methods.ts';
+import { type ScriptRunnerWrapper } from '../infrastructure/scriptRunner.ts';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Resolve a repo-relative asset path (e.g. 'scripts/countC.py') to an absolute
+// one, anchored on this file's location rather than the process cwd. Same idiom
+// as the static root in server/index.ts.
+export function resolveAsset(relativePath: string): string {
+  return resolve(__dirname, '..', '..', relativePath);
+}
+
+// runCountC resolves its script asset, asks the runner to run it under python3,
+// and hands back what the script printed. The path is configuration: it arrives
+// as an argument rather than sitting as a literal in here.
+export function defineRunCountC(
+  methods: Methods,
+  runner: ScriptRunnerWrapper,
+  scriptPath: string,
+): void {
+  methods.define('runCountC', async () => {
+    const result = await runner.exec('python3', [resolveAsset(scriptPath)]);
+    return result.stdout;
+  });
+}

--- a/server/start.ts
+++ b/server/start.ts
@@ -2,21 +2,25 @@ import { createServer } from './index.ts';
 import { MongoWrapper } from './infrastructure/mongo.ts';
 import { WebSocketWrapper } from './infrastructure/websocket.ts';
 import { FileStorageWrapper } from './infrastructure/fileStorage.ts';
+import { ScriptRunnerWrapper } from './infrastructure/scriptRunner.ts';
 import { Publications } from './logic/publications.ts';
 import { RpcHandler } from './logic/rpcHandler.ts';
 import { Methods } from './logic/methods.ts';
 import { Files } from './logic/files.ts';
+import { defineRunCountC } from './logic/analysis.ts';
 
 // Real boot. The same pieces the end-to-end test wires by hand, wired here for a
 // live process: a Mongo connection, a websocket server, the pub/sub engine that
 // turns subscriptions into live document streams, and the file store behind uploads.
 const mongoUri = process.env.MONGO_URI ?? 'mongodb://localhost:27017/ekolite';
 const fileDir = process.env.FILE_DIR ?? './uploads';
+const countCScript = process.env.COUNTC_SCRIPT ?? 'scripts/countC.py';
 const port = Number(process.env.PORT ?? 3001);
 
 const mongo = MongoWrapper.create(mongoUri);
 const ws = WebSocketWrapper.create();
 const storage = FileStorageWrapper.create(fileDir);
+const scriptRunner = ScriptRunnerWrapper.create();
 const methods = new Methods();
 const rpcHandler = new RpcHandler(methods, ws);
 const publications = new Publications(mongo, ws);
@@ -30,6 +34,13 @@ publications.define('files.all', () => ({ collection: 'files', query: {} }));
 // call('echo', 'hello') comes back 'echo: hello'. It gives the method round trip
 // something real to hit, the way files.all does for subscriptions.
 methods.define('echo', (message) => Promise.resolve(`echo: ${String(message)}`));
+
+// The first analysis method: runCountC resolves its script asset, runs it under
+// python3, and returns what the script printed. The path comes from config the
+// same way MONGO_URI and FILE_DIR do, so the method is handed its script rather
+// than knowing where it lives. The script itself lands in a later story; until
+// then a live call resolves and shells out, and fails loudly if it is missing.
+defineRunCountC(methods, scriptRunner, countCScript);
 
 // Dev convenience: seed a couple of files so a fresh Mongo is not a blank page.
 // Idempotent (only seeds an empty collection) and best-effort (a missing Mongo

--- a/server/start.ts
+++ b/server/start.ts
@@ -38,8 +38,8 @@ methods.define('echo', (message) => Promise.resolve(`echo: ${String(message)}`))
 // The first analysis method: runCountC resolves its script asset, runs it under
 // python3, and returns what the script printed. The path comes from config the
 // same way MONGO_URI and FILE_DIR do, so the method is handed its script rather
-// than knowing where it lives. The script itself lands in a later story; until
-// then a live call resolves and shells out, and fails loudly if it is missing.
+// than knowing where it lives. For now scripts/countC.py is a stand-in that prints
+// a fixed count; the real analysis lands in a later story.
 defineRunCountC(methods, scriptRunner, countCScript);
 
 // Dev convenience: seed a couple of files so a fresh Mongo is not a blank page.

--- a/tests/logic/analysis.test.ts
+++ b/tests/logic/analysis.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { Methods } from '../../server/logic/methods.ts';
+import { ScriptRunnerWrapper } from '../../server/infrastructure/scriptRunner.ts';
+import { defineRunCountC } from '../../server/logic/analysis.ts';
+
+describe('runCountC (null)', () => {
+  it('returns the script stdout when called through Methods', async () => {
+    const methods = new Methods();
+    const runner = ScriptRunnerWrapper.createNull({ python3: 'count: 42' });
+
+    defineRunCountC(methods, runner, 'scripts/countC.py');
+
+    const result = await methods.call('runCountC', []);
+    expect(result).toBe('count: 42');
+  });
+
+  it('runs the script path it is given, not a baked-in one', async () => {
+    const methods = new Methods();
+    const runner = ScriptRunnerWrapper.createNull({ python3: 'count: 0' });
+    const tracker = runner.trackChanges();
+
+    defineRunCountC(methods, runner, 'scripts/someOtherAnalysis.py');
+    await methods.call('runCountC', []);
+
+    expect(tracker.data).toHaveLength(1);
+    expect(tracker.data[0]).toMatchObject({ command: 'python3' });
+    const { args } = tracker.data[0] as { args: string[] };
+    expect(args[0]).toMatch(/scripts\/someOtherAnalysis\.py$/);
+  });
+});


### PR DESCRIPTION
## Summary

EkoLite could already run methods over the socket (`echo` proves the round trip) and could already shell out to scripts through `ScriptRunnerWrapper` (tested on nullables). Neither reached the other: no method ran a script, and `ScriptRunnerWrapper` had no caller in production. This PR is that first join.

It defines one analysis method, `runCountC`, that resolves a script asset, hands it to a `ScriptRunnerWrapper`, and returns what the script printed on stdout. The method is kept deliberately small, since the wiring is the point. A real analysis can grow on the same seam later.

## What changed

### The method

* `server/logic/analysis.ts` adds `defineRunCountC(methods, runner, scriptPath)`, which registers `runCountC` through `Methods.define`, the same way `echo` is registered in `start.ts`.
* The method runs `python3` with the resolved script path as an argument and returns `result.stdout`.
* `resolveAsset` turns a repo relative path such as `scripts/countC.py` into an absolute one, anchored on the module's own location rather than the process working directory, so it resolves the same whether the server boots from a shell, a container, or a test runner. Same idiom already used for the static root in `server/index.ts`.

### Configuration

* The script path is read once at boot as `COUNTC_SCRIPT ?? 'scripts/countC.py'` and injected through `defineRunCountC`, the same way `MONGO_URI` and `FILE_DIR` are. The method is handed its path rather than holding a literal.

### The runtime decision

* `exec` receives `python3` with the path as an argument, not the path as a standalone command. A `.py` file with no execute bit and no reliable shebang cannot run on its own, so the runtime is named explicitly. The nulled test is keyed on `python3` to match the command the real run sends.

### Throwaway script

* `scripts/countC.py` prints `count: 42`. It is a stand in so a live call over the socket returns a real value instead of an empty string. The real analysis and its integration test are held for the next slice.

## Tests

Two nulled tests in `tests/logic/analysis.test.ts`, neither shells out:

* The first primes the null runner with `count: 42` and asserts `runCountC` returns it, proving stdout travels from the runner through the method back to the caller.
* The second hands the method a different path and checks, through the runner's tracker, that the runner was asked to run that path and not one baked into the method. Without it the method could ignore its argument and the first test would still pass.

## Where this is heading

`runCountC` is the seam for a fuller loop the next stories build out: upload a file holding a sequence, count the C's in it on the server, and stream the count back to the client through the existing subscription. This PR is only the first joint of that, a method that runs a script and returns its stdout, proven on nullables. Held for the next slices:

* The real countC script that reads a sequence and counts the C's, with an integration test that shells out for real. Also where stdout handling is settled: the method returns stdout untouched and python's `print` adds a trailing newline, so a live call currently returns `count: 42\n`.
* `runCountC` taking the uploaded file as an argument, so it counts C's in that file rather than running a fixed script. The uploaded file's on-disk path is already recorded on its document at upload, so the method resolves the file by id.
* Writing the count back onto the file's document, which is what makes the result reactive: the client's `files.all` subscription streams the change back with no extra wiring.
* The client flow: upload, call `runCountC`, watch the count appear in the reactive store.

https://linear.app/ekohacks/issue/EKO-197/7a1-runcountc-null-wiring
