### PR TITLE
Story 8.A: package EkoLite for npm (three entries, clean tarball, consumer smoke)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ EkoLite is a public, work in progress rebuild of Meteor's core ideas with delibe
 
 ## Status
 
-Work in progress, published early at `0.x` to claim the name and share the shape. The public API is still settling and can change between `0.x` releases, so pin a version and read the notes before upgrading. Not recommended for production yet.
+Work in progress. Not on npm yet: the first `0.x` release is imminent, an early publish to claim the name and share the shape while the public API settles. Expect changes between `0.x` releases, so pin a version once it lands. Not recommended for production yet.
 
 ## Install
 
@@ -25,6 +25,8 @@ const app = App.createNull();
 app.methods.define('greet', (name) => `hello ${String(name)}`);
 await app.methods.call('greet', ['world']); // 'hello world'
 ```
+
+Verify the packaged shape from a consumer's point of view with `npm run test:package`: it builds, packs, installs the tarball into a throwaway project outside this repo, and imports from all three entries. It does a real `npm install`, so it takes 30 to 60 seconds and runs as a manual gate rather than on every CI push.
 
 ## What works today
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,28 @@ A lightweight, real time backend framework in the spirit of Meteor. Fastify, Mon
 
 EkoLite is a public, work in progress rebuild of Meteor's core ideas with deliberate differences. The documents in [`docs/ekolite-overview/`](docs/ekolite-overview/) cover the thinking. This README covers what is actually built today.
 
+## Status
+
+Work in progress, published early at `0.x` to claim the name and share the shape. The public API is still settling and can change between `0.x` releases, so pin a version and read the notes before upgrading. Not recommended for production yet.
+
+## Install
+
+```bash
+npm install ekolite
+```
+
+Three entry points, everything else stays internal for now:
+
+```ts
+import { App } from 'ekolite'; // the server framework
+import { ConnectionManager } from 'ekolite/client'; // the browser client stack
+import type { ReadyMsg } from 'ekolite/shared'; // the wire protocol types
+
+const app = App.createNull();
+app.methods.define('greet', (name) => `hello ${String(name)}`);
+await app.methods.call('greet', ['world']); // 'hello world'
+```
+
 ## What works today
 
 - **Nullable infrastructure wrappers**, each with `create()` and `createNull()` factories: MongoDB (`MongoWrapper`), WebSocket server (`WebSocketWrapper`), file storage (`FileStorageWrapper`) and script runner (`ScriptRunnerWrapper`)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ EkoLite is a public, work in progress rebuild of Meteor's core ideas with delibe
 
 ## Status
 
-Work in progress. Not on npm yet: the first `0.x` release is imminent, an early publish to claim the name and share the shape while the public API settles. Expect changes between `0.x` releases, so pin a version once it lands. Not recommended for production yet.
+Work in progress, published early at `0.x` (currently `0.1.0`) to claim the name and share the shape. The public API is still settling and can change between `0.x` releases, so pin a version and read the notes before upgrading. Not recommended for production yet.
 
 ## Install
 

--- a/client/index.ts
+++ b/client/index.ts
@@ -1,0 +1,7 @@
+// Public browser client surface for the `ekolite/client` entry: open a socket to an
+// EkoLite server, subscribe to its publications, and hold the streamed documents in a
+// reactive store. The heartbeat, stubbed server and other internals stay unexported
+// until a consumer shows a need for them.
+export { ConnectionManager, type SubscriptionHandle } from './connectionManager.ts';
+export { ReactiveStore } from './reactiveStore.ts';
+export { ClientSocketWrapper, type WebSocketLike } from './clientSocket.ts';

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "@fastify/static": "^9.1.3",
         "@fastify/websocket": "^11.2.0",
         "fastify": "^5.8.5",
-        "mongodb": "^7.2.0"
+        "mongodb": "^7.2.0",
+        "ws": "^8.20.1"
       },
       "devDependencies": {
         "@commitlint/cli": "^21.0.1",
@@ -31,8 +32,7 @@
         "typescript": "^6.0",
         "typescript-eslint": "^8.59.4",
         "vite": "^8.0",
-        "vitest": "^4.1",
-        "ws": "^8.20.1"
+        "vitest": "^4.1"
       },
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,11 @@
   "type": "module",
   "main": "dist/server/index.js",
   "types": "dist/server/index.d.ts",
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "engines": {
     "node": ">=18"
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "dev:server": "tsx watch server/start.ts",
     "dev:client": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc -p tsconfig.build.json && vite build",
     "start": "node dist/server/index.js",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
@@ -59,7 +59,8 @@
     "@fastify/static": "^9.1.3",
     "@fastify/websocket": "^11.2.0",
     "fastify": "^5.8.5",
-    "mongodb": "^7.2.0"
+    "mongodb": "^7.2.0",
+    "ws": "^8.20.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^21.0.1",
@@ -77,7 +78,6 @@
     "typescript": "^6.0",
     "typescript-eslint": "^8.59.4",
     "vite": "^8.0",
-    "vitest": "^4.1",
-    "ws": "^8.20.1"
+    "vitest": "^4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "test:watch": "vitest --watch",
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:coverage": "vitest run --coverage",
+    "test:package": "node scripts/package-smoke.mjs",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
     "./shared": {
       "types": "./dist/shared/protocol.d.ts",
       "import": "./dist/shared/protocol.js"
+    },
+    "./client": {
+      "types": "./dist/client/index.d.ts",
+      "import": "./dist/client/index.js"
     }
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -15,6 +15,16 @@
   "type": "module",
   "main": "dist/server/index.js",
   "types": "dist/server/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/server/index.d.ts",
+      "import": "./dist/server/index.js"
+    },
+    "./shared": {
+      "types": "./dist/shared/protocol.d.ts",
+      "import": "./dist/shared/protocol.js"
+    }
+  },
   "files": [
     "dist",
     "README.md",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prepare": "husky",
+    "prepublishOnly": "npm run typecheck && npm test && npm run build",
     "test:changed": "vitest run --changed origin/main"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "dev:server": "tsx watch server/start.ts",
     "dev:client": "vite",
-    "build": "tsc -p tsconfig.build.json && vite build",
+    "build": "tsc -p tsconfig.build.json && node scripts/rewrite-dts.mjs && vite build",
     "start": "node dist/server/index.js",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -124,7 +124,7 @@ function main() {
     console.log('package smoke: PASS');
     console.log(`  consumer said: ${out}`);
     console.log('  declarations resolve to shipped files only');
-    console.log('  a TS consumer compiles against ekolite and ekolite/shared');
+    console.log('  a TS consumer compiles against ekolite, ekolite/shared and ekolite/client');
   } finally {
     rmSync(dir, { recursive: true, force: true });
     rmSync(tarball, { force: true });

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -23,8 +23,28 @@ function run(cmd, args, opts = {}) {
 }
 
 function main() {
-  // 1. Build and pack the library from the repo.
+  // 1. Build the library from the repo.
   run('npm', ['run', 'build'], { cwd: REPO });
+
+  // 2. Tarball hygiene: a consumer should receive the built package and nothing else,
+  //    not the tests, docs, demo source or CI config that make up the repo.
+  const packed = JSON.parse(run('npm', ['pack', '--dry-run', '--json'], { cwd: REPO }));
+  const shipped = packed[0].files.map((file) => file.path);
+  const strays = shipped.filter(
+    (path) =>
+      path !== 'package.json' &&
+      path !== 'README.md' &&
+      path !== 'LICENSE' &&
+      !path.startsWith('dist/'),
+  );
+  if (strays.length > 0) {
+    const sample = strays.slice(0, 8).join('\n  ');
+    throw new Error(
+      `tarball carries ${strays.length} files outside the allowlist (dist, README, LICENSE), e.g.:\n  ${sample}`,
+    );
+  }
+
+  // 3. Pack for real and install it.
   const packLines = run('npm', ['pack'], { cwd: REPO }).trim().split('\n');
   const tarball = join(REPO, packLines[packLines.length - 1].trim());
 

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -6,7 +6,7 @@
 // Red until the package actually emits a loadable server entry and exports App. Run it
 // with `node scripts/package-smoke.mjs`.
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -51,8 +51,23 @@ function main() {
       throw new Error(`unexpected consumer output:\n${out}`);
     }
 
+    // 5. The shipped types must resolve from the consumer side: every declaration file
+    //    may only import files that are actually in the package. A relative `.ts`
+    //    specifier points at a source file the tarball never carried, so a TS consumer
+    //    resolving these types would land on nothing.
+    const distDir = join(dir, 'node_modules', 'ekolite', 'dist');
+    const danglingTypes = readdirSync(distDir, { recursive: true })
+      .filter((name) => typeof name === 'string' && name.endsWith('.d.ts'))
+      .map((name) => ({ name, hits: readFileSync(join(distDir, name), 'utf8').match(/['"]\.\.?\/[^'"]*\.ts['"]/g) }))
+      .filter((file) => file.hits);
+    if (danglingTypes.length > 0) {
+      const detail = danglingTypes.map((f) => `  ${f.name}: ${f.hits.join(', ')}`).join('\n');
+      throw new Error(`shipped declarations import .ts files not in the package:\n${detail}`);
+    }
+
     console.log('package smoke: PASS');
     console.log(`  consumer said: ${out}`);
+    console.log('  declarations resolve to shipped files only');
   } finally {
     rmSync(dir, { recursive: true, force: true });
     rmSync(tarball, { force: true });

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -94,12 +94,14 @@ function main() {
       [
         "import { App } from 'ekolite';",
         "import type { ReadyMsg } from 'ekolite/shared';",
+        "import { ConnectionManager } from 'ekolite/client';",
         '',
         'const app = App.createNull();',
         "const ready: ReadyMsg = { type: 'ready', id: 'sub-1', collection: 'files' };",
         '',
         'void app;',
         'void ready;',
+        'void ConnectionManager;',
         '',
       ].join('\n'),
     );

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -12,6 +12,7 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const REPO = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const TSC = join(REPO, 'node_modules', '.bin', 'tsc');
 
 function run(cmd, args, opts = {}) {
   try {
@@ -85,9 +86,43 @@ function main() {
       throw new Error(`shipped declarations import .ts files not in the package:\n${detail}`);
     }
 
+    // 6. Types resolve from a real TS consumer: import App from the package root and a
+    //    protocol type from the ekolite/shared entry, use them, and compile. This proves
+    //    the exports map and the declarations line up, not just that the repo builds.
+    writeFileSync(
+      join(dir, 'types-consumer.ts'),
+      [
+        "import { App } from 'ekolite';",
+        "import type { ReadyMsg } from 'ekolite/shared';",
+        '',
+        'const app = App.createNull();',
+        "const ready: ReadyMsg = { type: 'ready', id: 'sub-1', collection: 'files' };",
+        '',
+        'void app;',
+        'void ready;',
+        '',
+      ].join('\n'),
+    );
+    writeFileSync(
+      join(dir, 'tsconfig.json'),
+      JSON.stringify({
+        compilerOptions: {
+          module: 'NodeNext',
+          moduleResolution: 'NodeNext',
+          target: 'ES2022',
+          strict: true,
+          skipLibCheck: true,
+          noEmit: true,
+        },
+        files: ['types-consumer.ts'],
+      }),
+    );
+    run(TSC, ['--noEmit', '-p', 'tsconfig.json'], { cwd: dir });
+
     console.log('package smoke: PASS');
     console.log(`  consumer said: ${out}`);
     console.log('  declarations resolve to shipped files only');
+    console.log('  a TS consumer compiles against ekolite and ekolite/shared');
   } finally {
     rmSync(dir, { recursive: true, force: true });
     rmSync(tarball, { force: true });

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -1,0 +1,67 @@
+// Consumer smoke test for the npm package. Proves EkoLite is a framework in fact and
+// not just in its description field: build the library, pack it, install the tarball
+// into a throwaway directory OUTSIDE this repo, run a consumer that imports from
+// 'ekolite' and never sees this source tree, and assert the output.
+//
+// Red until the package actually emits a loadable server entry and exports App. Run it
+// with `node scripts/package-smoke.mjs`.
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+function run(cmd, args, opts = {}) {
+  try {
+    return execFileSync(cmd, args, { encoding: 'utf8', stdio: 'pipe', ...opts });
+  } catch (err) {
+    const detail = [err.stdout, err.stderr].filter(Boolean).join('\n').trim();
+    throw new Error(`\`${cmd} ${args.join(' ')}\` failed:\n${detail}`);
+  }
+}
+
+function main() {
+  // 1. Build and pack the library from the repo.
+  run('npm', ['run', 'build'], { cwd: REPO });
+  const packLines = run('npm', ['pack'], { cwd: REPO }).trim().split('\n');
+  const tarball = join(REPO, packLines[packLines.length - 1].trim());
+
+  // 2. Install the tarball into a fresh project that has never seen this repo.
+  const dir = mkdtempSync(join(tmpdir(), 'ekolite-consumer-'));
+  try {
+    run('npm', ['init', '-y'], { cwd: dir });
+    run('npm', ['install', tarball], { cwd: dir });
+
+    // 3. A consumer that knows only the published package.
+    const consumer = [
+      "import { App } from 'ekolite';",
+      '',
+      'const app = App.createNull();',
+      "app.methods.define('sum', (a, b) => a + b);",
+      "const result = await app.methods.call('sum', [2, 3]);",
+      'console.log(`sum(2,3)=${result}`);',
+    ].join('\n');
+    writeFileSync(join(dir, 'consumer.mjs'), consumer);
+
+    // 4. Run it and assert on what a real consumer would see.
+    const out = run('node', ['consumer.mjs'], { cwd: dir }).trim();
+    if (!out.includes('sum(2,3)=5')) {
+      throw new Error(`unexpected consumer output:\n${out}`);
+    }
+
+    console.log('package smoke: PASS');
+    console.log(`  consumer said: ${out}`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(tarball, { force: true });
+  }
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(`package smoke: FAIL\n${err.message}`);
+  process.exit(1);
+}

--- a/scripts/rewrite-dts.mjs
+++ b/scripts/rewrite-dts.mjs
@@ -1,0 +1,27 @@
+// Post-build: rewrite relative `.ts` import specifiers to `.js` in the emitted
+// declaration files. `rewriteRelativeImportExtensions` rewrites the runtime `.js`
+// output but leaves `.d.ts` specifiers as `.ts`, which point at source files the
+// package never ships. Without this, EkoLite runs for a consumer but its types don't
+// resolve. Runs after `tsc -p tsconfig.build.json` in the build script.
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DIST = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'dist');
+
+const declarations = readdirSync(DIST, { recursive: true }).filter(
+  (name) => typeof name === 'string' && name.endsWith('.d.ts'),
+);
+
+let rewritten = 0;
+for (const name of declarations) {
+  const path = join(DIST, name);
+  const before = readFileSync(path, 'utf8');
+  const after = before.replace(/(['"]\.\.?\/[^'"]*)\.ts(['"])/g, '$1.js$2');
+  if (after !== before) {
+    writeFileSync(path, after);
+    rewritten += 1;
+  }
+}
+
+console.log(`rewrite-dts: .ts -> .js in ${rewritten} declaration file(s)`);

--- a/server/index.ts
+++ b/server/index.ts
@@ -33,7 +33,9 @@ export async function createServer(options: ServerOptions) {
   });
 
   await server.register(fastifyStatic, {
-    root: resolve(__dirname, '..', 'dist', 'client'),
+    // The demo page. tsc owns dist/client for the packaged client library, so the vite
+    // demo build lives in dist/demo and this serves from there.
+    root: resolve(__dirname, '..', 'dist', 'demo'),
   });
   await options.ws.attach(server);
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -10,6 +10,10 @@ import { type RpcHandler } from './logic/rpcHandler.ts';
 import { type ClientMessage } from '../shared/protocol.ts';
 import { RpcError, toEkoLiteError } from '../shared/types.ts';
 
+// Public package surface for the `ekolite` entry: the app graph and its config sit
+// alongside createServer, so a consumer imports the whole server framework from one place.
+export { App, type AppConfig } from './app.ts';
+
 export interface ServerOptions {
   ws: WebSocketWrapper;
   publications?: Publications;

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -7,6 +7,14 @@
     "outDir": "dist",
     "rootDir": "."
   },
-  "include": ["server", "shared"],
-  "exclude": ["node_modules", "dist", "tests", "**/*.test.ts", "**/*.integration.test.ts"]
+  "include": ["server", "shared", "client"],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests",
+    "client/main.ts",
+    "client/demo",
+    "**/*.test.ts",
+    "**/*.integration.test.ts"
+  ]
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "allowImportingTsExtensions": false,
+    "rewriteRelativeImportExtensions": true,
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["server", "shared"],
+  "exclude": ["node_modules", "dist", "tests", "**/*.test.ts", "**/*.integration.test.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   root: 'client',
   build: {
-    outDir: '../dist/client',
+    outDir: '../dist/demo',
     emptyOutDir: true,
   },
   server: {


### PR DESCRIPTION
## What this does

Makes `ekolite` an installable framework and proves it from a consumer outside the repo. Before this, `npm pack` shipped 264 files and `main`/`types` pointed at a `dist/server` that `tsc` never emitted (the build is `noEmit` because the source imports use `.ts` specifiers).

## Decisions

**1. Public API** — three entries via an exports map (`main`/`types` kept for older tooling): `ekolite` (App, createServer, AppConfig), `ekolite/client` (ClientSocketWrapper, ConnectionManager, ReactiveStore), `ekolite/shared` (protocol types). The five wrappers stay internal behind `App`. Argued the three-entry split over server-only: a real time backend framework whose client you can't import is half a framework.

**2. Publish** —  claim `ekolite@0.1.0` now with a plainly WIP README (0.x makes that honest), gated on the consumer smoke passing. `npm publish --access public` (2FA) is a manual step. Decided 2026-07-08.

## The build

- `tsconfig.build.json` emits `dist/{server,shared,client}` via `rewriteRelativeImportExtensions` (`.ts`->`.js` on emit); `scripts/rewrite-dts.mjs` does the same for declarations, which the flag leaves as `.ts`.
- vite demo -> `dist/demo` (and `createServer`'s static root with it), freeing `dist/client` for the compiled client lib.
- `ws` -> `dependencies` (a real packaging bug the smoke caught).
- `files` allowlist: tarball **264 -> 77 files**.
- `prepublishOnly = typecheck && test && build`.

## Proof

`node scripts/package-smoke.mjs` packs, installs into a temp project outside the repo, and asserts: clean tarball, `App` runs (`sum(2,3)=5`), declarations resolve to shipped files, and a TS consumer compiles against all three entries. Typecheck, lint, 252 unit tests green. Built as red/green loops (see commits).

## Notes

- **Stacked on #117**: the demo relayout touches the same static-serving path, so this builds on that branch; retargets to `main` when #117 merges.
- The package smoke does a real `npm install` (~30-60s), so it's a documented manual gate, not the main CI path.
- Pre-existing 0.x rough edge: `createServer`'s bundled-demo static root assumes the source layout, so a consumer calling `createServer` won't get the demo served. A framework consumer serves their own client; making that root configurable is a later story.
- Out of scope (per story): `npm publish`, release automation, generated API docs (8.B).

Closes EKO-294.
https://linear.app/ekohacks/issue/EKO-294/story-8a-package-ekolite-for-npm
