### PR TITLE
7.A.3: runCountC counts an uploaded file and records the count

### DIFF
--- a/server/logic/analysis.ts
+++ b/server/logic/analysis.ts
@@ -1,7 +1,9 @@
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { type Methods } from './methods.ts';
+import { type Files } from './files.ts';
 import { type ScriptRunnerWrapper } from '../infrastructure/scriptRunner.ts';
+import { fileNotFound } from '../../shared/types.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -12,16 +14,24 @@ export function resolveAsset(relativePath: string): string {
   return resolve(__dirname, '..', '..', relativePath);
 }
 
-// runCountC resolves its script asset, asks the runner to run it under python3,
-// and hands back what the script printed. The path is configuration: it arrives
-// as an argument rather than sitting as a literal in here.
+// runCountC resolves an uploaded file by id, runs the count script against that
+// file, parses the number the script printed, and writes it back onto the file's
+// document so it streams to subscribers through files.all. The count also comes
+// back to the caller. The script path is configuration, injected at this seam.
 export function defineRunCountC(
   methods: Methods,
   runner: ScriptRunnerWrapper,
+  files: Files,
   scriptPath: string,
 ): void {
-  methods.define('runCountC', async () => {
-    const result = await runner.exec('python3', [resolveAsset(scriptPath)]);
-    return result.stdout;
+  methods.define('runCountC', async (fileId) => {
+    const file = await files.locate(fileId as string);
+    if (!file) {
+      throw fileNotFound(fileId as string);
+    }
+    const { stdout } = await runner.exec('python3', [resolveAsset(scriptPath), file.path]);
+    const count = Number(stdout.trim());
+    await files.recordCountC(file._id, count);
+    return count;
   });
 }

--- a/server/start.ts
+++ b/server/start.ts
@@ -35,12 +35,12 @@ publications.define('files.all', () => ({ collection: 'files', query: {} }));
 // something real to hit, the way files.all does for subscriptions.
 methods.define('echo', (message) => Promise.resolve(`echo: ${String(message)}`));
 
-// The first analysis method: runCountC resolves its script asset, runs it under
-// python3, and returns what the script printed. The path comes from config the
-// same way MONGO_URI and FILE_DIR do, so the method is handed its script rather
-// than knowing where it lives. For now scripts/countC.py is a stand-in that prints
-// a fixed count; the real analysis lands in a later story.
-defineRunCountC(methods, scriptRunner, countCScript);
+// The first analysis method: runCountC resolves an uploaded file by id, runs the
+// count script against it, and writes the count back onto the file's document so it
+// streams to subscribers. The script path comes from config the same way MONGO_URI
+// and FILE_DIR do. For now scripts/countC.py is a stand-in that prints a fixed
+// count; the real counting script lands in a later story.
+defineRunCountC(methods, scriptRunner, files, countCScript);
 
 // Dev convenience: seed a couple of files so a fresh Mongo is not a blank page.
 // Idempotent (only seeds an empty collection) and best-effort (a missing Mongo

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -100,3 +100,7 @@ export function toEkoLiteError(error: unknown): EkoLiteError {
 export function fileUploadError(extension: string): RpcError {
   return new RpcError(400, `Unsupported file type: .${extension}`);
 }
+
+export function fileNotFound(id: string): RpcError {
+  return new RpcError(404, `File not found: ${id}`);
+}

--- a/tests/logic/analysis.test.ts
+++ b/tests/logic/analysis.test.ts
@@ -1,30 +1,112 @@
 import { describe, it, expect } from 'vitest';
 import { Methods } from '../../server/logic/methods.ts';
 import { ScriptRunnerWrapper } from '../../server/infrastructure/scriptRunner.ts';
+import { MongoWrapper } from '../../server/infrastructure/mongo.ts';
+import { FileStorageWrapper } from '../../server/infrastructure/fileStorage.ts';
+import { Files } from '../../server/logic/files.ts';
 import { defineRunCountC } from '../../server/logic/analysis.ts';
 
-describe('runCountC (null)', () => {
-  it('returns the script stdout when called through Methods', async () => {
+// runCountC joins the pieces: resolve an uploaded file by id, run the count script
+// against that file, parse the number the script printed, and write it back onto the
+// file's document so it streams to subscribers. Sociable tests: real Files and real
+// analysis logic over nulled infrastructure, no shelling out and no database.
+const storedFile = {
+  _id: 'f1',
+  name: 'reads.bam',
+  path: '/data/reads.bam',
+  size: 9,
+  extension: 'bam',
+  uploadedAt: new Date(),
+};
+
+describe('runCountC', () => {
+  it('runs the script against the located file and records the parsed count', async () => {
+    const mongo = MongoWrapper.createNull({ find: [[storedFile]] });
+    const files = new Files(mongo, FileStorageWrapper.createNull());
+    const runner = ScriptRunnerWrapper.createNull({ python3: '42\n' });
+    const runs = runner.trackChanges();
+    const writes = await mongo.trackChanges('files');
     const methods = new Methods();
-    const runner = ScriptRunnerWrapper.createNull({ python3: 'count: 42' });
 
-    defineRunCountC(methods, runner, 'scripts/countC.py');
+    defineRunCountC(methods, runner, files, 'scripts/countC.py');
+    const result = await methods.call('runCountC', ['f1']);
 
-    const result = await methods.call('runCountC', []);
-    expect(result).toBe('count: 42');
+    // Ran python3 against the script and the located file's path.
+    expect(runs.data).toHaveLength(1);
+    const { command, args } = runs.data[0] as { command: string; args: string[] };
+    expect(command).toBe('python3');
+    expect(args[0]).toMatch(/scripts\/countC\.py$/);
+    expect(args[1]).toBe('/data/reads.bam');
+
+    // Parsed the stdout to a number and wrote only that onto the file document.
+    const write = writes.data.find((event) => (event as { type?: unknown }).type === 'update');
+    expect(write).toMatchObject({ type: 'update', collection: 'files', id: 'f1' });
+    expect((write as { fields: unknown }).fields).toEqual({ countC: 42 });
+
+    // Handed the count back to the caller as a number, not the raw stdout string.
+    expect(result).toBe(42);
   });
 
-  it('runs the script path it is given, not a baked-in one', async () => {
+  it('takes its script path from config rather than a baked-in string', async () => {
+    const mongo = MongoWrapper.createNull({ find: [[storedFile]] });
+    const files = new Files(mongo, FileStorageWrapper.createNull());
+    const runner = ScriptRunnerWrapper.createNull({ python3: '0\n' });
+    const runs = runner.trackChanges();
     const methods = new Methods();
-    const runner = ScriptRunnerWrapper.createNull({ python3: 'count: 0' });
-    const tracker = runner.trackChanges();
 
-    defineRunCountC(methods, runner, 'scripts/someOtherAnalysis.py');
-    await methods.call('runCountC', []);
+    defineRunCountC(methods, runner, files, 'scripts/someOtherAnalysis.py');
+    await methods.call('runCountC', ['f1']);
 
-    expect(tracker.data).toHaveLength(1);
-    expect(tracker.data[0]).toMatchObject({ command: 'python3' });
-    const { args } = tracker.data[0] as { args: string[] };
+    const { args } = runs.data[0] as { args: string[] };
     expect(args[0]).toMatch(/scripts\/someOtherAnalysis\.py$/);
+  });
+
+  it('records a count of zero rather than dropping it', async () => {
+    const mongo = MongoWrapper.createNull({ find: [[storedFile]] });
+    const files = new Files(mongo, FileStorageWrapper.createNull());
+    const runner = ScriptRunnerWrapper.createNull({ python3: '0\n' });
+    const writes = await mongo.trackChanges('files');
+    const methods = new Methods();
+
+    defineRunCountC(methods, runner, files, 'scripts/countC.py');
+    const result = await methods.call('runCountC', ['f1']);
+
+    const write = writes.data.find((event) => (event as { type?: unknown }).type === 'update');
+    expect((write as { fields: unknown }).fields).toEqual({ countC: 0 });
+    expect(result).toBe(0);
+  });
+
+  it('rejects an unknown file id without running the script or writing a count', async () => {
+    const mongo = MongoWrapper.createNull();
+    const files = new Files(mongo, FileStorageWrapper.createNull());
+    const runner = ScriptRunnerWrapper.createNull({ python3: '42\n' });
+    const runs = runner.trackChanges();
+    const writes = await mongo.trackChanges('files');
+    const methods = new Methods();
+
+    defineRunCountC(methods, runner, files, 'scripts/countC.py');
+
+    // A not-found file is a 404, the same shape methodNotFound uses, not whatever
+    // error happens to escape. Pinning the code keeps this from passing on an
+    // unrelated throw.
+    await expect(methods.call('runCountC', ['missing'])).rejects.toMatchObject({ code: 404 });
+    expect(runs.data).toHaveLength(0);
+    expect(writes.data.some((event) => (event as { type?: unknown }).type === 'update')).toBe(
+      false,
+    );
+  });
+
+  it('surfaces a failed write to the caller', async () => {
+    const mongo = MongoWrapper.createNull({
+      find: [[storedFile]],
+      update: [new Error('write conflict')],
+    });
+    const files = new Files(mongo, FileStorageWrapper.createNull());
+    const runner = ScriptRunnerWrapper.createNull({ python3: '42\n' });
+    const methods = new Methods();
+
+    defineRunCountC(methods, runner, files, 'scripts/countC.py');
+
+    await expect(methods.call('runCountC', ['f1'])).rejects.toThrow('write conflict');
   });
 });


### PR DESCRIPTION
## Summary
Grows `runCountC` from the 7.A.1 wiring cut into the real join.

## What changed
* `runCountC(fileId)` resolves the uploaded file via `Files.locate`, runs the script against `file.path`, parses the number with `Number(stdout.trim())`, writes it back via `Files.recordCountC`, and returns the count.
* An unknown file rejects with a 404 (`fileNotFound` helper in `shared/types`).
* `defineRunCountC` gained a `Files` collaborator; `start.ts` passes it in.

## Tests
Nullable, `tests/logic/analysis.test.ts`: runs the script against the located path, records the parsed count, records 0, returns the count, rejects an unknown file 404 without running or writing, surfaces a failed write.

Stacked on EKO-288.

https://linear.app/ekohacks/issue/EKO-289/7a3-runcountc-counts-an-uploaded-file-and-records-the-count
