### PR TITLE
React useSubscription hook (ekolite/react)

### DIFF
--- a/client/react.ts
+++ b/client/react.ts
@@ -1,0 +1,52 @@
+import { useEffect, useMemo, useState, useSyncExternalStore } from 'react';
+import { ConnectionManager } from './connectionManager.ts';
+import { bindStore } from './reactiveStoreBinding.ts';
+
+type StoredDocWithId = Record<string, unknown> & { _id: string };
+
+export interface UseSubscriptionResult {
+  data: StoredDocWithId[];
+  isLoading: boolean;
+}
+
+// The React binding — Meteor's useTracker, for EkoLite. Subscribes on mount, streams
+// the collection's live documents through useSyncExternalStore, and reports isLoading
+// until the subscription is ready; stops the subscription on unmount. A thin wrapper
+// over bindStore (the tested subscribe/getSnapshot core) and ConnectionManager.
+//
+// The collection name is passed explicitly rather than derived from the subscription
+// name: the server chooses the collection and it is not exposed on the handle.
+export function useSubscription(
+  manager: ConnectionManager,
+  name: string,
+  collection: string,
+  params?: Record<string, unknown>,
+): UseSubscriptionResult {
+  const [isLoading, setIsLoading] = useState(true);
+  // params is folded into a stable string so the effect only re-runs when it truly
+  // changes, not on every render's fresh object identity.
+  const paramsKey = JSON.stringify(params ?? null);
+
+  useEffect(() => {
+    const handle = manager.subscribe(name, params ?? undefined);
+    let active = true;
+    const done = () => {
+      if (active) {
+        setIsLoading(false);
+      }
+    };
+    handle.ready.then(done, done);
+    return () => {
+      active = false;
+      handle.stop();
+    };
+  }, [manager, name, paramsKey]);
+
+  // manager.store(collection) returns the same cached store instance each render, so
+  // the binding stays stable and useSyncExternalStore does not resubscribe every time.
+  const store = manager.store(collection);
+  const binding = useMemo(() => bindStore(store), [store]);
+  const data = useSyncExternalStore(binding.subscribe, binding.getSnapshot);
+
+  return { data, isLoading };
+}

--- a/client/reactiveStoreBinding.ts
+++ b/client/reactiveStoreBinding.ts
@@ -3,8 +3,8 @@ import { ReactiveStore } from './reactiveStore.ts';
 type StoredDocWithId = Record<string, unknown> & { _id: string };
 
 export interface StoreBinding {
-  subscribe(onStoreChange: () => void): () => void;
-  getSnapshot(): StoredDocWithId[];
+  subscribe: (onStoreChange: () => void) => () => void;
+  getSnapshot: () => StoredDocWithId[];
 }
 
 // The framework-agnostic core of the React hook. useSyncExternalStore wants a
@@ -16,14 +16,11 @@ export function bindStore(store: ReactiveStore): StoreBinding {
   let snapshot = store.getAll();
 
   return {
-    subscribe(onStoreChange: () => void): () => void {
-      return store.onChange(() => {
+    subscribe: (onStoreChange: () => void): (() => void) =>
+      store.onChange(() => {
         snapshot = store.getAll();
         onStoreChange();
-      });
-    },
-    getSnapshot(): StoredDocWithId[] {
-      return snapshot;
-    },
+      }),
+    getSnapshot: (): StoredDocWithId[] => snapshot,
   };
 }

--- a/client/reactiveStoreBinding.ts
+++ b/client/reactiveStoreBinding.ts
@@ -1,0 +1,29 @@
+import { ReactiveStore } from './reactiveStore.ts';
+
+type StoredDocWithId = Record<string, unknown> & { _id: string };
+
+export interface StoreBinding {
+  subscribe(onStoreChange: () => void): () => void;
+  getSnapshot(): StoredDocWithId[];
+}
+
+// The framework-agnostic core of the React hook. useSyncExternalStore wants a
+// subscribe/getSnapshot pair where getSnapshot returns a stable reference until
+// something actually changes — but ReactiveStore.getAll() builds a fresh array every
+// call, which would make React loop. bindStore caches the snapshot and recomputes it
+// once per change, inside the change handler, before notifying the consumer.
+export function bindStore(store: ReactiveStore): StoreBinding {
+  let snapshot = store.getAll();
+
+  return {
+    subscribe(onStoreChange: () => void): () => void {
+      return store.onChange(() => {
+        snapshot = store.getAll();
+        onStoreChange();
+      });
+    },
+    getSnapshot(): StoredDocWithId[] {
+      return snapshot;
+    },
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,10 +16,14 @@
         "mongodb": "^7.2.0",
         "ws": "^8.20.1"
       },
+      "bin": {
+        "ekolite": "dist/server/cli.js"
+      },
       "devDependencies": {
         "@commitlint/cli": "^21.0.1",
         "@commitlint/config-conventional": "^21.0.1",
         "@eslint/js": "^10.0.1",
+        "@types/react": "^18.3.31",
         "@types/ws": "^8.18.1",
         "@vitest/coverage-v8": "^4.1.6",
         "eslint": "^10.4.0",
@@ -28,6 +32,7 @@
         "husky": "^9.1.7",
         "lint-staged": "^17.0.5",
         "prettier": "^3.8.3",
+        "react": "^18.3.1",
         "tsx": "^4.22",
         "typescript": "^6.0",
         "typescript-eslint": "^8.59.4",
@@ -37,6 +42,14 @@
       },
       "engines": {
         "node": ">=24"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -2561,6 +2574,24 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/unist": {
@@ -5487,6 +5518,19 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "11.4.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
@@ -6205,6 +6249,19 @@
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",

--- a/package.json
+++ b/package.json
@@ -93,10 +93,19 @@
     "mongodb": "^7.2.0",
     "ws": "^8.20.1"
   },
+  "peerDependencies": {
+    "react": ">=18"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@commitlint/cli": "^21.0.1",
     "@commitlint/config-conventional": "^21.0.1",
     "@eslint/js": "^10.0.1",
+    "@types/react": "^18.3.31",
     "@types/ws": "^8.18.1",
     "@vitest/coverage-v8": "^4.1.6",
     "eslint": "^10.4.0",
@@ -105,6 +114,7 @@
     "husky": "^9.1.7",
     "lint-staged": "^17.0.5",
     "prettier": "^3.8.3",
+    "react": "^18.3.1",
     "tsx": "^4.22",
     "typescript": "^6.0",
     "typescript-eslint": "^8.59.4",

--- a/tests/client/reactiveStoreBinding.test.ts
+++ b/tests/client/reactiveStoreBinding.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { ReactiveStore } from '../../client/reactiveStore.ts';
+import { bindStore } from '../../client/reactiveStoreBinding.ts';
+
+// bindStore is the framework-agnostic half of the React hook: the subscribe +
+// cached-getSnapshot pair useSyncExternalStore needs. Tested here with no React and
+// no DOM, driving a plain ReactiveStore. The hook itself is a thin wrapper over this.
+describe('bindStore', () => {
+  it('getSnapshot returns a stable reference until the store changes', () => {
+    const store = new ReactiveStore();
+    const binding = bindStore(store);
+    let calls = 0;
+    binding.subscribe(() => {
+      calls += 1;
+    });
+
+    const first = binding.getSnapshot();
+    // Same reference across calls, so useSyncExternalStore's Object.is check does not
+    // loop. getAll() itself returns a fresh array each call; bindStore caches it.
+    expect(binding.getSnapshot()).toBe(first);
+
+    store.handleMessage({ type: 'added', collection: 'files', id: '1', fields: { name: 'a.bam' } });
+
+    expect(calls).toBe(1);
+    const second = binding.getSnapshot();
+    expect(second).not.toBe(first);
+    expect(second).toEqual([{ _id: '1', name: 'a.bam' }]);
+  });
+
+  it('unsubscribe stops notifications', () => {
+    const store = new ReactiveStore();
+    const binding = bindStore(store);
+    let calls = 0;
+    const unsubscribe = binding.subscribe(() => {
+      calls += 1;
+    });
+
+    unsubscribe();
+    store.handleMessage({ type: 'added', collection: 'files', id: '1', fields: {} });
+
+    expect(calls).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
Adds `ekolite/react` with `useSubscription(manager, name, collection, params?)` returning `{ data, isLoading }`: a React hook that keeps a component in sync with a live server collection. It subscribes on mount, streams the collection's live documents through `useSyncExternalStore`, reports `isLoading` until the subscription is ready, and stops on unmount.

## How (minimal deps)
Split so the substance is testable without a DOM or a test-render library:
* `bindStore(store)` — a framework-agnostic `{ subscribe, getSnapshot }` pair with snapshot caching (`ReactiveStore.getAll()` returns a fresh array each call, which would make `useSyncExternalStore` loop). Unit-tested via the existing `createNull()` seam, no React.
* `useSubscription` — a thin `useSyncExternalStore` wrapper over `bindStore` plus the subscribe/ready/stop lifecycle.

`react` + `@types/react` are an optional peer dependency (dev here for building). No happy-dom, no @testing-library/react, no react-dom.

## Notes
The collection name is passed explicitly because the server chooses it and it is not exposed on the subscription handle. Typecheck, lint, and client tests green.

Rebased onto main after #152, which made subscribing from a mount effect safe. Closes EKO-297.
