### PR TITLE
Story 8.B (docs prep): README truth pass, spec rename, overview clean

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,17 @@ EkoLite is a public, work in progress rebuild of Meteor's core ideas with delibe
 ## What works today
 
 - **Nullable infrastructure wrappers**, each with `create()` and `createNull()` factories: MongoDB (`MongoWrapper`), WebSocket server (`WebSocketWrapper`), file storage (`FileStorageWrapper`) and script runner (`ScriptRunnerWrapper`)
+- **App wiring** (`App`): `App.create()` assembles the whole graph (Mongo, websocket, publications, methods, files) and `App.createNull()` returns the same graph in memory, so the assembly that boots in production is the one the tests drive
 - **Pub/sub engine** (`Publications`): define a publication on the server, subscribe over a live socket, receive `ready` and data messages, with reference counted teardown. Wired end to end now: a real browser client subscribes over a real socket and its store fills from Mongo
+- **RPC methods** (`Methods`): register a named server method, call it over the socket, and get a typed result or a structured error back through the `method` / `result` / `error` messages
 - **File storage over HTTP** (`Files`): `POST /api/files` saves the bytes and inserts a document that streams into the live list through pub/sub; `GET /api/files/:id` streams them back
 - **Client stack**: `ClientSocketWrapper` (nullable WebSocket client), `ConnectionManager` (subscription lifecycle) and `ReactiveStore` (client side collection state)
 - **Mini DDP protocol** ([`shared/protocol.ts`](shared/protocol.ts)): six message types, typed end to end
-- **Live boot** (`start.ts`): real Mongo, websocket, publications and file store, with a runnable browser demo at [`client/demo/live.html`](client/demo/live.html)
+- **Graceful shutdown** (`Shutdown`): on a stop signal, or a shutdown message from a supervisor, it stops taking requests, closes the streams, drops the database connection, and exits cleanly
+- **Live boot** (`start.ts`): real Mongo, websocket, publications, methods and file store, with a runnable browser demo at [`client/demo/live.html`](client/demo/live.html)
 
 ## What is planned, not yet built
 
-- A server side method registry (RPC). The `method`, `result` and `error` message types already exist in the protocol; the registry that handles them is the next epic.
 - Reconnect and resubscribe after a dropped socket, and auth on the HTTP routes. Today a closed socket disposes and stays disposed, and the file routes are open.
 
 ## Quick start
@@ -71,7 +73,7 @@ Six message types, against roughly fifteen in full DDP:
 Client → Server:
   { type: 'subscribe', id, name, params? }
   { type: 'unsubscribe', id }
-  { type: 'method', id, name, params }      // handled by the upcoming method registry
+  { type: 'method', id, name, params }      // handled by the method registry
 
 Server → Client:
   { type: 'ready', id, collection }

--- a/docs/ekolite-overview/ekolite-overview.md
+++ b/docs/ekolite-overview/ekolite-overview.md
@@ -84,7 +84,7 @@ ST 6  File validation            → Bad files rejected?
 ST 7  End-to-end pipeline        → Full workflow works end-to-end
 ```
 
-When Smoke Test 7 passes, the framework does everything Meteor did for our app.
+When Smoke Test 7 passes, the framework does everything Meteor did for a real-time, data-driven app.
 
 ---
 
@@ -92,13 +92,10 @@ When Smoke Test 7 passes, the framework does everything Meteor did for our app.
 
 Read these when you need detail on a specific topic:
 
-| Doc                        | What's in it                                                                                                         |
-| -------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `ekolite-system-design.md` | How Meteor works, concept-by-concept mapping to EkoLite                                                              |
-| `ekolite-adrs.md`          | Architecture decisions and why we made them                                                                          |
-| `ekolite-epics.md`         | What the app does, user flows, migration plan                                                                        |
-| Linear                     | Every smoke test, story, and sub-story (the original written backlog is archived at `../archive/ekolite-backlog.md`) |
-| `ekolite-tdd-training.md`  | Red-green-refactor tutorial with worked examples                                                                     |
-| `ekolite-tdd.md`           | Nullable code reference, test pyramid, test structure                                                                |
-| `ekolite-customer.md`      | User stories and acceptance criteria                                                                                 |
-| `ekolite-spec.md`          | API signatures and type definitions                                                                                  |
+| Doc                        | What's in it                                            |
+| -------------------------- | ------------------------------------------------------- |
+| `ekolite-system-design.md` | How Meteor works, concept-by-concept mapping to EkoLite |
+| `ekolite-adrs.md`          | Architecture decisions and why we made them             |
+| `ekolite-tdd-training.md`  | Red-green-refactor tutorial with worked examples        |
+| `ekolite-tdd.md`           | Nullable code reference, test pyramid, test structure   |
+| `ekolite-spec.md`          | API signatures and type definitions                     |

--- a/docs/ekolite-overview/ekolite-spec.md
+++ b/docs/ekolite-overview/ekolite-spec.md
@@ -1,4 +1,4 @@
-# ekolite Specification
+# EkoLite Specification
 
 Start with [ekolite-overview.md](ekolite-overview.md) for the big picture. This is the API and type reference for EkoLite.
 
@@ -55,13 +55,13 @@ definePublication('UserFiles.all', (): FindCursor<UserFile> => {
 > current API.
 
 ```ts
-const sub = MeteorLight.subscribe('UserFiles.all');
+const sub = EkoLite.subscribe('UserFiles.all');
 
 sub.on('ready', () => {
   /* initial data loaded */
 });
 
-const store = MeteorLight.collection<UserFile>('UserFiles');
+const store = EkoLite.collection<UserFile>('UserFiles');
 
 store.on('change', (docs: UserFile[]) => {
   // update DOM, render chart, whatever — framework-agnostic
@@ -91,7 +91,7 @@ defineMethod('runCountC', async (targetPath: string): Promise<string> => {
 #### Client API:
 
 ```ts
-const output: string = await MeteorLight.call<string>('runCountC', '/path/to/uploads');
+const output: string = await EkoLite.call<string>('runCountC', '/path/to/uploads');
 ```
 
 ### 4. MongoDB Wrapper
@@ -152,7 +152,7 @@ defineUploadHandler({
 #### Client API:
 
 ```ts
-const upload = MeteorLight.upload('/api/upload', fileInput.files[0]);
+const upload = EkoLite.upload('/api/upload', fileInput.files[0]);
 
 upload.on('progress', (pct: number) => {
   /* update progress bar */
@@ -160,7 +160,7 @@ upload.on('progress', (pct: number) => {
 upload.on('complete', (file: StoredFile) => {
   /* handle success */
 });
-upload.on('error', (err: MeteorLightError) => {
+upload.on('error', (err: EkoLiteError) => {
   /* handle failure */
 });
 ```
@@ -180,7 +180,7 @@ const scriptPath: string = resolveAsset('scripts/countC.py');
 ## Type Definitions (shared/types.ts)
 
 ```ts
-export interface MeteorLightError {
+export interface EkoLiteError {
   code: number;
   message: string;
   details?: unknown;
@@ -243,7 +243,7 @@ export interface ResultMsg {
 export interface ErrorMsg {
   type: 'error';
   id: string;
-  error: MeteorLightError;
+  error: EkoLiteError;
 }
 
 export type ClientMessage = SubscribeMsg | UnsubscribeMsg | MethodMsg;


### PR DESCRIPTION
Part of EKO-295 (Story 8.B). This is the content prep the story says comes first, not the site itself.

## What this does

Three doc changes, no code:

- **README truth pass.** "What works today" now lists what shipped: `App` wiring, RPC methods (`Methods`), and graceful shutdown (`Shutdown`), alongside the pub/sub, files and client stack that were already there. The stale "planned" entry for the RPC method registry is gone (methods shipped), and the protocol comment no longer calls the registry "upcoming". Reconnect/resubscribe and route auth stay under "planned", because they are.
- **Spec rename.** `ekolite-spec.md` called the API `MeteorLight.*` and `MeteorLightError`. Renamed to `EkoLite` throughout, and the heading is now `EkoLite Specification`. The API reference no longer carries the old product name.
- **Overview trim.** The "Deep Dive Docs" table in `ekolite-overview.md` dropped the rows pointing at internal material: the Linear / archived-backlog row, and the `ekolite-epics.md` and `ekolite-customer.md` rows (roadmap and stakeholder brief, staying internal). "our app" softened to "a real-time, data-driven app".

## Why only these docs

An audit of the eight overview docs found most carry internal backlog coupling, dojo business-model and student framing, or half-finished artifacts. The genuinely stranger-ready set (overview, spec, API pages, manual) is here or already clean. The three that need real editing before they can go public (ADRs, system design, TDD training) are their own story, EKO-304. `ekolite-epics.md` and `ekolite-customer.md` stay internal.

## Not in this PR (still to come for 8.B)

- The VitePress scaffold and the Pages deploy workflow.
- `homepage` in package.json pointing at the site, and the README linking it.
- Final internal-link fixes (source-file links resolve on GitHub, not on the site).

## Ordering

The README here overlaps #119 (the npm packaging PR), which adds the Status and Install sections. The edits sit in different regions so it should merge cleanly, but land #119 first to be safe.

Part of https://linear.app/ekohacks/issue/EKO-295/story-8b-a-public-page-for-the-framework
Follow-up: https://linear.app/ekohacks/issue/EKO-304/story-8c-clean-the-design-docs-for-the-public-site
