### PR TITLE
Shutdown drains change streams before closing Mongo

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -96,10 +96,12 @@ export class App {
   }
 
   // Graceful shutdown. Closing the socket also closes the Fastify server it
-  // attached to; then the Mongo connection goes. Order matters: stop taking
-  // requests before dropping the database underneath them.
+  // attached to; then the publications' change streams are drained; then the Mongo
+  // connection goes. Order matters: stop taking requests, stop the streams, and only
+  // then drop the database, so it never closes with a change stream open underneath.
   async close(): Promise<void> {
     await this.ws.close();
+    await this.publications.stopAll();
     await this.mongo.close();
   }
 }

--- a/server/app.ts
+++ b/server/app.ts
@@ -7,6 +7,7 @@ import { RpcHandler } from './logic/rpcHandler.ts';
 import { Methods } from './logic/methods.ts';
 import { Files } from './logic/files.ts';
 import { defineRunCountC } from './logic/analysis.ts';
+import { closeAll } from '../shared/helperFunctions.ts';
 import { type StoredFile } from '../shared/types.ts';
 
 // Config for the real boot. The same knobs start.ts reads from the environment.
@@ -100,8 +101,13 @@ export class App {
   // connection goes. Order matters: stop taking requests, stop the streams, and only
   // then drop the database, so it never closes with a change stream open underneath.
   async close(): Promise<void> {
-    await this.ws.close();
-    await this.publications.stopAll();
-    await this.mongo.close();
+    // Best-effort: each step runs even if an earlier one rejects, so a failing socket
+    // close never leaves the Mongo connection open. closeAll rethrows the first error
+    // so a hung or broken shutdown still exits non-zero through Shutdown.
+    await closeAll([
+      () => this.ws.close(),
+      () => this.publications.stopAll(),
+      () => this.mongo.close(),
+    ]);
   }
 }

--- a/server/infrastructure/mongo.ts
+++ b/server/infrastructure/mongo.ts
@@ -7,7 +7,7 @@ interface CollectionLike {
   insertOne(doc: object): Promise<void>;
   updateMany(query: object, changes: object): Promise<void>;
   deleteMany(query: object): Promise<void>;
-  watch(onChange: (raw: unknown) => void): Promise<() => void>;
+  watch(onChange: (raw: unknown) => void): Promise<() => Promise<void>>;
 }
 
 type CollectionFactory = (name: string) => CollectionLike;
@@ -22,7 +22,7 @@ interface StubbedMongoOptions {
 export class MongoWrapper {
   private readonly collectionFactory: CollectionFactory;
   private readonly emitter = new EventEmitter();
-  private readonly activeWatches = new Map<string, Promise<() => void>>();
+  private readonly activeWatches = new Map<string, Promise<() => Promise<void>>>();
 
   private readonly closer: () => Promise<void>;
 
@@ -48,10 +48,24 @@ export class MongoWrapper {
     return new MongoWrapper((name: string) => stub.collection(name));
   }
 
-  // Close the driver connection. Safe to call when nothing ever connected: the
-  // driver's own close is a no-op in that case. Nulled instances close to nothing.
+  // Close the driver connection. Stop every open change stream first: closing the
+  // driver client with a change stream still open is the race that logs
+  // MongoClientClosedError. Safe to call when nothing ever connected — the driver's
+  // own close is a no-op then, and Nulled instances close to nothing.
   async close(): Promise<void> {
+    await this.stopAllWatches();
     await this.closer();
+  }
+
+  // Force every active change stream shut, regardless of remaining subscribers.
+  // Mirrors closeWatchIfUnused but drains the whole map at once, for shutdown.
+  private async stopAllWatches(): Promise<void> {
+    const watches = [...this.activeWatches.values()];
+    this.activeWatches.clear();
+    for (const watch of watches) {
+      const stopWatching = await watch;
+      await stopWatching();
+    }
   }
 
   async find<T>(collection: string, query: object): Promise<T[]> {
@@ -70,7 +84,10 @@ export class MongoWrapper {
     return this.collectionFactory(collection).deleteMany(query);
   }
 
-  async watchChanges(collection: string, cb: (data: ChangeEvent) => void): Promise<() => void> {
+  async watchChanges(
+    collection: string,
+    cb: (data: ChangeEvent) => void,
+  ): Promise<() => Promise<void>> {
     const wrappedCb = (data: unknown) => {
       if (isChangeEvent(data)) {
         cb(data);
@@ -79,9 +96,9 @@ export class MongoWrapper {
     this.emitter.on(collection, wrappedCb);
     await this.openWatchIfNeeded(collection);
 
-    return () => {
+    return async () => {
       this.emitter.off(collection, wrappedCb);
-      void this.closeWatchIfUnused(collection);
+      await this.closeWatchIfUnused(collection);
     };
   }
 
@@ -120,7 +137,7 @@ export class MongoWrapper {
     if (watch) {
       this.activeWatches.delete(collection);
       const stopWatching = await watch;
-      stopWatching();
+      await stopWatching();
     }
   }
 }
@@ -144,7 +161,7 @@ class RealCollection implements CollectionLike {
     return this.collection.deleteMany(query).then(() => undefined);
   }
 
-  async watch(onChange: (raw: unknown) => void): Promise<() => void> {
+  async watch(onChange: (raw: unknown) => void): Promise<() => Promise<void>> {
     const changeStream = this.collection.watch([], { fullDocument: 'updateLookup' });
     changeStream.on('change', onChange);
     changeStream.on('error', (err) => {
@@ -161,9 +178,9 @@ class RealCollection implements CollectionLike {
       });
       changeStream.once('error', reject);
     });
-    return () => {
-      void changeStream.close();
-    };
+    // Return the close promise so callers can await the stream actually shutting
+    // down before the driver client is closed underneath it.
+    return () => changeStream.close();
   }
 }
 
@@ -277,13 +294,14 @@ class StubbedCollection implements CollectionLike {
     return Promise.resolve();
   }
 
-  watch(onChange: (raw: unknown) => void): Promise<() => void> {
+  watch(onChange: (raw: unknown) => void): Promise<() => Promise<void>> {
     const listener = (data: unknown) => {
       onChange(data);
     };
     this.emitter.on(this.collectionName, listener);
     return Promise.resolve(() => {
       this.emitter.off(this.collectionName, listener);
+      return Promise.resolve();
     });
   }
 }

--- a/server/logic/publications.ts
+++ b/server/logic/publications.ts
@@ -9,7 +9,7 @@ import { ChangeEvent } from '../../shared/types.ts';
 type PublicationDef = (params?: Record<string, unknown>) => { collection: string; query: object };
 
 interface SubscriptionRecord {
-  cleanup: () => void;
+  cleanup: () => Promise<void>;
   // Document ids this subscription has sent `added` for and not yet sent
   // `removed` for. Mirrors the client's view of what's been delivered, not
   // the live Mongo state. When watcher 'update'/'delete' get wired through,
@@ -64,7 +64,7 @@ export class Publications {
     this.ws = ws;
     this.observer = observer;
     this.ws.onDisconnect((clientId) => {
-      this.tearDownClient(clientId);
+      void this.tearDownClient(clientId);
     });
   }
 
@@ -95,17 +95,21 @@ export class Publications {
     this.notifyObserver(message, 'failed', reason);
   }
 
-  private tearDownClient(clientId: string): void {
+  private async tearDownClient(clientId: string): Promise<void> {
     const clientSubs = this.subscriptions.get(clientId);
     if (!clientSubs) {
       return;
     }
 
-    for (const { cleanup } of clientSubs.values()) {
-      cleanup();
-    }
-
     this.subscriptions.delete(clientId);
+    await Promise.all([...clientSubs.values()].map(({ cleanup }) => cleanup()));
+  }
+
+  // Stop every subscription's change stream across all clients. Called on shutdown
+  // so App.close can await the streams closing before the Mongo client is dropped.
+  async stopAll(): Promise<void> {
+    const clientIds = [...this.subscriptions.keys()];
+    await Promise.all(clientIds.map((clientId) => this.tearDownClient(clientId)));
   }
 
   define(name: string, queryFn: PublicationDef): void {
@@ -216,7 +220,7 @@ export class Publications {
 
       const existing = clientSubs.get(message.id);
       if (existing) {
-        existing.cleanup();
+        await existing.cleanup();
       }
 
       clientSubs.set(message.id, { cleanup, documentIds, collection: collectionName });
@@ -245,7 +249,7 @@ export class Publications {
         return Promise.resolve();
       }
 
-      subscriptionRecord.cleanup();
+      await subscriptionRecord.cleanup();
 
       for (const docId of subscriptionRecord.documentIds) {
         this.ws.send(clientId, removedMessage(subscriptionRecord.collection, docId));

--- a/shared/helperFunctions.ts
+++ b/shared/helperFunctions.ts
@@ -2,6 +2,24 @@ export function assertNever(x: never): never {
   throw new Error(`Unexpected value: ${JSON.stringify(x)}`);
 }
 
+// Run shutdown steps in order, best-effort: every step runs even if an earlier one
+// rejects, so a failing socket close can't skip the database close. The first error
+// is rethrown once all steps have run, so the caller still knows the shutdown was
+// not clean (and can exit non-zero).
+export async function closeAll(steps: (() => Promise<void>)[]): Promise<void> {
+  const errors: unknown[] = [];
+  for (const step of steps) {
+    try {
+      await step();
+    } catch (err) {
+      errors.push(err);
+    }
+  }
+  if (errors.length > 0) {
+    throw errors[0];
+  }
+}
+
 export function hasMongoOperator(obj: unknown): boolean {
   if (obj === null || obj === undefined) {
     return false;

--- a/tests/infrastructure/mongo.integration.test.ts
+++ b/tests/infrastructure/mongo.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, afterAll } from 'vitest';
 import { MongoWrapper } from '../../server/infrastructure/mongo.ts';
 
 describe('MongoWrapper (real)', () => {
@@ -6,6 +6,12 @@ describe('MongoWrapper (real)', () => {
 
   afterEach(async () => {
     await mongo.remove('testDocs', {});
+  });
+
+  // Close the driver client once, cleanly. close() now drains any open change
+  // stream first, so this no longer races a live stream into "Topology is closed".
+  afterAll(async () => {
+    await mongo.close();
   });
 
   it('inserts and finds documents', async () => {
@@ -53,7 +59,9 @@ describe('MongoWrapper (real)', () => {
       expect(changes[1]).toMatchObject({ type: 'update', collection: 'testDocs' });
       expect(changes[2]).toMatchObject({ type: 'remove', collection: 'testDocs' });
     } finally {
-      stop();
+      // Await the stream actually closing, not fire-and-forget, so it is gone
+      // before the suite tears the client down.
+      await stop();
     }
   });
 });

--- a/tests/infrastructure/mongo.test.ts
+++ b/tests/infrastructure/mongo.test.ts
@@ -257,9 +257,9 @@ describe('MongoWrapper (null)', () => {
       /* empty */
     });
     expect(mongo.watcherCount('files')).toBe(2);
-    stop1();
+    await stop1();
     expect(mongo.watcherCount('files')).toBe(1);
-    stop2();
+    await stop2();
     expect(mongo.watcherCount('files')).toBe(0);
   });
 
@@ -289,5 +289,19 @@ describe('MongoWrapper (null)', () => {
 
     expect(changes).toHaveLength(1);
     expect(changes[0]).toMatchObject({ type: 'insert', collection: 'todos' });
+  });
+
+  it('close() stops the underlying change streams so no changes arrive after', async () => {
+    const mongo = MongoWrapper.createNull();
+    const changes: ChangeEvent[] = [];
+    await mongo.watchChanges('todos', (c) => changes.push(c));
+
+    await mongo.close();
+    await mongo.insert('todos', { text: 'after close' });
+
+    // With the streams stopped, the insert reaches no watcher. Before the fix,
+    // close() left the change stream open and this insert still arrived — the same
+    // open-stream-while-client-closes race that logs MongoClientClosedError in prod.
+    expect(changes).toHaveLength(0);
   });
 });

--- a/tests/logic/publications.test.ts
+++ b/tests/logic/publications.test.ts
@@ -28,6 +28,25 @@ describe('Publications', () => {
     });
   });
 
+  it('stopAll stops every active subscription watch across clients', async () => {
+    const mongo = MongoWrapper.createNull();
+    const ws = WebSocketWrapper.createNull();
+    const clientA = ws.simulateConnection();
+    const clientB = ws.simulateConnection();
+    const pubs = new Publications(mongo, ws);
+    pubs.define('files.all', () => ({ collection: 'files', query: {} }));
+
+    await pubs.handleMessage(clientA.id, { type: 'subscribe', id: 's1', name: 'files.all' });
+    await pubs.handleMessage(clientB.id, { type: 'subscribe', id: 's2', name: 'files.all' });
+    expect(mongo.watcherCount('files')).toBe(2);
+
+    await pubs.stopAll();
+
+    // Every client's change stream is drained, so a shutdown can close Mongo with
+    // no stream still open underneath it.
+    expect(mongo.watcherCount('files')).toBe(0);
+  });
+
   it('notifies observer on failed subscribe for unknown publication', async () => {
     const notifications: { type: string; outcome: ObserverOutcome; reason?: string | undefined }[] =
       [];

--- a/tests/shared/closeAll.test.ts
+++ b/tests/shared/closeAll.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { closeAll } from '../../shared/helperFunctions.ts';
+
+// closeAll runs a sequence of shutdown steps best-effort: a step that rejects must
+// not skip the ones after it (so App.close never drops the Mongo connection just
+// because the socket close threw), but the failure is still surfaced so the caller
+// can exit non-zero.
+describe('closeAll', () => {
+  it('runs every step even when an earlier one rejects, then throws the first error', async () => {
+    const calls: string[] = [];
+
+    await expect(
+      closeAll([
+        () => {
+          calls.push('a');
+          return Promise.resolve();
+        },
+        () => {
+          calls.push('b');
+          return Promise.reject(new Error('b failed'));
+        },
+        () => {
+          calls.push('c');
+          return Promise.resolve();
+        },
+      ]),
+    ).rejects.toThrow('b failed');
+
+    // c ran despite b rejecting.
+    expect(calls).toEqual(['a', 'b', 'c']);
+  });
+
+  it('resolves when every step succeeds', async () => {
+    const calls: string[] = [];
+
+    await closeAll([
+      () => {
+        calls.push('a');
+        return Promise.resolve();
+      },
+      () => {
+        calls.push('b');
+        return Promise.resolve();
+      },
+    ]);
+
+    expect(calls).toEqual(['a', 'b']);
+  });
+});


### PR DESCRIPTION
## Summary
On shutdown, `App.close()` closed the socket then the Mongo driver client without stopping the publications' open change streams first — so the client closed with a change stream still open, logging `MongoClientClosedError` / "Topology is closed". The same race is why 4 change-stream tests in `tests/infrastructure/mongo.integration.test.ts` were failing.

## What changed (red/green, one behaviour per commit)
* `MongoWrapper.close()` stops every active change stream before closing the driver; the watch-stop closures are now awaitable (`RealCollection.watch` returns the `changeStream.close()` promise instead of voiding it).
* `Publications.stopAll()` drains every client's subscription; `App.close()` awaits it before `mongo.close()`, so no stream outlives the driver client.
* The 4 integration tests await stream teardown and close the client cleanly in `afterAll` — they pass.

## Verification
Full unit suite green; full integration suite green (run serially — the websocket integration tests flake under parallel runs, pre-existing on the base). Re-running the meteorHilbert migration spike shows the `MongoClientClosedError` on shutdown is gone.

Stacked on #106; base retargets to main once it merges. Closes EKO-296.