### PR TITLE
7.B.3: App.create with real infrastructure

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -56,9 +56,11 @@ export class App {
   readonly methods: Methods;
   readonly files: Files;
   readonly rpcHandler: RpcHandler;
+  private readonly mongo: MongoWrapper;
 
   private constructor(parts: AppParts) {
     this.ws = parts.ws;
+    this.mongo = parts.mongo;
     this.methods = new Methods();
     this.rpcHandler = new RpcHandler(this.methods, parts.ws);
     this.publications = new Publications(parts.mongo, parts.ws);
@@ -91,5 +93,13 @@ export class App {
       scriptRunner: ScriptRunnerWrapper.createNull(nullConfig.scriptResponses ?? {}),
       countCScript: nullConfig.countCScript ?? DEFAULT_COUNTC_SCRIPT,
     });
+  }
+
+  // Graceful shutdown. Closing the socket also closes the Fastify server it
+  // attached to; then the Mongo connection goes. Order matters: stop taking
+  // requests before dropping the database underneath them.
+  async close(): Promise<void> {
+    await this.ws.close();
+    await this.mongo.close();
   }
 }

--- a/server/infrastructure/mongo.ts
+++ b/server/infrastructure/mongo.ts
@@ -24,19 +24,34 @@ export class MongoWrapper {
   private readonly emitter = new EventEmitter();
   private readonly activeWatches = new Map<string, Promise<() => void>>();
 
-  private constructor(collectionFactory: CollectionFactory) {
+  private readonly closer: () => Promise<void>;
+
+  private constructor(
+    collectionFactory: CollectionFactory,
+    closer: () => Promise<void> = () => Promise.resolve(),
+  ) {
     this.collectionFactory = collectionFactory;
+    this.closer = closer;
   }
 
   static create(uri: string): MongoWrapper {
     const client = new Driver(uri);
     const db = client.db();
-    return new MongoWrapper((name: string) => new RealCollection(db.collection(name)));
+    return new MongoWrapper(
+      (name: string) => new RealCollection(db.collection(name)),
+      () => client.close(),
+    );
   }
 
   static createNull(options: StubbedMongoOptions = {}): MongoWrapper {
     const stub = new StubbedCollectionFactory(options);
     return new MongoWrapper((name: string) => stub.collection(name));
+  }
+
+  // Close the driver connection. Safe to call when nothing ever connected: the
+  // driver's own close is a no-op in that case. Nulled instances close to nothing.
+  async close(): Promise<void> {
+    await this.closer();
   }
 
   async find<T>(collection: string, query: object): Promise<T[]> {

--- a/server/infrastructure/process.ts
+++ b/server/infrastructure/process.ts
@@ -1,0 +1,79 @@
+import { EventEmitter, OutputTracker } from './outputTracker.ts';
+
+export type Signal = 'SIGINT' | 'SIGTERM';
+
+const EXIT_EVENT = 'exit';
+
+interface ProcessLike {
+  onSignal(handler: (signal: Signal) => void): void;
+  exit(code: number): void;
+}
+
+export class ProcessWrapper {
+  private readonly proc: ProcessLike;
+  private readonly emitter = new EventEmitter();
+
+  private constructor(proc: ProcessLike) {
+    this.proc = proc;
+  }
+
+  static create(): ProcessWrapper {
+    return new ProcessWrapper(new RealProcess());
+  }
+
+  static createNull(): ProcessWrapper {
+    return new ProcessWrapper(new StubbedProcess());
+  }
+
+  onSignal(handler: (signal: Signal) => void): void {
+    this.proc.onSignal(handler);
+  }
+
+  exit(code: number): void {
+    this.emitter.emit(EXIT_EVENT, { code });
+    this.proc.exit(code);
+  }
+
+  trackExits(): OutputTracker {
+    return new OutputTracker(this.emitter, EXIT_EVENT);
+  }
+
+  simulateSignal(signal: Signal): void {
+    if (!(this.proc instanceof StubbedProcess)) {
+      throw new Error('simulateSignal only available on null instance');
+    }
+    this.proc.simulateSignal(signal);
+  }
+}
+
+class RealProcess implements ProcessLike {
+  onSignal(handler: (signal: Signal) => void): void {
+    for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+      process.on(signal, () => {
+        handler(signal);
+      });
+    }
+  }
+
+  exit(code: number): void {
+    process.exit(code);
+  }
+}
+
+class StubbedProcess implements ProcessLike {
+  private readonly handlers: ((signal: Signal) => void)[] = [];
+
+  onSignal(handler: (signal: Signal) => void): void {
+    this.handlers.push(handler);
+  }
+
+  exit(): void {
+    // The nulled process survives its own exit; the tracker holds the story.
+  }
+
+  simulateSignal(signal: Signal): void {
+    for (const handler of [...this.handlers]) {
+      handler(signal);
+    }
+  }
+}

--- a/server/infrastructure/process.ts
+++ b/server/infrastructure/process.ts
@@ -7,6 +7,7 @@ const EXIT_EVENT = 'exit';
 interface ProcessLike {
   onSignal(handler: (signal: Signal) => void): void;
   exit(code: number): void;
+  startTimer(ms: number, callback: () => void): () => void;
 }
 
 export class ProcessWrapper {
@@ -38,6 +39,17 @@ export class ProcessWrapper {
     return new OutputTracker(this.emitter, EXIT_EVENT);
   }
 
+  startTimer(ms: number, callback: () => void): () => void {
+    return this.proc.startTimer(ms, callback);
+  }
+
+  advanceTime(ms: number): void {
+    if (!(this.proc instanceof StubbedProcess)) {
+      throw new Error('advanceTime only available on null instance');
+    }
+    this.proc.advanceTime(ms);
+  }
+
   simulateSignal(signal: Signal): void {
     if (!(this.proc instanceof StubbedProcess)) {
       throw new Error('simulateSignal only available on null instance');
@@ -58,10 +70,25 @@ class RealProcess implements ProcessLike {
   exit(code: number): void {
     process.exit(code);
   }
+
+  startTimer(ms: number, callback: () => void): () => void {
+    const timer = setTimeout(callback, ms);
+    return () => {
+      clearTimeout(timer);
+    };
+  }
+}
+
+interface StubbedTimer {
+  dueAt: number;
+  callback: () => void;
+  live: boolean;
 }
 
 class StubbedProcess implements ProcessLike {
   private readonly handlers: ((signal: Signal) => void)[] = [];
+  private readonly timers: StubbedTimer[] = [];
+  private now = 0;
 
   onSignal(handler: (signal: Signal) => void): void {
     this.handlers.push(handler);
@@ -69,6 +96,24 @@ class StubbedProcess implements ProcessLike {
 
   exit(): void {
     // The nulled process survives its own exit; the tracker holds the story.
+  }
+
+  startTimer(ms: number, callback: () => void): () => void {
+    const timer = { dueAt: this.now + ms, callback, live: true };
+    this.timers.push(timer);
+    return () => {
+      timer.live = false;
+    };
+  }
+
+  advanceTime(ms: number): void {
+    this.now += ms;
+    for (const timer of [...this.timers]) {
+      if (timer.live && timer.dueAt <= this.now) {
+        timer.live = false;
+        timer.callback();
+      }
+    }
   }
 
   simulateSignal(signal: Signal): void {

--- a/server/logic/shutdown.ts
+++ b/server/logic/shutdown.ts
@@ -13,6 +13,7 @@ export class Shutdown {
   private readonly closable: Closable;
   private readonly proc: ProcessWrapper;
   private readonly graceMs: number;
+  private shuttingDown = false;
 
   constructor(closable: Closable, proc: ProcessWrapper, options: { graceMs?: number } = {}) {
     this.closable = closable;
@@ -22,6 +23,12 @@ export class Shutdown {
 
   arm(): void {
     this.proc.onSignal(() => {
+      // A second signal means it: exit hard, no second goodbye.
+      if (this.shuttingDown) {
+        this.proc.exit(1);
+        return;
+      }
+      this.shuttingDown = true;
       const cancelDeadline = this.proc.startTimer(this.graceMs, () => {
         console.error('shutdown timed out, exiting hard');
         this.proc.exit(1);

--- a/server/logic/shutdown.ts
+++ b/server/logic/shutdown.ts
@@ -21,11 +21,12 @@ export class Shutdown {
 
   arm(): void {
     this.proc.onSignal(() => {
-      this.proc.startTimer(this.graceMs, () => {
+      const cancelDeadline = this.proc.startTimer(this.graceMs, () => {
         console.error('shutdown timed out, exiting hard');
         this.proc.exit(1);
       });
       void this.closable.close().then(() => {
+        cancelDeadline();
         this.proc.exit(0);
       });
     });

--- a/server/logic/shutdown.ts
+++ b/server/logic/shutdown.ts
@@ -33,10 +33,17 @@ export class Shutdown {
         console.error('shutdown timed out, exiting hard');
         this.proc.exit(1);
       });
-      void this.closable.close().then(() => {
-        cancelDeadline();
-        this.proc.exit(0);
-      });
+      void this.closable.close().then(
+        () => {
+          cancelDeadline();
+          this.proc.exit(0);
+        },
+        (err: unknown) => {
+          cancelDeadline();
+          console.error('shutdown failed:', err);
+          this.proc.exit(1);
+        },
+      );
     });
   }
 }

--- a/server/logic/shutdown.ts
+++ b/server/logic/shutdown.ts
@@ -1,0 +1,25 @@
+import { ProcessWrapper } from '../infrastructure/process.ts';
+
+interface Closable {
+  close(): Promise<void>;
+}
+
+// The shutdown policy, out of the boot shell so it can be tested: on a signal,
+// close the app and exit 0.
+export class Shutdown {
+  private readonly closable: Closable;
+  private readonly proc: ProcessWrapper;
+
+  constructor(closable: Closable, proc: ProcessWrapper) {
+    this.closable = closable;
+    this.proc = proc;
+  }
+
+  arm(): void {
+    this.proc.onSignal(() => {
+      void this.closable.close().then(() => {
+        this.proc.exit(0);
+      });
+    });
+  }
+}

--- a/server/logic/shutdown.ts
+++ b/server/logic/shutdown.ts
@@ -4,11 +4,15 @@ interface Closable {
   close(): Promise<void>;
 }
 
+const DEFAULT_GRACE_MS = 5000;
+
 // The shutdown policy, out of the boot shell so it can be tested: on a signal,
-// close the app and exit 0.
+// arm the deadline, then close the app. A clean close exits 0; a close still
+// pending when the deadline fires exits 1 rather than waiting for SIGKILL.
 export class Shutdown {
   private readonly closable: Closable;
   private readonly proc: ProcessWrapper;
+  private readonly graceMs = DEFAULT_GRACE_MS;
 
   constructor(closable: Closable, proc: ProcessWrapper) {
     this.closable = closable;
@@ -17,6 +21,10 @@ export class Shutdown {
 
   arm(): void {
     this.proc.onSignal(() => {
+      this.proc.startTimer(this.graceMs, () => {
+        console.error('shutdown timed out, exiting hard');
+        this.proc.exit(1);
+      });
       void this.closable.close().then(() => {
         this.proc.exit(0);
       });

--- a/server/logic/shutdown.ts
+++ b/server/logic/shutdown.ts
@@ -12,11 +12,12 @@ const DEFAULT_GRACE_MS = 5000;
 export class Shutdown {
   private readonly closable: Closable;
   private readonly proc: ProcessWrapper;
-  private readonly graceMs = DEFAULT_GRACE_MS;
+  private readonly graceMs: number;
 
-  constructor(closable: Closable, proc: ProcessWrapper) {
+  constructor(closable: Closable, proc: ProcessWrapper, options: { graceMs?: number } = {}) {
     this.closable = closable;
     this.proc = proc;
+    this.graceMs = options.graceMs ?? DEFAULT_GRACE_MS;
   }
 
   arm(): void {

--- a/server/start.ts
+++ b/server/start.ts
@@ -1,5 +1,7 @@
 import { createServer } from './index.ts';
 import { App, type AppConfig } from './app.ts';
+import { ProcessWrapper } from './infrastructure/process.ts';
+import { Shutdown } from './logic/shutdown.ts';
 
 // Real boot. Read config from the environment, let App wire the graph (Mongo, the
 // websocket, the pub/sub engine, the file store, and the standard files.all / echo /
@@ -20,11 +22,6 @@ await server.listen({ port: config.port, host: '0.0.0.0' });
 console.warn(`EkoLite listening on http://localhost:${String(config.port)} (ws at /ws)`);
 
 // Graceful shutdown: stop taking requests, then drop the database connection.
-for (const signal of ['SIGINT', 'SIGTERM'] as const) {
-  process.on(signal, () => {
-    void (async () => {
-      await app.close();
-      process.exit(0);
-    })();
-  });
-}
+// The policy (deadline, exit codes, second signal) lives in Shutdown, tested on
+// the nulled process; the shell only wires it to the real one.
+new Shutdown(app, ProcessWrapper.create()).arm();

--- a/server/start.ts
+++ b/server/start.ts
@@ -1,62 +1,30 @@
 import { createServer } from './index.ts';
-import { MongoWrapper } from './infrastructure/mongo.ts';
-import { WebSocketWrapper } from './infrastructure/websocket.ts';
-import { FileStorageWrapper } from './infrastructure/fileStorage.ts';
-import { ScriptRunnerWrapper } from './infrastructure/scriptRunner.ts';
-import { Publications } from './logic/publications.ts';
-import { RpcHandler } from './logic/rpcHandler.ts';
-import { Methods } from './logic/methods.ts';
-import { Files } from './logic/files.ts';
-import { defineRunCountC } from './logic/analysis.ts';
+import { App, type AppConfig } from './app.ts';
 
-// Real boot. The same pieces the end-to-end test wires by hand, wired here for a
-// live process: a Mongo connection, a websocket server, the pub/sub engine that
-// turns subscriptions into live document streams, and the file store behind uploads.
-const mongoUri = process.env.MONGO_URI ?? 'mongodb://localhost:27017/ekolite';
-const fileDir = process.env.FILE_DIR ?? './uploads';
-const countCScript = process.env.COUNTC_SCRIPT ?? 'scripts/countC.py';
-const port = Number(process.env.PORT ?? 3001);
+// Real boot. Read config from the environment, let App wire the graph (Mongo, the
+// websocket, the pub/sub engine, the file store, and the standard files.all / echo /
+// runCountC definitions), then serve it over Fastify. The wiring that used to live
+// here now lives in App.create, so the same assembly the end-to-end test drives is
+// the one that boots in production.
+const config: AppConfig = {
+  mongoUri: process.env.MONGO_URI ?? 'mongodb://localhost:27017/ekolite',
+  fileDir: process.env.FILE_DIR ?? './uploads',
+  countCScript: process.env.COUNTC_SCRIPT ?? 'scripts/countC.py',
+  port: Number(process.env.PORT ?? 3001),
+};
 
-const mongo = MongoWrapper.create(mongoUri);
-const ws = WebSocketWrapper.create();
-const storage = FileStorageWrapper.create(fileDir);
-const scriptRunner = ScriptRunnerWrapper.create();
-const methods = new Methods();
-const rpcHandler = new RpcHandler(methods, ws);
-const publications = new Publications(mongo, ws);
-const files = new Files(mongo, storage);
+const app = App.create(config);
+const server = await createServer(app);
+await server.listen({ port: config.port, host: '0.0.0.0' });
 
-// One publication to start with: every document in the files collection, kept in
-// sync with the client as Mongo changes.
-publications.define('files.all', () => ({ collection: 'files', query: {} }));
+console.warn(`EkoLite listening on http://localhost:${String(config.port)} (ws at /ws)`);
 
-// One method to start with: echo bounces its argument straight back, so a live
-// call('echo', 'hello') comes back 'echo: hello'. It gives the method round trip
-// something real to hit, the way files.all does for subscriptions.
-methods.define('echo', (message) => Promise.resolve(`echo: ${String(message)}`));
-
-// The first analysis method: runCountC resolves an uploaded file by id, runs the
-// count script against it, and writes the count back onto the file's document so it
-// streams to subscribers. The script path comes from config the same way MONGO_URI
-// and FILE_DIR do. For now scripts/countC.py is a stand-in that prints a fixed
-// count; the real counting script lands in a later story.
-defineRunCountC(methods, scriptRunner, files, countCScript);
-
-// Dev convenience: seed a couple of files so a fresh Mongo is not a blank page.
-// Idempotent (only seeds an empty collection) and best-effort (a missing Mongo
-// should not stop the server booting; subscriptions just come back empty).
-try {
-  const existing = await mongo.find('files', {});
-  if (existing.length === 0) {
-    await mongo.insert('files', { _id: 'seed-1', name: 'welcome.txt' });
-    await mongo.insert('files', { _id: 'seed-2', name: 'getting-started.md' });
-    console.warn('seeded files with 2 documents');
-  }
-} catch (err) {
-  console.warn('skipped seeding (is Mongo running?):', err instanceof Error ? err.message : err);
+// Graceful shutdown: stop taking requests, then drop the database connection.
+for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+  process.on(signal, () => {
+    void (async () => {
+      await app.close();
+      process.exit(0);
+    })();
+  });
 }
-
-const server = await createServer({ ws, publications, rpcHandler, files });
-await server.listen({ port, host: '0.0.0.0' });
-
-console.warn(`EkoLite listening on http://localhost:${String(port)} (ws at /ws)`);

--- a/tests/infrastructure/process.test.ts
+++ b/tests/infrastructure/process.test.ts
@@ -35,7 +35,20 @@ describe('ProcessWrapper (null)', () => {
     expect(exits.data).toEqual([{ code: 0 }, { code: 1 }]);
   });
 
-  it.todo('fires a timer when time advances to its deadline, and not before');
+  it('fires a timer when time advances to its deadline, and not before', () => {
+    const proc = ProcessWrapper.createNull();
+    let fired = false;
+
+    proc.startTimer(5000, () => {
+      fired = true;
+    });
+
+    proc.advanceTime(4999);
+    expect(fired).toBe(false);
+
+    proc.advanceTime(1);
+    expect(fired).toBe(true);
+  });
 
   it.todo('never fires a cancelled timer, however far time advances');
 });

--- a/tests/infrastructure/process.test.ts
+++ b/tests/infrastructure/process.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { ProcessWrapper } from '../../server/infrastructure/process.ts';
+
+// The process seam: signals in, exit codes out, and the deadline timers that
+// shutdown policy arms. Nulled, signals are simulated by hand, time only moves
+// when a test advances it, and exit() records instead of killing the test runner.
+//
+// Proposed shape, following the other wrappers:
+//   ProcessWrapper.create()            — real process.on / process.exit / setTimeout
+//   ProcessWrapper.createNull()        — everything below
+//   onSignal(handler)                  — handler receives 'SIGINT' | 'SIGTERM'
+//   exit(code)                         — real: never returns; null: records { code }
+//   startTimer(ms, callback)           — returns a cancel function
+//   trackExits()                       — OutputTracker of { code }
+//   simulateSignal(signal)             — null only
+//   advanceTime(ms)                    — null only, fires timers that come due
+describe('ProcessWrapper (null)', () => {
+  it('delivers a simulated signal to the handler', () => {
+    const proc = ProcessWrapper.createNull();
+    const received: string[] = [];
+
+    proc.onSignal((signal) => received.push(signal));
+    proc.simulateSignal('SIGTERM');
+
+    expect(received).toEqual(['SIGTERM']);
+  });
+
+  it('records exits in an output tracker instead of killing the process', () => {
+    const proc = ProcessWrapper.createNull();
+    const exits = proc.trackExits();
+
+    proc.exit(0);
+    proc.exit(1);
+
+    expect(exits.data).toEqual([{ code: 0 }, { code: 1 }]);
+  });
+
+  it.todo('fires a timer when time advances to its deadline, and not before');
+
+  it.todo('never fires a cancelled timer, however far time advances');
+});

--- a/tests/infrastructure/process.test.ts
+++ b/tests/infrastructure/process.test.ts
@@ -50,5 +50,16 @@ describe('ProcessWrapper (null)', () => {
     expect(fired).toBe(true);
   });
 
-  it.todo('never fires a cancelled timer, however far time advances');
+  it('never fires a cancelled timer, however far time advances', () => {
+    const proc = ProcessWrapper.createNull();
+    let fired = false;
+
+    const cancel = proc.startTimer(5000, () => {
+      fired = true;
+    });
+    cancel();
+
+    proc.advanceTime(60_000);
+    expect(fired).toBe(false);
+  });
 });

--- a/tests/logic/shutdown.test.ts
+++ b/tests/logic/shutdown.test.ts
@@ -90,7 +90,20 @@ describe('Shutdown', () => {
     expect(exits.data).toEqual([{ code: 0 }]);
   });
 
-  it.todo('the grace period is configurable and fires at the deadline, not before');
+  it('the grace period is configurable and fires at the deadline, not before', () => {
+    const { closable } = closableDouble();
+    const proc = ProcessWrapper.createNull();
+    const exits = proc.trackExits();
+    new Shutdown(closable, proc, { graceMs: 100 }).arm();
+
+    proc.simulateSignal('SIGTERM');
+
+    proc.advanceTime(99);
+    expect(exits.data).toEqual([]);
+
+    proc.advanceTime(1);
+    expect(exits.data).toEqual([{ code: 1 }]);
+  });
 
   it.todo('the grace period defaults to five seconds');
 

--- a/tests/logic/shutdown.test.ts
+++ b/tests/logic/shutdown.test.ts
@@ -120,7 +120,18 @@ describe('Shutdown', () => {
     expect(exits.data).toEqual([{ code: 1 }]);
   });
 
-  it.todo('a second signal exits 1 immediately, without waiting for the close');
+  it('a second signal exits 1 immediately, without waiting for the close', () => {
+    const { closable, closeCalls } = closableDouble();
+    const proc = ProcessWrapper.createNull();
+    const exits = proc.trackExits();
+    new Shutdown(closable, proc).arm();
+
+    proc.simulateSignal('SIGINT');
+    proc.simulateSignal('SIGINT');
+
+    expect(exits.data).toEqual([{ code: 1 }]);
+    expect(closeCalls()).toBe(1);
+  });
 
   it.todo('a close that rejects exits 1 instead of dying as an unhandled rejection');
 });

--- a/tests/logic/shutdown.test.ts
+++ b/tests/logic/shutdown.test.ts
@@ -1,4 +1,33 @@
-import { describe, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
+import { ProcessWrapper } from '../../server/infrastructure/process.ts';
+import { Shutdown } from '../../server/logic/shutdown.ts';
+
+// Recording double for the app side: a plain closable whose close() the test can
+// resolve, reject, or leave hanging, and which counts how often it was asked.
+function closableDouble() {
+  let closeCalls = 0;
+  // Assigned synchronously by the Promise executor below.
+  let resolveClose!: () => void;
+  let rejectClose!: (err: Error) => void;
+  const closed = new Promise<void>((resolve, reject) => {
+    resolveClose = resolve;
+    rejectClose = reject;
+  });
+  return {
+    closable: {
+      close: () => {
+        closeCalls += 1;
+        return closed;
+      },
+    },
+    closeCalls: () => closeCalls,
+    resolveClose,
+    rejectClose,
+  };
+}
+
+// Let settled promises run their then handlers before asserting.
+const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
 
 // 7.B.4 (proposed) — graceful shutdown with a deadline.
 //
@@ -16,7 +45,20 @@ import { describe, it } from 'vitest';
 // one behaviour from the design conversation; nothing here tests how (no
 // Promise.race assertions, no clearTimeout spies), only what the process observes.
 describe('Shutdown', () => {
-  it.todo('a signal closes the app, and a clean close exits 0');
+  it('a signal closes the app, and a clean close exits 0', async () => {
+    const { closable, closeCalls, resolveClose } = closableDouble();
+    const proc = ProcessWrapper.createNull();
+    const exits = proc.trackExits();
+    new Shutdown(closable, proc).arm();
+
+    proc.simulateSignal('SIGTERM');
+    expect(closeCalls()).toBe(1);
+
+    resolveClose();
+    await flush();
+
+    expect(exits.data).toEqual([{ code: 0 }]);
+  });
 
   it.todo('exits 1 when the close is still pending at the grace deadline');
 

--- a/tests/logic/shutdown.test.ts
+++ b/tests/logic/shutdown.test.ts
@@ -133,5 +133,20 @@ describe('Shutdown', () => {
     expect(closeCalls()).toBe(1);
   });
 
-  it.todo('a close that rejects exits 1 instead of dying as an unhandled rejection');
+  it('a close that rejects exits 1 instead of dying as an unhandled rejection', async () => {
+    const { closable, rejectClose } = closableDouble();
+    const proc = ProcessWrapper.createNull();
+    const exits = proc.trackExits();
+    new Shutdown(closable, proc).arm();
+
+    proc.simulateSignal('SIGTERM');
+    rejectClose(new Error('mongo refused to hang up'));
+    await flush();
+
+    expect(exits.data).toEqual([{ code: 1 }]);
+
+    // And the deadline was stood down here too: no second exit later.
+    proc.advanceTime(60_000);
+    expect(exits.data).toEqual([{ code: 1 }]);
+  });
 });

--- a/tests/logic/shutdown.test.ts
+++ b/tests/logic/shutdown.test.ts
@@ -60,7 +60,18 @@ describe('Shutdown', () => {
     expect(exits.data).toEqual([{ code: 0 }]);
   });
 
-  it.todo('exits 1 when the close is still pending at the grace deadline');
+  it('exits 1 when the close is still pending at the grace deadline', () => {
+    const { closable } = closableDouble();
+    const proc = ProcessWrapper.createNull();
+    const exits = proc.trackExits();
+    new Shutdown(closable, proc).arm();
+
+    proc.simulateSignal('SIGINT');
+    proc.advanceTime(5000);
+
+    // The close never resolved; the deadline exits anyway. No race needed.
+    expect(exits.data).toEqual([{ code: 1 }]);
+  });
 
   it.todo('a clean close cancels the deadline: time can pass, only one exit is recorded');
 

--- a/tests/logic/shutdown.test.ts
+++ b/tests/logic/shutdown.test.ts
@@ -73,7 +73,22 @@ describe('Shutdown', () => {
     expect(exits.data).toEqual([{ code: 1 }]);
   });
 
-  it.todo('a clean close cancels the deadline: time can pass, only one exit is recorded');
+  it('a clean close cancels the deadline: time can pass, only one exit is recorded', async () => {
+    const { closable, resolveClose } = closableDouble();
+    const proc = ProcessWrapper.createNull();
+    const exits = proc.trackExits();
+    new Shutdown(closable, proc).arm();
+
+    proc.simulateSignal('SIGTERM');
+    resolveClose();
+    await flush();
+
+    // A real process dies at exit(0) and can never testify about a forgotten
+    // clearTimeout. The nulled one outlives it, so the mess would show up here.
+    proc.advanceTime(60_000);
+
+    expect(exits.data).toEqual([{ code: 0 }]);
+  });
 
   it.todo('the grace period is configurable and fires at the deadline, not before');
 

--- a/tests/logic/shutdown.test.ts
+++ b/tests/logic/shutdown.test.ts
@@ -105,7 +105,20 @@ describe('Shutdown', () => {
     expect(exits.data).toEqual([{ code: 1 }]);
   });
 
-  it.todo('the grace period defaults to five seconds');
+  it('the grace period defaults to five seconds', () => {
+    const { closable } = closableDouble();
+    const proc = ProcessWrapper.createNull();
+    const exits = proc.trackExits();
+    new Shutdown(closable, proc).arm();
+
+    proc.simulateSignal('SIGTERM');
+
+    proc.advanceTime(4999);
+    expect(exits.data).toEqual([]);
+
+    proc.advanceTime(1);
+    expect(exits.data).toEqual([{ code: 1 }]);
+  });
 
   it.todo('a second signal exits 1 immediately, without waiting for the close');
 

--- a/tests/logic/shutdown.test.ts
+++ b/tests/logic/shutdown.test.ts
@@ -1,0 +1,32 @@
+import { describe, it } from 'vitest';
+
+// 7.B.4 (proposed) — graceful shutdown with a deadline.
+//
+// The policy that used to be three untestable lines in start.ts: on a signal,
+// close the app; if the close beats the grace period, exit 0; if it hangs, exit 1
+// rather than wait for SIGKILL. Runs on ProcessWrapper.createNull() so signals,
+// time, and exits are all in the test's hands. The app side is a recording
+// double: a plain closable whose close() the test can resolve, hang, or reject.
+//
+// Proposed shape:
+//   new Shutdown(closable, proc, { graceMs? })   — graceMs defaults to 5000
+//   shutdown.arm()                               — subscribes to SIGINT and SIGTERM
+//
+// These activate one at a time, in order, as the ladder is climbed. Each name is
+// one behaviour from the design conversation; nothing here tests how (no
+// Promise.race assertions, no clearTimeout spies), only what the process observes.
+describe('Shutdown', () => {
+  it.todo('a signal closes the app, and a clean close exits 0');
+
+  it.todo('exits 1 when the close is still pending at the grace deadline');
+
+  it.todo('a clean close cancels the deadline: time can pass, only one exit is recorded');
+
+  it.todo('the grace period is configurable and fires at the deadline, not before');
+
+  it.todo('the grace period defaults to five seconds');
+
+  it.todo('a second signal exits 1 immediately, without waiting for the close');
+
+  it.todo('a close that rejects exits 1 instead of dying as an unhandled rejection');
+});

--- a/tests/server/appCreate.integration.test.ts
+++ b/tests/server/appCreate.integration.test.ts
@@ -12,15 +12,18 @@ import { App } from '../../server/app.ts';
 // graceful shutdown: it closes the socket (and with it the Fastify server) and the
 // Mongo connection.
 describe('App.create wires real infrastructure', () => {
-  let app: App;
+  let app: App | undefined;
   let server: Awaited<ReturnType<typeof createServer>>;
   let client: WebSocket | undefined;
 
   afterEach(async () => {
     client?.close();
+    client = undefined;
     // app.close() shuts the socket, which closes the Fastify server it attached to,
-    // then the Mongo connection. One close for the whole graph.
-    await app.close();
+    // then the Mongo connection. One close for the whole graph. Guarded: if
+    // App.create ever throws, app is still undefined here.
+    await app?.close();
+    app = undefined;
   });
 
   it('boots a server that serves the page and accepts websocket connections', async () => {

--- a/tests/server/appCreate.integration.test.ts
+++ b/tests/server/appCreate.integration.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import WebSocket from 'ws';
+import { createServer } from '../../server/index.ts';
+import { App } from '../../server/app.ts';
+
+// 7.B.3 — App.create wires real infrastructure.
+//
+// The live boot, behind the class. App.create(config) builds the real Mongo, socket,
+// storage and script runner, and createServer turns that into a Fastify server that
+// serves the built client and speaks the websocket protocol. GET / and /ws touch
+// neither Mongo nor python, so this runs without a database. app.close() is the
+// graceful shutdown: it closes the socket (and with it the Fastify server) and the
+// Mongo connection.
+describe('App.create wires real infrastructure', () => {
+  let app: App;
+  let server: Awaited<ReturnType<typeof createServer>>;
+  let client: WebSocket | undefined;
+
+  afterEach(async () => {
+    client?.close();
+    // app.close() shuts the socket, which closes the Fastify server it attached to,
+    // then the Mongo connection. One close for the whole graph.
+    await app.close();
+  });
+
+  it('boots a server that serves the page and accepts websocket connections', async () => {
+    app = App.create({
+      mongoUri: 'mongodb://localhost:27017/ekolite-test',
+      fileDir: './uploads',
+      countCScript: 'scripts/countC.py',
+      port: 0,
+    });
+
+    server = await createServer(app);
+    await server.listen({ port: 0 });
+    const port = String(server.addresses()[0].port);
+
+    const response = await server.inject({ method: 'GET', url: '/' });
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['content-type']).toContain('text/html');
+
+    client = new WebSocket(`ws://localhost:${port}/ws`);
+    await new Promise((resolve, reject) => {
+      client?.on('open', resolve);
+      client?.on('error', reject);
+    });
+
+    expect(client.readyState).toBe(WebSocket.OPEN);
+  });
+});


### PR DESCRIPTION
## Summary
The live boot moves behind `App.create(config)`; `start.ts` shrinks to reading env config and serving the app. Then graceful shutdown grows into a proper, tested policy: on a signal the app closes cleanly within a deadline, or exits with a meaningful code.

## What changed
* `start.ts`: reads `MONGO_URI` / `FILE_DIR` / `COUNTC_SCRIPT` / `PORT` into an `AppConfig`, calls `App.create(config)`, and hands it to `createServer`. The by hand wiring is gone, and so is the dev convenience seeding block — a fresh Mongo now starts empty.
* Graceful shutdown: `app.close()` closes the socket first (taking the Fastify server it attached to with it), then the Mongo connection — stop taking requests before dropping the database underneath them.
* `MongoWrapper` gains `close()`: the real one closes the driver client (safe when nothing ever connected), the Nulled one closes to nothing.

## The shutdown ladder
The signal handling behind `start.ts` is now a tested policy, not three hand-rolled lines, built one behaviour per commit:
* `ProcessWrapper` (`server/infrastructure/process.ts`) — a nullable seam over the parts of Node a test can't touch: signals in, exits out (recorded, not executed), and a manual-clock timer. `create()` uses the real process; `createNull()` lets a test simulate a signal, advance time, and read exits from an output tracker.
* `Shutdown` (`server/logic/shutdown.ts`) — the policy: on SIGINT/SIGTERM, close the app; exit 0 if it closes within a 5s grace, exit 1 if it hangs past the deadline or the close rejects; a second signal exits 1 immediately.
* `start.ts` wires it: `new Shutdown(app, ProcessWrapper.create()).arm()`.

Eleven tests pin the policy (`tests/infrastructure/process.test.ts`, `tests/logic/shutdown.test.ts`). Verified live: boot, SIGTERM, exit 0.

## Tests
Integration, `tests/server/appCreate.integration.test.ts`: a booted `App.create(config)` answers `GET /` with the page and accepts a `/ws` connection, touching neither Mongo nor python, and `app.close()` shuts the whole graph down in the teardown.

https://linear.app/ekohacks/issue/EKO-193/7b3-appcreate-with-real-infrastructure
