### PR TITLE
7.A.5: Call runCountC from the client, count arrives reactively

### DIFF
--- a/client/demo/live.html
+++ b/client/demo/live.html
@@ -71,8 +71,9 @@
       <p class="lede">
         The real ConnectionManager and ReactiveStore, talking to a live server at
         ws://localhost:3001/ws. The files list streams from Mongo. Pick a file and upload
-        it; it lands on the server and streams back into the list. Start the server with
-        npm run dev:server first.
+        it; it lands on the server and streams back into the list. Hit Count C on a row to
+        run the analysis; the count streams back onto that row. Start the server with npm
+        run dev:server first.
       </p>
       <p id="status">connecting…</p>
 

--- a/client/demo/live.ts
+++ b/client/demo/live.ts
@@ -88,7 +88,29 @@ function render(): void {
     ...docs.map((doc) => {
       const item = document.createElement('li');
       const name = typeof doc.name === 'string' ? doc.name : '';
-      item.textContent = `${doc._id} · ${name}`;
+      const count = typeof doc.countC === 'number' ? ` · C: ${String(doc.countC)}` : '';
+
+      const label = document.createElement('span');
+      label.textContent = `${doc._id} · ${name}${count}`;
+
+      // Call runCountC on this file over the socket. The server counts, writes the
+      // count onto the document, and it streams back into this same store, so the
+      // number appears on re-render with no extra wiring here.
+      const countBtn = document.createElement('button');
+      countBtn.textContent = 'Count C';
+      countBtn.addEventListener('click', () => {
+        log(`out: runCountC ${doc._id}`);
+        void manager
+          .call('runCountC', doc._id)
+          .then((result) => {
+            log(`in: runCountC ${doc._id} → ${String(result)}`);
+          })
+          .catch((err: unknown) => {
+            log(`runCountC error: ${err instanceof Error ? err.message : String(err)}`);
+          });
+      });
+
+      item.append(label, ' ', countBtn);
       return item;
     }),
   );

--- a/tests/server/runCountCReactive.integration.test.ts
+++ b/tests/server/runCountCReactive.integration.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createServer } from '../../server/index.ts';
+import { WebSocketWrapper } from '../../server/infrastructure/websocket.ts';
+import { MongoWrapper } from '../../server/infrastructure/mongo.ts';
+import { FileStorageWrapper } from '../../server/infrastructure/fileStorage.ts';
+import { ScriptRunnerWrapper } from '../../server/infrastructure/scriptRunner.ts';
+import { Publications } from '../../server/logic/publications.ts';
+import { RpcHandler } from '../../server/logic/rpcHandler.ts';
+import { Methods } from '../../server/logic/methods.ts';
+import { Files } from '../../server/logic/files.ts';
+import { defineRunCountC } from '../../server/logic/analysis.ts';
+import { ClientSocketWrapper } from '../../client/clientSocket.ts';
+import { ConnectionManager } from '../../client/connectionManager.ts';
+
+// The whole point of the arc, proven over a real socket: a client calls runCountC
+// on an uploaded file, the server counts and writes the count onto the file's
+// document, and the change streams back into the client's reactive store through the
+// same files.all subscription. Nulled Mongo and runner so it needs no database or
+// python; the socket, server, and client are real.
+const waitFor = async (predicate: () => boolean, timeoutMs = 1000): Promise<void> => {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error('timed out waiting for the reactive count to arrive');
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+};
+
+describe('runCountC over a real socket, the count arrives reactively', () => {
+  let server: Awaited<ReturnType<typeof createServer>>;
+  let socket: ClientSocketWrapper;
+
+  afterEach(async () => {
+    await socket.close();
+    await server.close();
+  });
+
+  it('a client call runs the analysis and streams the count back into the store', async () => {
+    const storedFile = {
+      _id: 'f1',
+      name: 'reads.bam',
+      path: '/data/reads.bam',
+      size: 9,
+      extension: 'bam',
+      uploadedAt: new Date(),
+    };
+    // First find fills the subscription; second answers runCountC's locate.
+    const mongo = MongoWrapper.createNull({ find: [[storedFile], [storedFile]] });
+    const storage = FileStorageWrapper.createNull();
+    const runner = ScriptRunnerWrapper.createNull({ python3: '3\n' });
+    const ws = WebSocketWrapper.create();
+    const methods = new Methods();
+    const files = new Files(mongo, storage);
+    defineRunCountC(methods, runner, files, 'scripts/countC.py');
+    const rpcHandler = new RpcHandler(methods, ws);
+    const publications = new Publications(mongo, ws);
+    publications.define('files.all', () => ({ collection: 'files', query: {} }));
+
+    server = await createServer({ ws, publications, rpcHandler, files });
+    await server.listen({ port: 0 });
+    const port = String(server.addresses()[0].port);
+
+    socket = ClientSocketWrapper.create(`ws://localhost:${port}/ws`);
+    await socket.connect();
+    const manager = new ConnectionManager(socket);
+    const handle = manager.subscribe('files.all');
+    await handle.ready;
+
+    const store = manager.store('files');
+    expect(store.getById('f1')).toMatchObject({ _id: 'f1', name: 'reads.bam' });
+
+    const count = await manager.call('runCountC', 'f1');
+    expect(count).toBe(3);
+
+    await waitFor(() => (store.getById('f1') as { countC?: number } | undefined)?.countC === 3);
+    expect((store.getById('f1') as { countC?: number }).countC).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
Proves and delivers the whole arc: a client calls `runCountC` and the count arrives reactively.

## What changed
* **Acceptance test** (`tests/server/runCountCReactive.integration.test.ts`): real server, socket, and client with nulled Mongo and runner. Subscribes to `files.all`, calls `runCountC(fileId)`, and asserts the count streams back into the reactive store. Green — the server-side arc from 7.A.3 already composes end to end.
* **Live demo**: a Count C button per file row calls `runCountC` over the socket; the server counts, writes the count onto the document, and it streams back onto that row through the same subscription — no extra client wiring.

Stacked on EKO-289.

https://linear.app/ekohacks/issue/EKO-291/7a5-call-runcountc-from-the-client-and-see-the-count-arrive-reactively
