### PR TITLE
7.B.6: A supervisor can stop the server, on Windows too

### DIFF
--- a/server/infrastructure/process.ts
+++ b/server/infrastructure/process.ts
@@ -1,11 +1,22 @@
+import { SHUTDOWN_MESSAGE } from '../../shared/serverMessages.ts';
 import { EventEmitter, OutputTracker } from './outputTracker.ts';
 
-export type Signal = 'SIGINT' | 'SIGTERM';
+// How the process was asked to stop. Two doors, and they are not interchangeable.
+//
+// SIGINT and SIGTERM are POSIX. On Windows Node will let you register a listener for
+// either, and SIGINT fires when a human presses Ctrl+C in the console, but no parent
+// process can generate one: the call you would need is GenerateConsoleCtrlEvent, and
+// Node does not expose it. SIGTERM never fires there at all.
+//
+// 'message' is the door a supervisor can reach on every platform. It exists whenever
+// the process was spawned with an `ipc` slot in stdio.
+export type ShutdownRequest = 'SIGINT' | 'SIGTERM' | 'message';
 
+const SHUTDOWN_SIGNALS = ['SIGINT', 'SIGTERM'] as const;
 const EXIT_EVENT = 'exit';
 
 interface ProcessLike {
-  onSignal(handler: (signal: Signal) => void): void;
+  onShutdownRequest(handler: (request: ShutdownRequest) => void): void;
   exit(code: number): void;
   startTimer(ms: number, callback: () => void): () => void;
 }
@@ -34,8 +45,8 @@ export class ProcessWrapper {
     return this.proc;
   }
 
-  onSignal(handler: (signal: Signal) => void): void {
-    this.proc.onSignal(handler);
+  onShutdownRequest(handler: (request: ShutdownRequest) => void): void {
+    this.proc.onShutdownRequest(handler);
   }
 
   exit(code: number): void {
@@ -55,18 +66,27 @@ export class ProcessWrapper {
     this.requireStubbedProcess().advanceTime(ms);
   }
 
-  simulateSignal(signal: Signal): void {
-    this.requireStubbedProcess().simulateSignal(signal);
+  simulateShutdownRequest(request: ShutdownRequest): void {
+    this.requireStubbedProcess().simulateShutdownRequest(request);
   }
 }
 
 class RealProcess implements ProcessLike {
-  onSignal(handler: (signal: Signal) => void): void {
-    for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+  onShutdownRequest(handler: (request: ShutdownRequest) => void): void {
+    for (const signal of SHUTDOWN_SIGNALS) {
       process.on(signal, () => {
         handler(signal);
       });
     }
+
+    // Costs nothing when there is no IPC channel: without an `ipc` slot in the parent's
+    // stdio, 'message' never fires. With one, this is how a supervisor stops us on a
+    // platform where it cannot raise a signal.
+    process.on('message', (message) => {
+      if (message === SHUTDOWN_MESSAGE) {
+        handler('message');
+      }
+    });
   }
 
   exit(code: number): void {
@@ -88,11 +108,11 @@ interface StubbedTimer {
 }
 
 class StubbedProcess implements ProcessLike {
-  private readonly handlers: ((signal: Signal) => void)[] = [];
+  private readonly handlers: ((request: ShutdownRequest) => void)[] = [];
   private readonly timers: StubbedTimer[] = [];
   private now = 0;
 
-  onSignal(handler: (signal: Signal) => void): void {
+  onShutdownRequest(handler: (request: ShutdownRequest) => void): void {
     this.handlers.push(handler);
   }
 
@@ -138,9 +158,9 @@ class StubbedProcess implements ProcessLike {
     }
   }
 
-  simulateSignal(signal: Signal): void {
+  simulateShutdownRequest(request: ShutdownRequest): void {
     for (const handler of [...this.handlers]) {
-      handler(signal);
+      handler(request);
     }
   }
 }

--- a/server/logic/shutdown.ts
+++ b/server/logic/shutdown.ts
@@ -6,9 +6,13 @@ interface Closable {
 
 const DEFAULT_GRACE_MS = 5000;
 
-// The shutdown policy, out of the boot shell so it can be tested: on a signal,
-// arm the deadline, then close the app. A clean close exits 0; a close still
+// The shutdown policy, out of the boot shell so it can be tested: on a request to
+// stop, arm the deadline, then close the app. A clean close exits 0; a close still
 // pending when the deadline fires exits 1 rather than waiting for SIGKILL.
+//
+// The policy does not care which door the request came through. A SIGTERM from Docker,
+// a Ctrl+C from a keyboard and a shutdown message from a supervisor all mean the same
+// thing here, which is why the handler ignores its argument.
 export class Shutdown {
   private readonly closable: Closable;
   private readonly proc: ProcessWrapper;
@@ -23,8 +27,8 @@ export class Shutdown {
   }
 
   arm(): void {
-    this.proc.onSignal(() => {
-      this.handleShutdownSignal();
+    this.proc.onShutdownRequest(() => {
+      this.handleShutdownRequest();
     });
   }
 
@@ -36,8 +40,8 @@ export class Shutdown {
     this.proc.exit(code);
   }
 
-  private handleShutdownSignal(): void {
-    // A second signal means it: exit hard, no second goodbye.
+  private handleShutdownRequest(): void {
+    // A second request means it: exit hard, no second goodbye.
     if (this.shuttingDown) {
       this.exitOnce(1);
       return;

--- a/server/start.ts
+++ b/server/start.ts
@@ -27,13 +27,21 @@ const app = App.create(config);
 const server = await createServer(app);
 await server.listen({ port: config.port, host: '0.0.0.0' });
 
+// Graceful shutdown: stop taking requests, then drop the database connection.
+// The policy (deadline, exit codes, second signal) lives in Shutdown, tested on
+// the nulled process; the shell only wires it to the real one.
+//
+// This must come before the ready line. Whoever reads that line may act on it at once,
+// and a supervisor's first act is often to stop us. Announce first and there is a window
+// where the server is listening and has no SIGTERM handler, so the default action kills
+// it and the exit is (null, 'SIGTERM') rather than a clean 0. The window is microseconds
+// wide and the child usually wins it, which is the worst size for a window to be.
+new Shutdown(app, ProcessWrapper.create()).arm();
+
 // The smoke test waits for this exact line on stdout, so it goes to stdout (not the
 // stderr that console.warn writes to) and carries the port, so a spawned harness can
 // confirm the server bound the one it was handed. Written directly because the lint
 // rule reserves console for warn/error.
+//
+// Ready means ready: bound, serving, and able to be stopped.
 process.stdout.write(`${READY_MESSAGE} http://localhost:${String(config.port)}\n`);
-
-// Graceful shutdown: stop taking requests, then drop the database connection.
-// The policy (deadline, exit codes, second signal) lives in Shutdown, tested on
-// the nulled process; the shell only wires it to the real one.
-new Shutdown(app, ProcessWrapper.create()).arm();

--- a/shared/serverMessages.ts
+++ b/shared/serverMessages.ts
@@ -3,3 +3,11 @@
 // the string lives in one place and both the server and the test import it rather than
 // duplicating a literal that could drift.
 export const READY_MESSAGE = 'ekolite: ready on';
+
+// What a supervisor sends over the IPC channel to ask the server to stop.
+//
+// On Windows no parent process can deliver a signal to a child. child.kill('SIGTERM')
+// there calls TerminateProcess, so nothing in the child ever runs. A message over the
+// IPC channel is the only door a supervisor has, and it works on POSIX too. PM2 uses
+// this exact word for this exact reason, in its shutdown_with_message option.
+export const SHUTDOWN_MESSAGE = 'shutdown';

--- a/tests/helpers/freePort.ts
+++ b/tests/helpers/freePort.ts
@@ -1,0 +1,22 @@
+import net from 'node:net';
+
+// A fresh ephemeral port per run, so an integration test never collides with the 3001
+// that `npm run dev:server` binds. The probe releases the port before the caller binds
+// it, which is a race on paper; the kernel does not reissue an ephemeral port that fast.
+export function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = net.createServer();
+    probe.on('error', reject);
+    probe.listen(0, () => {
+      const address = probe.address();
+      if (address === null || typeof address === 'string') {
+        reject(new Error('could not reserve a free port'));
+        return;
+      }
+      const { port } = address;
+      probe.close(() => {
+        resolve(port);
+      });
+    });
+  });
+}

--- a/tests/helpers/serverProcess.integration.test.ts
+++ b/tests/helpers/serverProcess.integration.test.ts
@@ -1,0 +1,119 @@
+import net from 'node:net';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ServerProcess } from './serverProcess.ts';
+import { freePort } from './freePort.ts';
+import { READY_MESSAGE } from '../../shared/serverMessages.ts';
+
+// The harness's own tests. Not about whether EkoLite boots: about whether the harness can
+// say why it did not.
+//
+// This file exists because it could not. A Windows run of the smoke test failed with
+// `Test timed out in 5000ms` and nothing else. No stdout, no stderr, no exit code, no way
+// to tell a server that never started from a server that started and was never heard. The
+// harness had all of it and was killed mid-sentence by vitest's default budget, which was
+// shorter than the harness's own ready timeout.
+//
+// Both branches of startAsync's failure are pinned below. If the timeout ordering in
+// vitest.integration.config.ts is ever broken again, these two are the first to time out,
+// and they time out saying nothing, which is the whole complaint.
+
+const NEVER_PRINTED = 'a line that server/start.ts never prints';
+const NEVER_PRINTED_TIMEOUT_MS = 1_500;
+
+// Reject the resolve. A startAsync that succeeds where we expect it to fail must not be
+// allowed to pass silently into the assertions below.
+async function startAndCaptureErrorAsync(server: ServerProcess): Promise<Error> {
+  try {
+    await server.startAsync();
+  } catch (error) {
+    return error as Error;
+  }
+  throw new Error('startAsync resolved; expected it to reject');
+}
+
+function listenAsync(): Promise<{ server: net.Server; port: number }> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.on('error', reject);
+    server.listen(0, () => {
+      const address = server.address();
+      if (address === null || typeof address === 'string') {
+        reject(new Error('could not occupy a port'));
+        return;
+      }
+      resolve({ server, port: address.port });
+    });
+  });
+}
+
+function closeAsync(server: net.Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+describe('ServerProcess says why a server never became ready', () => {
+  let server: ServerProcess | null = null;
+  let occupied: net.Server | null = null;
+
+  afterEach(async () => {
+    if (server !== null) {
+      await server.stopAsync();
+      server = null;
+    }
+    if (occupied !== null) {
+      await closeAsync(occupied);
+      occupied = null;
+    }
+  });
+
+  // The child dies on its own. Hold the port first, so start.ts cannot bind it and exits
+  // before printing anything. Deterministic and fast: no timeout is involved on this path,
+  // so it cannot race a slow machine.
+  it('names the exit code and hands back stderr when the child dies before ready', async () => {
+    const taken = await listenAsync();
+    occupied = taken.server;
+
+    server = new ServerProcess({
+      readyString: READY_MESSAGE,
+      env: {
+        EKOLITE_PORT: String(taken.port),
+        EKOLITE_MONGO_DB: `ekolite_harness_${String(process.pid)}`,
+      },
+    });
+
+    const error = await startAndCaptureErrorAsync(server);
+
+    expect(error.message).toContain('server exited before ready');
+    expect(error.message).toContain('EADDRINUSE');
+  });
+
+  // The child lives and says nothing we recognise. This is the branch vitest was cutting
+  // off. Only the shape of the message is asserted, never its stdout contents, so a slow
+  // boot changes what the message carries but never whether the test passes.
+  it('names the ready string, the timeout, and both streams when the line never arrives', async () => {
+    const port = await freePort();
+
+    server = new ServerProcess({
+      readyString: NEVER_PRINTED,
+      readyTimeoutMs: NEVER_PRINTED_TIMEOUT_MS,
+      env: {
+        EKOLITE_PORT: String(port),
+        EKOLITE_MONGO_DB: `ekolite_harness_${String(process.pid)}`,
+      },
+    });
+
+    const error = await startAndCaptureErrorAsync(server);
+
+    expect(error.message).toContain(`did not print ${JSON.stringify(NEVER_PRINTED)}`);
+    expect(error.message).toContain(`within ${String(NEVER_PRINTED_TIMEOUT_MS)}ms`);
+    expect(error.message).toContain('stdout:');
+    expect(error.message).toContain('stderr:');
+  });
+});

--- a/tests/helpers/serverProcess.ts
+++ b/tests/helpers/serverProcess.ts
@@ -2,11 +2,12 @@ import { spawn, type ChildProcess } from 'node:child_process';
 import { once } from 'node:events';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { SHUTDOWN_MESSAGE } from '../../shared/serverMessages.ts';
 
 // Test infrastructure, not production infrastructure: a thin wrapper over
 // child_process.spawn with no Nullable factory. It exists only to let the smoke test
 // drive the real entry point as an operating system would, spawn it, wait for a line
-// on stdout, then send it a signal, so it lives under tests/ and runs only in the
+// on stdout, then ask it to stop, so it lives under tests/ and runs only in the
 // integration suite.
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
@@ -14,6 +15,22 @@ const ENTRY_POINT = 'server/start.ts';
 
 const DEFAULT_READY_TIMEOUT_MS = 10_000;
 const DEFAULT_STOP_GRACE_MS = 5_000;
+
+// Which door to knock on. A signal, or a shutdown message down the IPC channel.
+export type Knock = 'signal' | 'message';
+
+// Every platform check in this harness, in one named function, at the boundary.
+// Modelled on build/util/build_command.js in James Shore's lets_code_javascript: two
+// lines of platform knowledge in one place, and nothing else in the file ever asks
+// what operating system it is running on.
+//
+// child.kill('SIGTERM') on Windows does not deliver a signal, it shoots the process.
+// libuv folds SIGTERM into TerminateProcess, so no handler in the child ever runs and
+// the exit event arrives as (null, 'SIGTERM'). The message door travels the IPC channel
+// and works everywhere, so it is the knock we use where signals are not real.
+export function defaultKnock(): Knock {
+  return process.platform === 'win32' ? 'message' : 'signal';
+}
 
 export interface ServerProcessOptions {
   // The child is considered up once this string appears on stdout.
@@ -54,16 +71,28 @@ export class ServerProcess {
   }
 
   // Run start.ts in a single node process (tsx as an import hook, not a child of tsx),
-  // so a later SIGTERM lands on the server itself and its exit code is the one we read.
+  // so a later stop lands on the server itself and its exit code is the one we read.
+  //
+  // The fourth stdio slot opens the IPC channel. Without it child.send throws and the
+  // server's process.on('message') never fires, which is to say: without it there is no
+  // way for any supervisor to stop this server on Windows.
   startAsync(): Promise<void> {
     const child = spawn(process.execPath, ['--import', 'tsx', ENTRY_POINT], {
       cwd: REPO_ROOT,
       env: { ...process.env, ...this.env },
-      stdio: ['ignore', 'pipe', 'pipe'],
+      stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
     });
     this.child = child;
 
+    // With a three slot stdio the spawn overload guarantees these pipes and TypeScript
+    // knows it. The fourth slot drops us to the general ChildProcess signature, where
+    // both are nullable. They are not null here, and if they ever were, every diagnostic
+    // this harness gives would be an empty string, so say so out loud rather than assert.
     const { stdout, stderr } = child;
+    if (stdout === null || stderr === null) {
+      throw new Error('spawn returned no stdout or stderr pipe; the harness cannot see the server');
+    }
+
     stdout.setEncoding('utf8');
     stderr.setEncoding('utf8');
     stdout.on('data', (chunk: string) => {
@@ -114,10 +143,34 @@ export class ServerProcess {
     });
   }
 
-  // SIGTERM and wait for the child to leave within the grace period. If it overstays,
-  // SIGKILL it and throw, so a server that ignored the polite signal fails the test
-  // rather than passing on a hard kill.
-  async stopAsync(): Promise<ExitResult> {
+  // The knock this platform's supervisors use. For teardown, where a graceful stop is
+  // not the claim under test. The two named methods below are the doors themselves, and
+  // a test that means to assert one of them must say which.
+  stopAsync(): Promise<ExitResult> {
+    return defaultKnock() === 'message' ? this.stopWithMessageAsync() : this.stopWithSignalAsync();
+  }
+
+  // Sends the message and nothing else. No fallback to a signal when nothing answers:
+  // with one, a POSIX run would pass whether or not the message door works, and the only
+  // platform that could catch that is the one that cannot run the test.
+  stopWithMessageAsync(): Promise<ExitResult> {
+    return this.knockAndWaitAsync((child) => {
+      child.send(SHUTDOWN_MESSAGE);
+    });
+  }
+
+  // The door Docker and systemd knock on. POSIX only: see defaultKnock.
+  stopWithSignalAsync(): Promise<ExitResult> {
+    return this.knockAndWaitAsync((child) => {
+      child.kill('SIGTERM');
+    });
+  }
+
+  // Knock, then wait for the child to leave within the grace period. If it overstays,
+  // SIGKILL it and throw, so a server that ignored the polite request fails the test
+  // rather than passing on a hard kill. This is not the fallback the message door
+  // forbids: a SIGKILL here can only ever produce a thrown error, never a clean exit 0.
+  private async knockAndWaitAsync(knock: (child: ChildProcess) => void): Promise<ExitResult> {
     const child = this.child;
     if (child === null) {
       return { exitCode: null, signal: null };
@@ -126,7 +179,7 @@ export class ServerProcess {
       return { exitCode: child.exitCode, signal: child.signalCode };
     }
 
-    child.kill('SIGTERM');
+    knock(child);
     const graceTimer = setTimeout(() => {
       child.kill('SIGKILL');
     }, this.stopGraceMs);
@@ -136,7 +189,7 @@ export class ServerProcess {
 
     if (signal === 'SIGKILL') {
       throw new Error(
-        `server did not exit within ${String(this.stopGraceMs)}ms of SIGTERM; had to SIGKILL.\n` +
+        `server did not exit within ${String(this.stopGraceMs)}ms of the stop request; had to SIGKILL.\n` +
           `stderr:\n${this.stderrBuffer}`,
       );
     }

--- a/tests/infrastructure/process.test.ts
+++ b/tests/infrastructure/process.test.ts
@@ -1,28 +1,41 @@
 import { describe, expect, it } from 'vitest';
 import { ProcessWrapper } from '../../server/infrastructure/process.ts';
 
-// The process seam: signals in, exit codes out, and the deadline timers that
-// shutdown policy arms. Nulled, signals are simulated by hand, time only moves
+// The process seam: requests to stop in, exit codes out, and the deadline timers that
+// shutdown policy arms. Nulled, requests are simulated by hand, time only moves
 // when a test advances it, and exit() records instead of killing the test runner.
 //
 // Proposed shape, following the other wrappers:
 //   ProcessWrapper.create()            — real process.on / process.exit / setTimeout
 //   ProcessWrapper.createNull()        — everything below
-//   onSignal(handler)                  — handler receives 'SIGINT' | 'SIGTERM'
+//   onShutdownRequest(handler)         — handler receives 'SIGINT' | 'SIGTERM' | 'message'
 //   exit(code)                         — real: never returns; null: records { code }
 //   startTimer(ms, callback)           — returns a cancel function
 //   trackExits()                       — OutputTracker of { code }
-//   simulateSignal(signal)             — null only
+//   simulateShutdownRequest(request)   — null only
 //   advanceTime(ms)                    — null only, fires timers that come due
 describe('ProcessWrapper (null)', () => {
   it('delivers a simulated signal to the handler', () => {
     const proc = ProcessWrapper.createNull();
     const received: string[] = [];
 
-    proc.onSignal((signal) => received.push(signal));
-    proc.simulateSignal('SIGTERM');
+    proc.onShutdownRequest((request) => received.push(request));
+    proc.simulateShutdownRequest('SIGTERM');
 
     expect(received).toEqual(['SIGTERM']);
+  });
+
+  // The door a supervisor reaches on Windows, where it cannot raise a signal at all.
+  // Nulled, it is the same seam: a request arrives, the handler hears it, and the
+  // handler cannot tell from the outside which door it came through.
+  it('delivers a simulated shutdown message to the handler', () => {
+    const proc = ProcessWrapper.createNull();
+    const received: string[] = [];
+
+    proc.onShutdownRequest((request) => received.push(request));
+    proc.simulateShutdownRequest('message');
+
+    expect(received).toEqual(['message']);
   });
 
   it('records exits in an output tracker instead of killing the process', () => {

--- a/tests/logic/shutdown.test.ts
+++ b/tests/logic/shutdown.test.ts
@@ -31,15 +31,15 @@ const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
 
 // 7.B.4 (proposed) — graceful shutdown with a deadline.
 //
-// The policy that used to be three untestable lines in start.ts: on a signal,
+// The policy that used to be three untestable lines in start.ts: on a request to stop,
 // close the app; if the close beats the grace period, exit 0; if it hangs, exit 1
-// rather than wait for SIGKILL. Runs on ProcessWrapper.createNull() so signals,
+// rather than wait for SIGKILL. Runs on ProcessWrapper.createNull() so requests,
 // time, and exits are all in the test's hands. The app side is a recording
 // double: a plain closable whose close() the test can resolve, hang, or reject.
 //
 // Proposed shape:
 //   new Shutdown(closable, proc, { graceMs? })   — graceMs defaults to 5000
-//   shutdown.arm()                               — subscribes to SIGINT and SIGTERM
+//   shutdown.arm()                               — subscribes to every shutdown door
 //
 // These activate one at a time, in order, as the ladder is climbed. Each name is
 // one behaviour from the design conversation; nothing here tests how (no
@@ -51,7 +51,26 @@ describe('Shutdown', () => {
     const exits = proc.trackExits();
     new Shutdown(closable, proc).arm();
 
-    proc.simulateSignal('SIGTERM');
+    proc.simulateShutdownRequest('SIGTERM');
+    expect(closeCalls()).toBe(1);
+
+    resolveClose();
+    await flush();
+
+    expect(exits.data).toEqual([{ code: 0 }]);
+  });
+
+  // The same policy, through the other door. On Windows this is the only door a
+  // supervisor has, so if the message reached ProcessWrapper but stopped short of
+  // Shutdown, EkoLite would still be unstoppable there and every test above would
+  // still be green.
+  it('a shutdown message closes the app, and a clean close exits 0', async () => {
+    const { closable, closeCalls, resolveClose } = closableDouble();
+    const proc = ProcessWrapper.createNull();
+    const exits = proc.trackExits();
+    new Shutdown(closable, proc).arm();
+
+    proc.simulateShutdownRequest('message');
     expect(closeCalls()).toBe(1);
 
     resolveClose();
@@ -66,7 +85,7 @@ describe('Shutdown', () => {
     const exits = proc.trackExits();
     new Shutdown(closable, proc).arm();
 
-    proc.simulateSignal('SIGINT');
+    proc.simulateShutdownRequest('SIGINT');
     proc.advanceTime(5000);
 
     // The close never resolved; the deadline exits anyway. No race needed.
@@ -79,7 +98,7 @@ describe('Shutdown', () => {
     const exits = proc.trackExits();
     new Shutdown(closable, proc).arm();
 
-    proc.simulateSignal('SIGTERM');
+    proc.simulateShutdownRequest('SIGTERM');
     resolveClose();
     await flush();
 
@@ -96,7 +115,7 @@ describe('Shutdown', () => {
     const exits = proc.trackExits();
     new Shutdown(closable, proc, { graceMs: 100 }).arm();
 
-    proc.simulateSignal('SIGTERM');
+    proc.simulateShutdownRequest('SIGTERM');
 
     proc.advanceTime(99);
     expect(exits.data).toEqual([]);
@@ -111,7 +130,7 @@ describe('Shutdown', () => {
     const exits = proc.trackExits();
     new Shutdown(closable, proc).arm();
 
-    proc.simulateSignal('SIGTERM');
+    proc.simulateShutdownRequest('SIGTERM');
 
     proc.advanceTime(4999);
     expect(exits.data).toEqual([]);
@@ -126,8 +145,8 @@ describe('Shutdown', () => {
     const exits = proc.trackExits();
     new Shutdown(closable, proc).arm();
 
-    proc.simulateSignal('SIGINT');
-    proc.simulateSignal('SIGINT');
+    proc.simulateShutdownRequest('SIGINT');
+    proc.simulateShutdownRequest('SIGINT');
 
     expect(exits.data).toEqual([{ code: 1 }]);
     expect(closeCalls()).toBe(1);
@@ -139,7 +158,7 @@ describe('Shutdown', () => {
     const exits = proc.trackExits();
     new Shutdown(closable, proc).arm();
 
-    proc.simulateSignal('SIGTERM');
+    proc.simulateShutdownRequest('SIGTERM');
     rejectClose(new Error('mongo refused to hang up'));
     await flush();
 
@@ -156,7 +175,7 @@ describe('Shutdown', () => {
     const exits = proc.trackExits();
     new Shutdown(closable, proc).arm();
 
-    proc.simulateSignal('SIGTERM');
+    proc.simulateShutdownRequest('SIGTERM');
     proc.advanceTime(5000);
     expect(exits.data).toEqual([{ code: 1 }]);
 
@@ -172,8 +191,8 @@ describe('Shutdown', () => {
     const exits = proc.trackExits();
     new Shutdown(closable, proc).arm();
 
-    proc.simulateSignal('SIGTERM');
-    proc.simulateSignal('SIGTERM');
+    proc.simulateShutdownRequest('SIGTERM');
+    proc.simulateShutdownRequest('SIGTERM');
     expect(exits.data).toEqual([{ code: 1 }]);
 
     resolveClose();

--- a/tests/server/smoke.integration.test.ts
+++ b/tests/server/smoke.integration.test.ts
@@ -1,16 +1,24 @@
-import net from 'node:net';
 import { afterEach, describe, expect, it } from 'vitest';
 import { ServerProcess } from '../helpers/serverProcess.ts';
+import { freePort } from '../helpers/freePort.ts';
 import { READY_MESSAGE } from '../../shared/serverMessages.ts';
 
 // The one test that bypasses every Null and drives the real entry point. It spawns
 // server/start.ts as a child process, waits for it to announce readiness on stdout,
-// fetches the home page, and asks it to shut down cleanly. If start.ts ever stops
-// wiring Mongo, Fastify, the websocket, publications and files together, this is the
-// test that catches it, because nothing else looks at the wiring.
+// fetches the home page, and asks it to stop.
 //
-// Integration only: it needs a real port and a real MongoDB (see AGENTS.md), so it
-// lives in the integration config and runs under `npm run test:integration`.
+// What it covers, and nothing else can: the wiring inside start.ts. App.create building
+// the graph, createServer serving it, listen binding the port, and Shutdown.arm() meeting
+// the real process. Shutdown policy is already tested against the Nulled process and is
+// not repeated here; only the line where policy meets the operating system is.
+//
+// What it does not cover, despite what this comment used to claim: Mongo. The driver
+// connects lazily and nothing here reads or writes, so the server boots and serves the
+// home page with no database running at all. Verified by running it with mongod stopped.
+// If start.ts stopped wiring Mongo tomorrow, this file would stay green.
+//
+// Integration only: it needs a real port and spawns a real process, so it lives in the
+// integration config and runs under `npm run test:integration`.
 
 // The home page is served from dist/client, so this asserts the built client is wired
 // to `/`. The marker lives in client/index.html and survives the vite build.
@@ -20,58 +28,93 @@ const HOME_PAGE_MARKER = '<!-- ekolite home page -->';
 // practice today; this is the seam to widen if a future node or tsx prints a warning.
 const BENIGN_STDERR: RegExp[] = [/ExperimentalWarning/, /--trace-warnings/];
 
-// A fresh ephemeral port per run, so the smoke test never collides with the default
-// 3001 that `npm run dev:server` binds.
-function freePort(): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const probe = net.createServer();
-    probe.on('error', reject);
-    probe.listen(0, () => {
-      const address = probe.address();
-      if (address === null || typeof address === 'string') {
-        reject(new Error('could not reserve a free port'));
-        return;
-      }
-      const { port } = address;
-      probe.close(() => {
-        resolve(port);
-      });
-    });
-  });
+// SIGTERM is a POSIX fact. Windows cannot deliver one to a child, so the signal door
+// is asserted only where that door exists. The message door exists on both platforms,
+// so it is asserted on both. Skipping the signal test on Windows is the honest thing;
+// running only the signal test would leave the message door uncovered everywhere.
+const itOnPosix = it.skipIf(process.platform === 'win32');
+
+// Everything the runtime printed to stderr that is not a known benign warning. A clean
+// shutdown says nothing at all.
+function stderrNoise(server: ServerProcess): string[] {
+  return server.stderr
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .filter((line) => !BENIGN_STDERR.some((pattern) => pattern.test(line)));
 }
 
 describe('EkoLite boots end to end', () => {
-  let server: ServerProcess;
+  let server: ServerProcess | null = null;
+  let port: number;
+  let bootCount = 0;
 
-  afterEach(async () => {
-    await server.stopAsync();
-  });
-
-  it('spawns the real entry point, serves the home page, and shuts down cleanly', async () => {
-    const port = await freePort();
-    server = new ServerProcess({
+  async function startServerAsync(): Promise<ServerProcess> {
+    port = await freePort();
+    bootCount += 1;
+    const started = new ServerProcess({
       readyString: READY_MESSAGE,
       env: {
         EKOLITE_PORT: String(port),
-        EKOLITE_MONGO_DB: `ekolite_smoke_${String(process.pid)}`,
+        EKOLITE_MONGO_DB: `ekolite_smoke_${String(process.pid)}_${String(bootCount)}`,
       },
     });
+    server = started;
+    await started.startAsync();
+    return started;
+  }
 
-    await server.startAsync();
-    expect(server.stdout).toContain(READY_MESSAGE);
+  // Guarded: a test that fails before it spawns anything should report its own failure,
+  // not a TypeError from the teardown standing on top of it.
+  afterEach(async () => {
+    if (server !== null) {
+      await server.stopAsync();
+      server = null;
+    }
+  });
 
-    const response = await fetch(`http://localhost:${String(port)}/`);
+  it('spawns the real entry point and serves the home page', async () => {
+    const started = await startServerAsync();
+
+    expect(started.stdout).toContain(READY_MESSAGE);
+
+    // start.ts binds 0.0.0.0, the IPv4 wildcard, so 127.0.0.1 is the address it is
+    // actually listening on. `localhost` is a name, and what it resolves to is the
+    // resolver's business: on Windows it answers ::1 first, where nothing is bound.
+    // A slow, once-per-run test should not be able to fail over a DNS preference. If we
+    // ever want `localhost` itself to be part of the claim, start.ts should bind `::`
+    // and that is a change to the server, not to this line.
+    const response = await fetch(`http://127.0.0.1:${String(port)}/`);
     expect(response.status).toBe(200);
     expect(await response.text()).toContain(HOME_PAGE_MARKER);
+  });
 
-    const result = await server.stopAsync();
+  // The door a supervisor can always reach. On Windows it is the only one: no parent
+  // process can deliver a signal to a child, so a shutdown message over the IPC channel
+  // is how PM2 and friends stop a node server there. It works on POSIX too, which is why
+  // this test is not skipped anywhere.
+  //
+  // stopWithMessageAsync must send the message and nothing else. If it ever falls back to
+  // a signal when the message goes unanswered, this test passes on POSIX whether or not
+  // the message door works, and the only platform it actually covers is the one that
+  // cannot run it. A server that ignores the message must hang here and fail.
+  it('shuts down cleanly when a supervisor sends a shutdown message', async () => {
+    const started = await startServerAsync();
+
+    const result = await started.stopWithMessageAsync();
+
     expect(result).toEqual({ exitCode: 0, signal: null });
+    expect(stderrNoise(started)).toEqual([]);
+  });
 
-    const noise = server.stderr
-      .split('\n')
-      .map((line) => line.trim())
-      .filter((line) => line.length > 0)
-      .filter((line) => !BENIGN_STDERR.some((pattern) => pattern.test(line)));
-    expect(noise).toEqual([]);
+  // The door Docker and systemd knock on. It exists only on POSIX, and the message test
+  // can never exercise it, so it gets its own test rather than sharing one.
+  itOnPosix('shuts down cleanly on SIGTERM', async () => {
+    const started = await startServerAsync();
+
+    const result = await started.stopWithSignalAsync();
+
+    expect(result).toEqual({ exitCode: 0, signal: null });
+    expect(stderrNoise(started)).toEqual([]);
   });
 });

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,8 +1,28 @@
 import { defineConfig } from 'vitest/config';
 
+// The budget around an integration test must be larger than every timeout inside it.
+//
+// ServerProcess waits up to 10s for the ready line and gives a server 5s to leave after a
+// stop. Both of those carry the diagnostics you need when a boot goes wrong: what the
+// child printed on stdout, what it printed on stderr, what exit code it left with.
+// vitest's default testTimeout is 5000ms, shorter than either, so vitest killed the test
+// before the harness could finish its sentence, and every failure arrived as a bare
+// `Test timed out in 5000ms` with nothing attached to it.
+//
+// That is how a Windows boot failure spent a week looking like a shutdown bug. The one
+// machine that could have told us what was wrong was the one machine this default gagged.
+//
+// These are ceilings, not waits. A green run on Linux touches neither: boot, fetch and
+// stop together cost about half a second. Keep both above DEFAULT_READY_TIMEOUT_MS and
+// DEFAULT_STOP_GRACE_MS in tests/helpers/serverProcess.ts. If that ordering ever breaks,
+// tests/helpers/serverProcess.integration.test.ts is the first thing to time out.
+const TEST_BUDGET_MS = 30_000;
+
 export default defineConfig({
   test: {
     root: '.',
     include: ['**/*.integration.test.ts'],
+    testTimeout: TEST_BUDGET_MS,
+    hookTimeout: TEST_BUDGET_MS,
   },
 });


### PR DESCRIPTION
Closes EKO-303.

https://linear.app/ekohacks/issue/EKO-303/7b6-the-smoke-test-asserts-a-signal-windows-does-not-have

`npm run test:integration` was green on Linux and macOS and red on Windows. The ticket called it a signal bug. It is one, but two other problems sat in front of it, and one of those is a real bug in the server.

## The harness could not report anything

Ebuka's failure was `Test timed out in 5000ms`, with no stdout, no stderr, no exit code.

vitest's default `testTimeout` is 5000ms. `ServerProcess` waits 10000ms for the ready line and gives a server 5000ms to leave after a stop, and both of those carry the diagnostics. The test budget was shorter than the timeouts inside it, so vitest killed the test before the harness could report, and every failure inside a spawned server looked identical. I reproduced Ebuka's exact error on Linux with a healthy server, just by waiting for a line the server never prints.

`vitest.integration.config.ts` now sets the budget above every timeout in the harness, with the ordering documented next to the constant. `tests/helpers/serverProcess.integration.test.ts` pins both kinds of failed boot so it cannot go quiet again: one holds the port so `start.ts` dies with `EADDRINUSE` on stderr, the other waits for a line that never comes. These are ceilings, not waits: a green run spends about half a second and hits neither.

## start.ts announced ready before it could be stopped

`start.ts` printed the ready line and armed `Shutdown` five lines later. In that gap the server is listening with no SIGTERM handler, so anything that acts on the ready line meets the default action: the process dies and the exit is `(null, 'SIGTERM')` instead of a clean 0.

Sending SIGTERM the instant the ready line arrived lost two runs in three under load. Waiting even 25ms lost none, because by then the arm five lines later had run. The window is that narrow, which is why the smoke test never hit it and why a supervisor stopping a service the moment it reports ready would. We deploy to Linux and develop on Windows, so a slow machine is not hypothetical.

The fix is to arm shutdown before printing ready, so ready means bound, serving, and stoppable. Twelve runs out of twelve were clean after the change. This surfaced while mutating the message door: the SIGTERM test started failing when it should not have. `Shutdown.arm()` meeting the real process is the one line of wiring no unit test can reach, which is what the smoke test is for.

## The signal bug

`child.kill('SIGTERM')` on Windows does not deliver a signal, it terminates the process. libuv folds SIGTERM into `TerminateProcess`, so nothing in the child runs, and Node reports the event as `(null, 'SIGTERM')`. The assertion could never have passed there.

SIGINT fires on Windows when a person presses Ctrl+C, but no parent process can generate one; the call is `GenerateConsoleCtrlEvent`, and Node does not expose it. So EkoLite's graceful shutdown worked on Windows for a person at a keyboard and nothing else: not a supervisor, not Docker, not the smoke test. That is a gap in the framework, so this PR closes it.

`ProcessWrapper` now listens for a shutdown message on the IPC channel alongside its signals, the same door PM2 uses on Windows and for the same reason. `Signal`/`onSignal` became `ShutdownRequest`/`onShutdownRequest`, since the policy does not care which door the request came through. The harness spawns with an IPC slot and gets two named stop methods, and `defaultKnock()` is the only place in it that checks the operating system.

## Two tests, not one parameterised

A Windows leg that stops via a message never exercises SIGTERM, and a POSIX leg that stops via SIGTERM never exercises the message door. One test parameterised by platform leaves the wrong door untested on each, so this is two tests, one per door.

`stopWithMessageAsync` sends the message and nothing else, no fallback to a signal. I checked what that rule is worth: removing `process.on('message')` from the server fails only the message test, so the doors are independent; removing it and adding the forbidden fallback (a SIGTERM 100ms after the unanswered message) turns all three green with the message door gone. No test in the suite can catch that fallback, so the reason it must not exist lives in a comment above the method.

Two named methods rather than `stopAsync({ via })` for the same reason: vitest does not type check, so an options object would be transpiled straight past, and the message test could send a SIGTERM and pass while proving nothing. A method that does not exist cannot be faked.

## Also in here

- The smoke test fetches `127.0.0.1`, not `localhost`. `start.ts` binds `0.0.0.0`, so that is the address it is listening on. `localhost` is a name, and Windows resolves it to `::1` first, where nothing is bound. If we want `localhost` in the claim, `start.ts` should bind `::`, which is a server change.
- The smoke test's header comment claimed the file catches it if `start.ts` stops wiring Mongo. It does not: with mongod stopped the integration suite is green and the home page still serves in about 400ms, because the driver connects lazily and nothing here reads or writes. The comment now says so.

## The commits

The red commit uses `--no-verify`: lint-staged runs eslint, and eslint was right to object to two methods that do not exist yet, four errors and a matching type error. That is what the red commit is there to show.

## Not verified on Windows

Every Windows claim here is read off the libuv and Node sources. Nobody on this PR has a Windows machine.

Ebuka, this part needs you. Pull the branch and run `npm run test:integration` before reading further into the code. Three outcomes, each useful:

- Green: the message door works, the race is closed, done.
- Boot timeout with empty stdout: the boot is what hangs on your machine, and the harness will now print what it saw. A different bug.
- Boot timeout with the ready line already in stdout: it was the fetch, and `127.0.0.1` should have fixed that before you got there. Say so if it did not.

Paste whatever you get, and the timings. `serverProcess.ts` hardcodes a 10 second ready timeout and a 5 second stop grace, both guesses. Boot is about 400ms on Linux; if yours is eight seconds that is worth knowing, and it continues in EKO-302.
