### PR TITLE
7.A.4: countC.py counts C's for real

### DIFF
--- a/scripts/countC.py
+++ b/scripts/countC.py
@@ -1,4 +1,9 @@
-# Throwaway stand-in so runCountC has something real to shell out to.
-# The real analysis lands in a later story; for now this just prints the same
-# value the nullable test primes, so a live call returns it end to end.
-print("count: 42")
+# Count the C's in a sequence file. Case-insensitive: both c and C count.
+# Takes the file path as its one argument and prints the count as a bare integer,
+# which is what runCountC parses with Number(stdout.trim()).
+import sys
+
+with open(sys.argv[1]) as handle:
+    sequence = handle.read()
+
+print(sequence.lower().count("c"))

--- a/tests/server/countC.integration.test.ts
+++ b/tests/server/countC.integration.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ScriptRunnerWrapper } from '../../server/infrastructure/scriptRunner.ts';
+import { resolveAsset } from '../../server/logic/analysis.ts';
+
+// Integration, shells out for real. This is the only place the actual countC.py runs
+// against a real file, so it is where the script's real behaviour is pinned: what it
+// counts and what it prints. The nulled tests rehearse the wiring; this proves the
+// script itself. Runs only under the integration suite (npm run test:integration) and
+// needs python3 on the machine.
+describe('countC.py (integration)', () => {
+  async function runOnSequence(sequence: string): Promise<{ stdout: string; exitCode: number }> {
+    const dir = await mkdtemp(join(tmpdir(), 'ekolite-countc-'));
+    const dataPath = join(dir, 'sequence.txt');
+    await writeFile(dataPath, sequence);
+    try {
+      const runner = ScriptRunnerWrapper.create();
+      return await runner.exec('python3', [resolveAsset('scripts/countC.py'), dataPath]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }
+
+  it('counts the C characters in a sequence and exits cleanly', async () => {
+    // Mixed case on purpose. Pinning 4 here fixes the decision as case-insensitive:
+    // both c and C count. If countC should only count the base C (upper) or only a
+    // literal lowercase c, change the script and this number together.
+    const { stdout, exitCode } = await runOnSequence('cCcC');
+
+    expect(exitCode).toBe(0);
+    expect(Number(stdout.trim())).toBe(4);
+  });
+
+  it('counts zero when the sequence has no C', async () => {
+    const { stdout, exitCode } = await runOnSequence('abdefg');
+
+    expect(exitCode).toBe(0);
+    expect(Number(stdout.trim())).toBe(0);
+  });
+
+  it('prints just the number, so Number(stdout.trim()) parses cleanly', async () => {
+    // runCountC does Number(stdout.trim()). If the script printed a label such as
+    // 'count: 3' this would be NaN, so the contract is a bare integer on stdout.
+    const { stdout } = await runOnSequence('gattacaCCC');
+
+    expect(Number.isNaN(Number(stdout.trim()))).toBe(false);
+    expect(stdout.trim()).toMatch(/^\d+$/);
+  });
+});


### PR DESCRIPTION
## Summary
Replaces the throwaway `countC.py` with the real counting script.

## What changed
* `scripts/countC.py` reads the sequence file passed as its argument and prints the count of C as a bare integer. Case-insensitive: both c and C count.

## Tests
Integration (shells out for real), `tests/server/countC.integration.test.ts`: counts C's case-insensitively, counts 0 when none, prints a bare number so `Number(stdout.trim())` parses. Runs under `npm run test:integration`, needs python3.

Stacked on #95; independent of 7.A.2/7.A.3.

https://linear.app/ekohacks/issue/EKO-290/7a4-countcpy-counts-cs-for-real
