### PR TITLE
7.A.2: Locate a file and record its count

### DIFF
--- a/server/logic/files.ts
+++ b/server/logic/files.ts
@@ -71,6 +71,21 @@ export class Files {
     return { file, data };
   }
 
+  // The lean lookup the analysis method needs: the document for an id, and only the
+  // document. Unlike read it does not pull the bytes off disk; the script opens the
+  // file itself and only the path is wanted.
+  async locate(id: string): Promise<StoredFile | null> {
+    const docs = await this.mongo.find<StoredFile>('files', { _id: id });
+    return docs[0] ?? null;
+  }
+
+  // Write a computed count back onto the file's own document. A $set keyed by id so
+  // it merges the field rather than replacing the document, and so the change streams
+  // to subscribers through the same files.all publication the upload used.
+  async recordCountC(id: string, count: number): Promise<void> {
+    await this.mongo.update('files', { _id: id }, { $set: { countC: count } });
+  }
+
   validate(name: string): boolean {
     return this.isAllowed(extensionOf(name));
   }

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -20,6 +20,7 @@ export interface StoredFile {
   size: number;
   extension: string;
   uploadedAt: Date;
+  countC?: number;
   meta?: Record<string, unknown>;
 }
 

--- a/tests/logic/files.test.ts
+++ b/tests/logic/files.test.ts
@@ -99,3 +99,87 @@ describe('Files.read', () => {
     expect(inserts.data).toHaveLength(0);
   });
 });
+
+// A count computed on the server is written back onto the file's own document, so it
+// streams to subscribers through the same files.all publication the upload used. The
+// write is a $set on the existing file keyed by id, not a new document.
+describe('Files.recordCountC', () => {
+  it('writes the count onto the file document as a $set keyed by id', async () => {
+    const mongo = MongoWrapper.createNull();
+    const storage = FileStorageWrapper.createNull();
+    const files = new Files(mongo, storage);
+    const updates = await mongo.trackChanges('files');
+
+    await files.recordCountC('file-1', 42);
+
+    const update = updates.data.find((event) => (event as { type?: unknown }).type === 'update');
+    expect(update).toMatchObject({ type: 'update', collection: 'files', id: 'file-1' });
+    // Exactly the count and nothing else, so $set merges the field rather than
+    // replacing the document and losing name, path and the rest.
+    expect((update as { fields: unknown }).fields).toEqual({ countC: 42 });
+  });
+
+  it('writes a count of zero rather than dropping it', async () => {
+    const mongo = MongoWrapper.createNull();
+    const storage = FileStorageWrapper.createNull();
+    const files = new Files(mongo, storage);
+    const updates = await mongo.trackChanges('files');
+
+    await files.recordCountC('file-1', 0);
+
+    const update = updates.data.find((event) => (event as { type?: unknown }).type === 'update');
+    expect((update as { fields: unknown }).fields).toEqual({ countC: 0 });
+  });
+
+  it('updates the existing document rather than inserting a new one', async () => {
+    const mongo = MongoWrapper.createNull();
+    const storage = FileStorageWrapper.createNull();
+    const files = new Files(mongo, storage);
+    const changes = await mongo.trackChanges('files');
+
+    await files.recordCountC('file-1', 7);
+
+    const byType = (type: string) =>
+      changes.data.filter((event) => (event as { type?: unknown }).type === type);
+    expect(byType('insert')).toHaveLength(0);
+    expect(byType('update')).toHaveLength(1);
+  });
+});
+
+// locate is the lean lookup runCountC needs: the document for an id, and only the
+// document. Unlike read it does not pull the bytes off disk, because the analysis
+// script opens the file itself and only the path is needed.
+describe('Files.locate', () => {
+  it('returns the document for a known id without reading the bytes', async () => {
+    const mongo = MongoWrapper.createNull({
+      find: [
+        [
+          {
+            _id: 'known',
+            name: 'reads.bam',
+            path: '/data/reads.bam',
+            size: 9,
+            extension: 'bam',
+            uploadedAt: new Date(),
+          },
+        ],
+      ],
+    });
+    // Storage is empty on purpose: if locate read the bytes it would fail here,
+    // so a document coming back proves it never touched the store.
+    const storage = FileStorageWrapper.createNull();
+    const files = new Files(mongo, storage);
+
+    const file = await files.locate('known');
+
+    expect(file).toMatchObject({ _id: 'known', name: 'reads.bam', path: '/data/reads.bam' });
+  });
+
+  it('returns null when the id is unknown', async () => {
+    const mongo = MongoWrapper.createNull();
+    const storage = FileStorageWrapper.createNull();
+    const files = new Files(mongo, storage);
+
+    expect(await files.locate('nope')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Adds the two `Files` methods `runCountC` leans on.

## What changed
* `Files.locate(id)` returns the stored document for an id (null for an unknown one), without reading the bytes off disk — the script opens the file itself, only the path is wanted.
* `Files.recordCountC(id, count)` writes the count onto the file's document as a `$set` keyed by id, so it merges the field rather than replacing the document, and streams to subscribers through `files.all`.
* `StoredFile` gains an optional `countC` field.

## Tests
Nullable, `tests/logic/files.test.ts`: recordCountC writes a keyed `$set`, keeps a count of 0, updates rather than inserts; locate hits and misses.

Stacked on #95; base retargets to main once #95 merges.

https://linear.app/ekohacks/issue/EKO-288/7a2-locate-a-file-and-record-its-count
