### PR TITLE
Story 8.C: publish the design docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Verify the packaged shape from a consumer's point of view with `npm run test:pac
 - **RPC methods** (`Methods`): register a named server method, call it over the socket, and get a typed result or a structured error back through the `method` / `result` / `error` messages
 - **File storage over HTTP** (`Files`): `POST /api/files` saves the bytes and inserts a document that streams into the live list through pub/sub; `GET /api/files/:id` streams them back
 - **Client stack**: `ClientSocketWrapper` (nullable WebSocket client), `ConnectionManager` (subscription lifecycle) and `ReactiveStore` (client side collection state)
-- **Mini DDP protocol** ([`shared/protocol.ts`](shared/protocol.ts)): six message types, typed end to end
+- **Mini DDP protocol** ([`shared/protocol.ts`](shared/protocol.ts)): eleven message types, typed end to end
+- **Heartbeat** (`ping` / `pong`): a socket can die while both ends still think it is open, so the client pings and closes a connection that stops answering
 - **Graceful shutdown** (`Shutdown`): on a stop signal, or a shutdown message from a supervisor, it stops taking requests, closes the streams, drops the database connection, and exits cleanly
 - **Live boot** (`start.ts`): real Mongo, websocket, publications, methods and file store, with a runnable browser demo at [`client/demo/live.html`](client/demo/live.html)
 
@@ -93,18 +94,20 @@ ekolite/
 
 ## Mini DDP protocol
 
-Six message types, against roughly fifteen in full DDP:
+Eleven message types, against roughly fifteen in full DDP. The saving is less in the count than in what is absent: no connect handshake, no session identity, no merge box, no latency compensation.
 
 ```
 Client → Server:
   { type: 'subscribe', id, name, params? }
   { type: 'unsubscribe', id }
   { type: 'method', id, name, params }      // handled by the method registry
+  { type: 'ping', id? }                     // heartbeat
 
 Server → Client:
   { type: 'ready', id, collection }
   { type: 'added' | 'changed' | 'removed', collection, id, fields? }
   { type: 'result' | 'error', id, ... }
+  { type: 'pong', id? }
 ```
 
 ## Testing

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -2,9 +2,9 @@ import { defineConfig } from 'vitepress';
 
 // EkoLite documentation site. Root is docs/, so the page links below are relative to it.
 //
-// Excluded from the build: the internal planning docs (epics, customer), which stay
-// private, and the design docs still being cleaned for public reading (system design,
-// ADRs, the TDD guides). Those ship once that cleanup lands, tracked in EKO-304.
+// Excluded from the build: the internal planning docs. Epics is the roadmap and customer is
+// a stakeholder brief, so neither is a framework document and neither goes public. Everything
+// else in ekolite-overview/ is published.
 export default defineConfig({
   title: 'EkoLite',
   description:
@@ -13,10 +13,7 @@ export default defineConfig({
   srcExclude: [
     'ekolite-overview/ekolite-epics.md',
     'ekolite-overview/ekolite-customer.md',
-    'ekolite-overview/ekolite-system-design.md',
-    'ekolite-overview/ekolite-adrs.md',
     'ekolite-overview/ekolite-tdd.md',
-    'ekolite-overview/ekolite-tdd-training.md',
     'archive/**',
   ],
   themeConfig: {
@@ -36,8 +33,16 @@ export default defineConfig({
         ],
       },
       {
+        text: 'Design',
+        items: [
+          { text: 'System design', link: '/ekolite-overview/ekolite-system-design' },
+          { text: 'Architecture decisions', link: '/ekolite-overview/ekolite-adrs' },
+        ],
+      },
+      {
         text: 'Manual',
         items: [
+          { text: 'Test-driven development', link: '/ekolite-overview/ekolite-tdd-training' },
           {
             text: 'Nullables: how much should the stub know?',
             link: '/manual/nullables-how-much-should-the-stub-know',

--- a/docs/ekolite-overview/ekolite-adrs.md
+++ b/docs/ekolite-overview/ekolite-adrs.md
@@ -1,139 +1,97 @@
-# ekolite -- Architecture Decision Records
+# EkoLite, Architecture Decision Records
 
 Start with [ekolite-overview.md](ekolite-overview.md) for the big picture.
 
----
-
-## ADR-001: Replace Meteor with a Custom Lightweight Stack
-
-**Decision:** Build ekolite, a ~820-line replacement using Fastify, MongoDB driver, WebSocket, and Vite.
-**Why:** Meteor installs 69 packages (most unused), has slow rebuilds, and locks us into its ecosystem. Our app only uploads BAM files, runs a Python script, and displays charts -- we don't need accounts, sessions, or optimistic UI.
-**Backlog impact:**
-
-- All 7 epics exist because of this decision.
-- Risk mitigated by keeping the framework small, fully typed, and test-driven.
+Each record states what was decided and why. They are kept as written, so a decision that later moved is corrected in place rather than quietly deleted.
 
 ---
 
-## ADR-002: Fastify as HTTP Server (Not Express)
+## ADR-001: Replace Meteor With a Lightweight Stack
 
-**Decision:** Use Fastify for its speed, first-class plugin architecture, built-in validation, and official WebSocket/multipart plugins.
-**Why:** We need an HTTP server for the client app and file uploads. Fastify is 2-3x faster than Express, has encapsulated plugins instead of sequential middleware, and ships with first-class TypeScript support.
-**Backlog impact:**
+**Decision:** Replace Meteor with EkoLite: roughly 3,500 lines of TypeScript over Fastify, the MongoDB driver, WebSocket and Vite.
 
-- Epic 1 (Story 1.A) sets up Fastify; Epic 2 (Story 2.A) uses @fastify/websocket; Epic 5 (Story 5.C) uses @fastify/multipart.
+**Why:** The application this was built for uploads genomic data files, runs an analysis script over them and displays the results. It needs live data and remote calls. It does not need accounts, sessions, optimistic UI or a client-side query engine. Meteor ships all of that, installs 69 packages to do it, takes its own build system with it, and rebuilds slowly. The cost of owning a small stack turned out to be lower than the cost of carrying a large one.
 
 ---
 
-## ADR-003: Mini-DDP Instead of Full DDP
+## ADR-002: Fastify as HTTP Server, Not Express
 
-**Decision:** Implement Mini-DDP with 6 message types instead of the full ~15-type DDP protocol.
-**Why:** Our app only uses subscribe/unsubscribe, method/result/error, and added/changed/removed/ready. We don't need the connect handshake, ping/pong keepalive, session IDs, or reconnect replay.
-**Backlog impact:**
+**Decision:** Use Fastify for its speed, plugin architecture, built-in validation and official WebSocket and multipart plugins.
 
-- Story 0.B builds the WebSocket wrapper.
-- Stories 3.A.1-3.A.4 implement pub/sub; Stories 4.B.1-4.B.2 implement RPC.
+**Why:** The framework needs an HTTP server for the client application and for file uploads. Fastify is significantly faster than Express, has encapsulated plugins rather than sequential middleware, and ships first-class TypeScript support.
 
 ---
 
-## ADR-004: ReactiveStore Instead of Minimongo
+## ADR-003: Mini DDP Instead of Full DDP
 
-**Decision:** Replace Minimongo with a `Map<string, T>` that responds to added/changed/removed messages and emits a 'change' event.
-**Why:** Our client code does exactly one thing: `UserFiles.find({})` -- get all files with no filter or sort. Minimongo's full MongoDB query API is thousands of lines we don't need. ReactiveStore is ~90 lines.
-**Backlog impact:**
+**Decision:** Implement Mini DDP: eleven message types against roughly fifteen in full DDP, and none of the session machinery.
 
-- Stories 3.B.1-3.B.3 build the ReactiveStore.
+`subscribe`, `unsubscribe`, `method` and `ping` go from client to server. `ready`, `added`, `changed`, `removed`, `result`, `error` and `pong` come back.
+
+**Why:** The saving is not really in the message count, it is in what the protocol refuses to do. There is no connect handshake, no session identity, no merge box reconciling overlapping subscriptions, and no reconnect replay. A client that loses its socket re-subscribes rather than replaying a session log.
+
+**Later correction:** This decision originally dropped `ping` and `pong` too, on the grounds that the WebSocket library keeps the connection alive by itself. That turned out to be wrong. A TCP connection can be dead while both ends still believe it is open, and the library's own keepalive does not tell the application. The heartbeat added `ping` and `pong` at the application level so a client can detect a silently dead socket and close it. The two message types are in the protocol because that problem is real.
+
+---
+
+## ADR-004: ReactiveStore Instead of a Client-Side Database
+
+**Decision:** Give the client a `ReactiveStore`: a `Map<string, T>` that responds to `added`, `changed` and `removed` messages and emits a change event.
+
+**Why:** The client asks one question: give me the documents in this collection. A full query engine mirrored into the browser is thousands of lines to answer a question nobody asked. The store is about ninety lines. Anything that needs filtering or sorting can do it on the server, where the data already lives.
 
 ---
 
 ## ADR-005: MongoDB Change Streams Instead of Oplog Tailing
 
-**Decision:** Use MongoDB change streams to power pub/sub instead of tailing the raw oplog.
-**Why:** Change streams are a documented, supported API (MongoDB 3.6+) that works with the standard driver. Oplog tailing requires Meteor-specific parsing and replica set configuration we don't need to own.
-**Backlog impact:**
+**Decision:** Use MongoDB change streams to power pub/sub rather than tailing the raw oplog.
 
-- Story 0.A.2 implements change stream support in MongoWrapper.
-- Story 3.A.3 wires it to Publications.
+**Why:** Change streams are a documented, supported API that works with the standard driver. Oplog tailing, which is how Meteor did it, means parsing an internal log and owning replica set configuration that the application otherwise has no reason to care about.
 
 ---
 
-## ADR-006: @fastify/multipart Instead of ostrio:files
+## ADR-006: Standard HTTP Multipart Uploads
 
-**Decision:** Use standard HTTP multipart uploads via @fastify/multipart with XHR progress events on the client.
-**Why:** ostrio:files adds DDP chunking, resumable uploads, and its own FilesCollection abstraction -- complexity we don't need for small-to-medium BAM files. Standard HTTP upload works with any client (curl, Postman, not just our app).
-**Backlog impact:**
+**Decision:** Upload files with standard HTTP multipart through `@fastify/multipart`, with progress reported from the browser's own upload events.
 
-- Story 0.C builds FileStorage.
-- Stories 5.A-5.D build the upload pipeline; Stories 5.C.1-5.C.2 build the Fastify route.
+**Why:** Uploading over the WebSocket protocol means chunking, resumption and a bespoke file collection abstraction. Standard HTTP upload is simpler, and it works from anything that speaks HTTP, including curl and Postman, not only from the application's own client.
 
 ---
 
-## ADR-007: Vite Instead of Meteor's Build System
+## ADR-007: Vite Instead of a Bespoke Bundler
 
-**Decision:** Use Vite for client builds, tsx for dev server, and tsc for type checking only.
-**Why:** Meteor's custom bundler transpiles 69 packages via Babel with seconds-long rebuilds and full-page reloads. Vite uses esbuild (100x faster than Babel) and provides true HMR -- sub-100ms updates without page reload.
-**Backlog impact:**
+**Decision:** Use Vite for client builds, tsx for the dev server, and tsc for type checking only.
 
-- Story 1.B sets up Vite config.
-- Story 1.A.1 serves the Vite output.
+**Why:** Meteor's custom bundler transpiled its whole package set through Babel, took seconds to rebuild, and reloaded the entire page on a change. It was the single biggest drag on the development loop. Vite uses esbuild, which is orders of magnitude faster than Babel, and gives true hot module replacement rather than reloading the whole page. Type checking is a separate step on purpose: the dev loop strips types without checking them, so it stays fast, and `tsc --noEmit` is the gate.
 
 ---
 
-## ADR-008: Testing Without Mocks (Nullable Pattern)
+## ADR-008: Testing Without Mocks, the Nullable Pattern
 
-**Decision:** Use James Shore's Nullable pattern -- every infrastructure wrapper has `create()` (real) and `createNull()` (in-memory, same interface), with parity tests ensuring identical behavior.
-**Why:** Traditional mocks drift from reality, spy-based assertions break on refactors, and mock setup is verbose. Nullable infrastructure gives fast, reliable tests that catch real bugs and survive refactoring. Only vitest needed -- no mock libraries.
-**Backlog impact:**
+**Decision:** Use James Shore's Nullable pattern. Every infrastructure wrapper has `create()` for the real thing and `createNull()` for an in-memory one behind the same interface, with parity tests holding the two to identical behaviour.
 
-- All of Smoke Test 0 (Stories 0.A-0.D) builds wrappers with Nullables.
-- Every subsequent story uses them. Training: see `ekolite-tdd-training.md` Section 2.
+**Why:** Mocks drift from reality, spy-based assertions break whenever the code is refactored, and mock setup buries the point of the test. Nullable infrastructure gives fast tests that exercise real logic against substitutable edges, survive refactoring, and need no mocking library. There is vitest, and nothing else.
 
 ---
 
-## ADR-009: A-Frame Architecture (Logic / Infrastructure Separation)
+## ADR-009: A-Frame Architecture, Logic Separated From Infrastructure
 
-**Decision:** Separate infrastructure wrappers (external system access) from logic classes (constructor injection), wired together by an Application layer (`App`).
-**Why:** If logic classes directly import infrastructure they can't be tested without the real database. With A-Frame, `App.create()` wires real wrappers for production and `App.createNull()` wires Null wrappers for tests. Logic classes never know which kind they received.
-**Backlog impact:**
+**Decision:** Separate infrastructure wrappers, which reach outside the process, from logic classes, which receive their collaborators through the constructor. An application layer, `App`, wires the two together.
 
-- Directory structure follows this: `server/infrastructure/`, `server/logic/`.
-- Story 7.B wires it all in `App`.
+**Why:** Logic that imports its own infrastructure cannot be tested without the real database. With the wiring pulled out, `App.create()` assembles real wrappers for production and `App.createNull()` assembles nulled ones for tests, and the logic never learns which kind it was handed. The assembly that boots in production is the assembly the tests drive.
 
 ---
 
-## ADR-010: TypeScript for the Full Stack
+## ADR-010: TypeScript Everywhere
 
-**Decision:** Write ekolite in TypeScript with shared types in `shared/types.ts` used by both server and client.
-**Why:** Catch errors at compile time, self-documenting APIs, full IDE support.
-**Backlog impact:**
+**Decision:** Write EkoLite in TypeScript, with the wire protocol types in `shared/protocol.ts` used by both server and client.
 
-- All code. `tsc --noEmit` checks types; Vite and tsx strip types without checking for fast dev.
+**Why:** The protocol is the contract between the two halves. If it is typed in one place and both ends import it, a message that changes shape breaks the build rather than a user's session.
 
 ---
 
-## ADR-011: Build the Framework (Don't Buy)
+## ADR-011: Build the Framework Rather Than Adopt One
 
-**Decision:** Build ekolite ourselves rather than adopting tRPC, Convex, Socket.IO, or Supabase Realtime.
-**Why:** ekolite serves a dual purpose: a lightweight biotech real-time stack for genomic data apps, and the teaching platform for the ekohacks coding dojo and bootcamp. Building it teaches Testing Without Mocks, TDD, XP practices, WebSocket protocols, and how to build a framework from first principles.
-**Backlog impact:**
+**Decision:** Build EkoLite rather than assemble the same capability from tRPC, Convex, Socket.IO or Supabase Realtime.
 
-- The building process is the product -- smoke tests, TDD training, and worked examples are bootcamp material.
-- ~820 lines is a feature: small enough for a bootcamp student to read and understand the entire framework.
-
----
-
-## ADR Summary -> Backlog Impact
-
-| ADR | Key Decision          | Primary Backlog Impact                                             |
-| :-: | --------------------- | ------------------------------------------------------------------ |
-| 001 | Replace Meteor        | All epics                                                          |
-| 002 | Fastify               | Epic 1 (1.A), Epic 2 (2.A), Epic 5 (5.C)                           |
-| 003 | Mini-DDP              | Story 0.B, Epic 3 (3.A), Epic 4 (4.B)                              |
-| 004 | ReactiveStore         | Epic 3 (3.B)                                                       |
-| 005 | Change streams        | Story 0.A.2, Epic 3 (3.A.3)                                        |
-| 006 | @fastify/multipart    | Story 0.C, Epic 5 (5.A-5.D)                                        |
-| 007 | Vite                  | Epic 1 (1.B)                                                       |
-| 008 | Testing Without Mocks | All of Smoke Test 0, all test code                                 |
-| 009 | A-Frame architecture  | Directory structure, Story 7.B                                     |
-| 010 | TypeScript            | All code                                                           |
-| 011 | Build don't buy       | All -- the framework is the ekohacks product + bootcamp curriculum |
+**Why:** The requirement is narrow and long-lived: live data from MongoDB, remote calls, file uploads, and nothing else. An adopted stack brings its own model of all three, and the parts that do not fit are the parts you end up fighting for years. A framework small enough to read end to end is a framework you can change when the requirement changes. That is the trade being made: more code owned, in exchange for owning it.

--- a/docs/ekolite-overview/ekolite-overview.md
+++ b/docs/ekolite-overview/ekolite-overview.md
@@ -1,6 +1,6 @@
 # EkoLite — Overview
 
-A ~820-line real-time backend framework for biotech apps. Built with TypeScript, tested without mocks.
+A small real-time backend framework, around 3,500 lines of TypeScript across server, client and shared. Tested without mocks.
 
 ---
 
@@ -11,7 +11,7 @@ EkoLite is a lightweight real-time backend framework. Five standard tools do the
 | Capability     | How                                             |
 | -------------- | ----------------------------------------------- |
 | HTTP server    | Fastify                                         |
-| Real-time data | WebSocket + Mini-DDP (6 message types)          |
+| Real-time data | WebSocket + Mini-DDP (11 message types)         |
 | Database       | MongoDB driver + change streams                 |
 | Client data    | ReactiveStore (a simple Map that stays in sync) |
 | File uploads   | @fastify/multipart                              |
@@ -44,16 +44,17 @@ This is how we test without mocks. The logic layer doesn't know which one it's t
 
 ## The Protocol
 
-Client and server talk over WebSocket with 6 message types:
+Client and server talk over WebSocket with 11 message types:
 
 ```
 Client → Server:         Server → Client:
   subscribe                ready
   unsubscribe              added / changed / removed
   method                   result / error
+  ping                     pong
 ```
 
-Full DDP has ~15 message types. We use 6.
+Full DDP has ~15 message types. The saving is less in the count than in what is absent: no connect handshake, no session identity, no merge box, no latency compensation.
 
 ---
 
@@ -92,10 +93,9 @@ When Smoke Test 7 passes, the framework covers everything a real-time, data-driv
 
 Read these when you need detail on a specific topic:
 
-| Doc                        | What's in it                                          |
-| -------------------------- | ----------------------------------------------------- |
-| `ekolite-system-design.md` | How the framework works, concept by concept           |
-| `ekolite-adrs.md`          | Architecture decisions and why we made them           |
-| `ekolite-tdd-training.md`  | Red-green-refactor tutorial with worked examples      |
-| `ekolite-tdd.md`           | Nullable code reference, test pyramid, test structure |
-| `ekolite-spec.md`          | API signatures and type definitions                   |
+| Doc                                                | What's in it                                       |
+| -------------------------------------------------- | -------------------------------------------------- |
+| [System design](ekolite-system-design.md)          | How the framework is put together, and why         |
+| [Architecture decisions](ekolite-adrs.md)          | What was decided, and what it cost                 |
+| [Test-driven development](ekolite-tdd-training.md) | The red, green, refactor loop with worked examples |
+| [Specification](ekolite-spec.md)                   | API signatures and type definitions                |

--- a/docs/ekolite-overview/ekolite-overview.md
+++ b/docs/ekolite-overview/ekolite-overview.md
@@ -70,22 +70,22 @@ No `vi.mock()`. No spies. Real code with an off switch.
 
 ---
 
-## The Build Plan
+## Where It Stands
 
-8 smoke tests, built in order. Each one proves a piece of the framework works.
+EkoLite is published early at `0.x` and the public API is still settling. What is built:
 
-```
-ST 0  Infrastructure wrappers    → Can we test without real systems?
-ST 1  Server + static page       → Fastify + Vite work?
-ST 2  WebSocket connection        → Real-time transport works?
-ST 3  Pub/sub + reactive store   → Live data updates work?
-ST 4  RPC methods                → Server calls work?
-ST 5  File upload                → BAM upload works?
-ST 6  File validation            → Bad files rejected?
-ST 7  End-to-end pipeline        → Full workflow works end-to-end
-```
+- **Pub/sub over a live socket.** Define a publication, subscribe from a page, and a reactive store fills from MongoDB change streams and keeps up as the data moves.
+- **RPC methods.** Register a named server method, call it over the socket, get a typed result or a structured error back.
+- **File uploads over HTTP.** The bytes go to storage, the metadata goes to MongoDB, and the change stream pushes the new file into every subscribed client's list.
+- **Nullable infrastructure.** Every wrapper has `create()` and `createNull()`, so the whole graph runs in memory for tests.
+- **App wiring.** `App.create()` assembles the real graph and `App.createNull()` assembles the same one nulled, so the tests drive the assembly that boots in production.
+- **Graceful shutdown.** On a stop signal the server stops taking requests, drains the change streams, closes MongoDB and exits.
+- **A heartbeat**, so a client can tell a silently dead socket from a quiet one.
 
-When Smoke Test 7 passes, the framework covers everything a real-time, data-driven app needs.
+What is not built yet, and matters:
+
+- **Reconnect and resubscribe.** A closed socket disposes and stays disposed. The client does not yet come back on its own.
+- **Auth on the file routes.** `POST /api/files` and `GET /api/files/:id` are open.
 
 ---
 

--- a/docs/ekolite-overview/ekolite-overview.md
+++ b/docs/ekolite-overview/ekolite-overview.md
@@ -92,10 +92,10 @@ When Smoke Test 7 passes, the framework covers everything a real-time, data-driv
 
 Read these when you need detail on a specific topic:
 
-| Doc                        | What's in it                                            |
-| -------------------------- | ------------------------------------------------------- |
-| `ekolite-system-design.md` | How Meteor works, concept-by-concept mapping to EkoLite |
-| `ekolite-adrs.md`          | Architecture decisions and why we made them             |
-| `ekolite-tdd-training.md`  | Red-green-refactor tutorial with worked examples        |
-| `ekolite-tdd.md`           | Nullable code reference, test pyramid, test structure   |
-| `ekolite-spec.md`          | API signatures and type definitions                     |
+| Doc                        | What's in it                                          |
+| -------------------------- | ----------------------------------------------------- |
+| `ekolite-system-design.md` | How the framework works, concept by concept           |
+| `ekolite-adrs.md`          | Architecture decisions and why we made them           |
+| `ekolite-tdd-training.md`  | Red-green-refactor tutorial with worked examples      |
+| `ekolite-tdd.md`           | Nullable code reference, test pyramid, test structure |
+| `ekolite-spec.md`          | API signatures and type definitions                   |

--- a/docs/ekolite-overview/ekolite-spec.md
+++ b/docs/ekolite-overview/ekolite-spec.md
@@ -25,19 +25,24 @@ A stripped-down version of DDP that keeps only pub/sub and RPC. No merge box, no
 - Client maintains a local **reactive store** (plain TS, framework-agnostic)
 - Store emits events on changes — any UI layer can listen
 
-#### 6 message types (vs ~15 in full DDP):
+#### 11 message types (vs ~15 in full DDP):
 
 ```
 Client → Server:
-  { type: 'subscribe', id, name, params }
+  { type: 'subscribe', id, name, params? }
   { type: 'unsubscribe', id }
   { type: 'method', id, name, params }
+  { type: 'ping', id? }
 
 Server → Client:
-  { type: 'ready', id }
-  { type: 'added' | 'changed' | 'removed', collection, id, fields }
+  { type: 'ready', id, collection }
+  { type: 'added' | 'changed' | 'removed', collection, id, fields? }
   { type: 'result' | 'error', id, result | error }
+  { type: 'pong', id? }
 ```
+
+`ping` and `pong` carry the heartbeat: a TCP connection can be dead while both ends still
+believe it is open, so the client pings and closes the socket if no pong comes back.
 
 #### Server API:
 

--- a/docs/ekolite-overview/ekolite-system-design.md
+++ b/docs/ekolite-overview/ekolite-system-design.md
@@ -1,478 +1,187 @@
-# ekolite — System Design
+# EkoLite, System Design
 
-Start with [ekolite-overview.md](ekolite-overview.md) for the big picture. This document explains how Meteor works and how every concept maps to EkoLite.
-
----
-
-## 1. What Is Meteor
-
-Meteor is a full-stack JavaScript framework. You write client and server code in the same project, and the framework handles everything in between: building, bundling, data synchronization, real-time updates, and RPC.
-
-### 1.1 The Meteor Architecture
-
-```
-┌──────────────────────────────────────────────────────────────┐
-│                      METEOR FRAMEWORK                         │
-│                                                               │
-│  ┌─── CLIENT (browser) ────────┐   ┌─── SERVER (Node.js) ──┐ │
-│  │                              │   │                        │ │
-│  │  Meteor.startup()            │   │  Meteor.startup()      │ │
-│  │  ↓                           │   │  ↓                     │ │
-│  │  React renders App           │   │  MongoDB connects      │ │
-│  │                              │   │  Publications defined  │ │
-│  │  Minimongo ◄── DDP ────────────── Mongo.Collection       │ │
-│  │  (in-memory mirror)  (WebSocket)  (real MongoDB)          │ │
-│  │                              │   │                        │ │
-│  │  Meteor.subscribe() ◄─────────── Meteor.publish()        │ │
-│  │  Meteor.call() ◄──────────────── Meteor.methods()        │ │
-│  │                              │   │                        │ │
-│  │  useTracker() → React re-render  │                        │ │
-│  │                              │   │                        │ │
-│  │  ostrio:files.insert() ────────── FilesCollection         │ │
-│  │  (upload with progress)      │   │  (disk + MongoDB)      │ │
-│  │                              │   │                        │ │
-│  └──────────────────────────────┘   └────────────────────────┘ │
-│                                                               │
-│  Build system: Babel + custom bundler + 69 packages            │
-└──────────────────────────────────────────────────────────────┘
-```
-
-Everything communicates over **DDP** (Distributed Data Protocol) — a WebSocket-based protocol with ~15 message types. You never see the WebSocket directly. Meteor manages connections, reconnection, session tracking, and data merging automatically.
-
-### 1.2 Meteor Concepts — Explained with Our Code
-
-#### Meteor.startup()
-
-Runs your code after the framework is ready.
-
-**Client** (`client/main.jsx`):
-
-```jsx
-Meteor.startup(() => {
-  const container = document.getElementById('react-target');
-  const root = createRoot(container);
-  root.render(
-    <ChakraProvider>
-      <App />
-    </ChakraProvider>,
-  );
-});
-```
-
-Waits for: DDP connection established, packages loaded, DOM ready. Then renders React.
-
-**Server** (`server/main.js`):
-
-```js
-Meteor.startup(() => {
-  console.log('Server started and ready for file uploads.');
-});
-```
-
-Waits for: MongoDB connected, all server code loaded. Then runs.
-
-#### Collections & Minimongo
-
-Meteor gives you one `Collection` object that works on both client and server. On the server it talks to real MongoDB. On the client it talks to **Minimongo** — an in-memory database that Meteor keeps in sync.
-
-**Our code** (`imports/api/files.js`):
-
-```js
-export const UserFiles = new FilesCollection({
-  collectionName: 'UserFiles',
-  storagePath: 'assets/app/uploads',
-  allowClientCode: false,
-  onBeforeUpload(file) {
-    if (/bam$/i.test(file.extension)) return true;
-    return 'Only .bam files are allowed!';
-  },
-  onAfterUpload(fileObj) {
-    // renames file to original name, updates metadata in MongoDB
-    const oldPath = fileObj.path;
-    const newPath = path.join(path.dirname(oldPath), originalName);
-    fs.rename(oldPath, newPath, (err) => { ... });
-    UserFiles.collection.updateAsync(fileObj._id, { $set: { ... } });
-  }
-});
-```
-
-`FilesCollection` (from `ostrio:files`) extends the Meteor collection concept with file storage: disk path, validation hooks, metadata tracking.
-
-**How Minimongo sync works:**
-
-```
-Server MongoDB  ──── DDP messages ────►  Client Minimongo
-     │               (added, changed,         │
-     │                removed)                 │
-     │                                         ▼
-     ▼                                  UserFiles.find({})
-UserFiles.find({})                      → instant, from memory
-→ from real MongoDB                     → re-renders React via useTracker
-```
-
-#### Publish / Subscribe
-
-The server controls what data clients can see. The client requests data by name.
-
-**Server** (`imports/api/files.js`):
-
-```js
-Meteor.publish('files.UserFiles.all', function () {
-  return UserFiles.find().cursor;
-});
-```
-
-Defines a **publication**: "anyone who subscribes to `'files.UserFiles.all'` gets all documents from UserFiles."
-
-**Client** (`imports/ui/Home.jsx`):
-
-```jsx
-const { files, isLoading } = useTracker(() => {
-  const filesHandle = Meteor.subscribe('UserFiles.all');
-  const loading = !filesHandle.ready();
-  const filesList = UserFiles.find({});
-  return { files: filesList, isLoading: loading };
-}, []);
-```
-
-What happens step by step:
-
-1. `Meteor.subscribe('UserFiles.all')` sends a DDP `sub` message to the server
-2. Server runs the publication function, finds matching documents
-3. Server sends each document as a DDP `added` message
-4. Server sends a `ready` message when done
-5. As documents change, server sends `changed`/`removed` messages
-6. `useTracker()` re-runs whenever the data changes → React re-renders
-
-```
-Client                              Server
-  │                                    │
-  │── sub('UserFiles.all') ──────────►│
-  │                                    │── UserFiles.find().cursor
-  │◄── added { _id:'1', name:'a' } ──│
-  │◄── added { _id:'2', name:'b' } ──│
-  │◄── ready ─────────────────────────│
-  │                                    │
-  │    (new file uploaded)             │
-  │                                    │── change stream detects insert
-  │◄── added { _id:'3', name:'c' } ──│
-  │                                    │
-  │    useTracker re-renders React     │
-```
-
-#### Methods / Call (RPC)
-
-The server defines named functions. The client calls them remotely.
-
-**Server** (`imports/api/PythonMethods.js`):
-
-```js
-Meteor.methods({
-  async runCountC() {
-    return new Promise((resolve, reject) => {
-      const scriptPath = Assets.absoluteFilePath('scripts/countC.py');
-      const targetAbs = path.resolve(buildRoot, 'assets/app/uploads/bam');
-
-      execFile('python3', [scriptPath, targetAbs], (error, stdout, stderr) => {
-        if (error) {
-          reject(new Meteor.Error('python-failed', stderr || error.message));
-          return;
-        }
-        resolve(String(stdout).trim());
-      });
-    });
-  },
-});
-```
-
-Key pieces:
-
-- `Meteor.methods({})` registers functions by name
-- `Assets.absoluteFilePath()` resolves paths inside the Meteor build output
-- `Meteor.Error` is a structured error with a reason code
-- `execFile` runs the Python analysis script
-
-**Client** (`imports/ui/GoSubmitButton.jsx`):
-
-```jsx
-const handleSubmit = async () => {
-  const targetPath = '.meteor/local/build/programs/server/assets/app/uploads/bam';
-  const result = await Meteor.callAsync('runCountC', targetPath);
-  console.log('Count from Python:', result);
-};
-```
-
-The client calls `Meteor.callAsync('runCountC', ...)` → DDP sends a `method` message → server runs it → DDP returns a `result` message → Promise resolves.
-
-**Note:** Meteor methods also support **optimistic UI** (run the method on client first for instant feedback, then reconcile with server result). We don't use this feature — our method runs Python, which is server-only.
-
-#### File Uploads (ostrio:files)
-
-**Client** (`imports/ui/BamUploader.jsx`):
-
-```jsx
-BamCollection.insert({
-  file,
-  onBeforeUpload(fileData) {
-    const isBam = fileData.extension?.toLowerCase() === 'txt'; // changed for testing
-    if (!isBam) return false;
-    return true;
-  },
-  onProgress(currentProgress) {
-    setProgress(Math.round(currentProgress));
-  },
-  onUploaded(error, fileObj) {
-    if (error) console.error('Upload error:', error);
-    else console.log('Upload complete. File ID:', fileObj._id);
-  },
-});
-```
-
-`ostrio:files` handles the full upload lifecycle:
-
-1. Client-side validation (`onBeforeUpload`)
-2. Chunked transfer over DDP or HTTP
-3. Server stores file on disk at `storagePath`
-4. Server inserts metadata into MongoDB
-5. Server runs `onAfterUpload` hook (our app renames the file)
-6. Client gets progress updates (`onProgress`)
-7. Client gets completion callback (`onUploaded`)
-
-#### DDP — The Wire Protocol
-
-DDP ties everything together. You never write DDP messages in Meteor — the framework does it for you.
-
-**Full DDP has ~15 message types:**
-
-```
-connect, connected, ping, pong, sub, unsub, nosub,
-added, changed, removed, ready, updated,
-method, result, error
-```
-
-The important ones for us:
-
-- `sub`/`unsub` — client subscribes/unsubscribes to publications
-- `added`/`changed`/`removed` — server pushes data changes to client
-- `ready` — server signals initial data is loaded
-- `method` — client calls an RPC method
-- `result`/`error` — server returns method outcome
-
-#### Build System
-
-Meteor has its own build system:
-
-- Scans `imports/`, `client/`, `server/` directories
-- Babel transpiles JSX and modern JS
-- Bundles 69 packages (most unused in our app)
-- Full rebuild takes seconds
-- Hot code push reloads the entire page (not just the changed component)
-
-Our `.meteor/` directory contains the entire build pipeline and package system.
+Start with [ekolite-overview.md](ekolite-overview.md) for the big picture, and [ekolite-spec.md](ekolite-spec.md) for signatures and types. This document explains how the framework is put together and why it is shaped the way it is. The decisions behind it are recorded in [ekolite-adrs.md](ekolite-adrs.md).
 
 ---
 
-## 2. What ekolite Keeps, Simplifies, and Drops
+## 1. The Shape of the Framework
 
-### 2.1 The Decision Table
+EkoLite splits into three layers, and the split is the whole design.
 
-| Meteor Feature                     | Decision                                                       | Rationale                                                                                              |
-| ---------------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| DDP (full protocol, ~15 msg types) | **Simplify** → Mini-DDP (6 msg types)                          | We only use pub/sub and RPC. Drop connect handshake, ping/pong, session tracking, merge box.           |
-| Mongo.Collection + Minimongo       | **Simplify** → MongoWrapper + ReactiveStore                    | We don't need client-side queries. A simple Map that responds to server messages is enough.            |
-| Meteor.methods / Meteor.call       | **Keep** → Methods.define / MeteorLight.call                   | Same concept, same pattern. Just our code instead of Meteor's.                                         |
-| Meteor.publish / Meteor.subscribe  | **Keep** → Publications.define / MeteorLight.subscribe         | Same concept. We use MongoDB change streams instead of Meteor's oplog tailing.                         |
-| ostrio:files                       | **Replace** → UploadHandler + FileStorage + @fastify/multipart | ostrio:files is a 3rd party package with complex internals. Standard HTTP multipart upload is simpler. |
-| Assets.absoluteFilePath            | **Keep** → resolveAsset()                                      | Same utility, just not tied to Meteor's build output paths.                                            |
-| Accounts, Session, ReactiveVar     | **Drop**                                                       | Our app has no auth, no sessions, no reactive variables.                                               |
-| Merge box                          | **Drop**                                                       | Merge box deduplicates data across overlapping subscriptions. We have one subscription.                |
-| Latency compensation               | **Drop**                                                       | Our methods run Python scripts server-side. Nothing to optimistically simulate on the client.          |
-| Reconnect replay                   | **Drop**                                                       | If the connection drops, the client re-subscribes. Simpler than replaying a session log.               |
-| Blaze, Tracker autorun             | **Drop**                                                       | We use React. Tracker is Blaze's reactivity system.                                                    |
-| Build system (69 packages)         | **Replace** → Vite + tsx + tsc                                 | Meteor's custom bundler is the main source of slowness and complexity.                                 |
+**Infrastructure** reaches outside the process: MongoDB, the WebSocket server, the file system, child processes. Each one is a wrapper with two factories, `create()` for the real thing and `createNull()` for an in-memory stand-in behind the same interface.
 
-### 2.2 The Architecture Comparison
+**Logic** is everything that decides something: which documents a subscription sends, what a method returns, whether a file is acceptable. Logic classes never import infrastructure. They receive it through the constructor, and they cannot tell a real wrapper from a nulled one.
 
-**Before (Meteor):**
+**The application layer** wires the two together. `App.create(config)` assembles real infrastructure. `App.createNull()` assembles the same graph with nulled infrastructure. The assembly that boots in production is the assembly the tests drive, which is the point: there is no separate test wiring to drift out of step.
 
 ```
-┌──────────────────────────────┐
-│         METEOR               │
-│  69 packages                 │
-│  Custom bundler              │
-│  DDP (~15 msg types)         │
-│  Minimongo                   │
-│  Merge box                   │
-│  Latency compensation        │
-│  Session tracking            │
-│  ostrio:files                │
-│  ~??? lines (framework)      │
-└──────────────────────────────┘
+server/
+  infrastructure/     mongo.ts, websocket.ts, fileStorage.ts, scriptRunner.ts, process.ts
+  logic/              publications.ts, methods.ts, rpcHandler.ts, files.ts, shutdown.ts
+  app.ts              App.create() / App.createNull()
+  index.ts            createServer(): Fastify, static, websocket routing, file routes
+client/
+  clientSocket.ts     ClientSocketWrapper, the nullable WebSocket client
+  connectionManager.ts  subscriptions, remote calls, lifecycle
+  reactiveStore.ts    client-side collection state
+  uploader.ts         file upload with progress
+shared/
+  protocol.ts         the wire protocol, typed for both ends
 ```
 
-**After (ekolite):**
-
-```
-┌──────────────────────────────┐
-│       ekolite           │
-│  5 runtime dependencies      │
-│  Vite (client build)         │
-│  Mini-DDP (6 msg types)      │
-│  ReactiveStore (Map)         │
-│  No merge box                │
-│  No latency compensation     │
-│  No sessions                 │
-│  @fastify/multipart          │
-│  ~820 lines (our code)       │
-└──────────────────────────────┘
-```
+`App` exposes exactly three things: `publications`, `methods` and `files`.
 
 ---
 
-## 3. Concept Mapping — Meteor → ekolite
+## 2. The Wire Protocol
 
-This is the central reference. Every row connects a Meteor concept to our actual code, its ekolite replacement, and where that replacement gets built.
+The protocol is called Mini DDP. It is deliberately small, and `shared/protocol.ts` is the only place it is defined, imported by both halves so a message that changes shape breaks the build rather than a user's session.
 
-|  #  | Meteor Concept                      | Our Meteor Code                                                        | ekolite Replacement                                            | Where It's Built        |
-| :-: | ----------------------------------- | ---------------------------------------------------------------------- | -------------------------------------------------------------- | ----------------------- |
-|  1  | `Meteor.startup()` (client)         | `client/main.jsx` — renders React after DDP ready                      | Vite entry script — just `import` and run                      | Epic 1, Story 1.A       |
-|  2  | `Meteor.startup()` (server)         | `server/main.js` — logs "ready" after Mongo connects                   | `App.create(config)` → `fastify.listen()`                      | Epic 7, Story 7.B       |
-|  3  | `Mongo.Collection`                  | `FilesCollection` in `imports/api/files.js`                            | `MongoWrapper` (thin wrapper over `mongodb` driver)            | Smoke Test 0, Story 0.A |
-|  4  | Minimongo (client-side mirror)      | Automatic via DDP — `UserFiles.find({})` works on client               | `ReactiveStore` — `Map<id, doc>` fed by server messages        | Epic 3, Story 3.B       |
-|  5  | `Meteor.publish()`                  | `Meteor.publish('files.UserFiles.all', ...)` in `imports/api/files.js` | `Publications.define('UserFiles.all', ...)`                    | Epic 3, Story 3.A       |
-|  6  | `Meteor.subscribe()`                | `Meteor.subscribe('UserFiles.all')` in `imports/ui/Home.jsx`           | `MeteorLight.subscribe('UserFiles.all')`                       | Epic 3, Story 3.C       |
-|  7  | `useTracker()`                      | `useTracker(() => { ... })` in `imports/ui/Home.jsx`                   | `store.on('change', callback)` — UI layer listens to store     | Epic 3, Story 3.B       |
-|  8  | `Meteor.methods()`                  | `Meteor.methods({ runCountC() { ... } })` in `PythonMethods.js`        | `Methods.define('runCountC', async (...) => { ... })`          | Epic 4, Story 4.A       |
-|  9  | `Meteor.call()` / `callAsync()`     | `Meteor.callAsync('runCountC', targetPath)` in `GoSubmitButton.jsx`    | `MeteorLight.call('runCountC', targetPath)`                    | Epic 4, Story 4.C       |
-| 10  | `Meteor.Error`                      | `new Meteor.Error("python-failed", ...)` in `PythonMethods.js`         | `MeteorLightError { code, message, details }`                  | Epic 4, Story 4.A       |
-| 11  | `Assets.absoluteFilePath()`         | `Assets.absoluteFilePath("scripts/countC.py")` in `PythonMethods.js`   | `resolveAsset("scripts/countC.py")`                            | Epic 7, Story 7.A       |
-| 12  | `execFile` (child_process)          | `execFile("python3", [...])` in `PythonMethods.js`                     | `ScriptRunner.exec("python3", [...])`                          | Smoke Test 0, Story 0.D |
-| 13  | `FilesCollection.insert()` (client) | `BamCollection.insert({ file, onProgress, ... })` in `BamUploader.jsx` | `MeteorLight.upload('/api/upload', file)` with progress events | Epic 5, Story 5.D       |
-| 14  | `onBeforeUpload`                    | Extension check in `imports/api/files.js`                              | `UploadHandler.validate()`                                     | Epic 5, Story 5.A       |
-| 15  | `onAfterUpload`                     | Rename + metadata update in `imports/api/files.js`                     | Post-save logic in `UploadHandler.handle()`                    | Epic 5, Story 5.B       |
-| 16  | `onProgress`                        | `setProgress(Math.round(currentProgress))` in `BamUploader.jsx`        | `upload.on('progress', (pct) => { ... })`                      | Epic 5, Story 5.D       |
-| 17  | DDP protocol (~15 msg types)        | Invisible — framework handles it                                       | Mini-DDP (6 msg types) in `shared/protocol.ts`                 | Smoke Test 0, Story 0.B |
-| 18  | DDP transport (WebSocket)           | Invisible — framework handles it                                       | `WebSocketServer` wrapper                                      | Smoke Test 0, Story 0.B |
-| 19  | Build system (Babel + bundler)      | `.meteor/` directory, 69 packages                                      | Vite (client) + tsx (server dev) + tsc (types)                 | Epic 1, Story 1.B       |
-| 20  | `React Router`                      | `BrowserRouter` + `Routes` in `App.jsx`                                | Stays the same — ekolite doesn't dictate UI                    | Not in scope            |
-
----
-
-## 4. Mini-DDP Protocol Design
-
-Full DDP has ~15 message types. We keep 6:
-
-### 4.1 Messages We Keep
+### 2.1 The Messages
 
 ```
 Client → Server:
-  { type: 'subscribe', id, name, params }     ← request data
-  { type: 'unsubscribe', id }                 ← stop receiving data
-  { type: 'method', id, name, params }        ← call a server function
+  { type: 'subscribe', id, name, params? }   request a publication
+  { type: 'unsubscribe', id }                stop receiving it
+  { type: 'method', id, name, params }       call a server method
+  { type: 'ping', id? }                      are you still there
 
 Server → Client:
-  { type: 'ready', id }                       ← initial data loaded
-  { type: 'added'|'changed'|'removed',        ← data changed
-    collection, id, fields }
-  { type: 'result'|'error', id, result|error } ← method response
+  { type: 'ready', id, collection }          initial documents sent
+  { type: 'added', collection, id, fields? }
+  { type: 'changed', collection, id, fields? }
+  { type: 'removed', collection, id }
+  { type: 'result', id, result }             the method returned
+  { type: 'error', id, error }               the method failed
+  { type: 'pong', id? }                      still here
 ```
 
-### 4.2 Messages We Drop and Why
+Eleven message types, against roughly fifteen in full DDP.
 
-| DDP Message             | Purpose                                       | Why We Don't Need It                        |
-| ----------------------- | --------------------------------------------- | ------------------------------------------- |
-| `connect` / `connected` | Handshake with version negotiation            | WebSocket `open` event is enough            |
-| `ping` / `pong`         | Keepalive                                     | The `ws` library handles this natively      |
-| `nosub`                 | Subscription rejected                         | We send a regular `error` message           |
-| `updated`               | "Method writes have been applied to all subs" | We don't do optimistic UI                   |
-| Session IDs             | Track client across reconnects                | Client re-subscribes on reconnect — simpler |
+### 2.2 What the Protocol Refuses to Do
 
-### 4.3 Flow Examples
+The count is not really the point. The saving is in the machinery that is absent, and each absence is a decision.
 
-**Subscribe to file list:**
+| Not implemented      | What it would do                                     | Why it is not here                                                                                    |
+| -------------------- | ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| Connect handshake    | Version negotiation before anything else             | The WebSocket `open` event already says the connection is up                                          |
+| Session identity     | Track a client across reconnects                     | A client that reconnects re-subscribes, which is simpler than replaying a log                         |
+| Merge box            | Reconcile documents across overlapping subscriptions | Subscriptions do not overlap in practice, and the bookkeeping is substantial                          |
+| Latency compensation | Run the method on the client first, reconcile later  | Methods run server-side work, such as an analysis script. There is nothing to simulate optimistically |
+| Reconnect replay     | Resume a dropped session where it left off           | Not built yet. Today a closed socket disposes and stays disposed                                      |
+
+That last row is a gap, not a decision, and it is named as one.
+
+### 2.3 The Heartbeat
+
+`ping` and `pong` exist because a TCP connection can be dead while both ends still believe it is open. The socket does not close, no error fires, and the client sits waiting for data that will never arrive.
+
+`ClientSocketWrapper` runs a `Heartbeat` that sends a `ping` on an interval and expects a `pong` before a deadline. If the deadline passes, the connection is treated as dead and closed, which is the only way the client finds out. The server answers every `ping` with a `pong`, carrying the `id` back when the ping sent one.
+
+The heartbeat is opt-in: `pingIntervalMs` and `pongTimeoutMs` default to zero, which means off.
+
+### 2.4 Flows
+
+**Subscribe, then live updates:**
 
 ```
-Client                              Server
-  │── subscribe(id:'s1',            │
-  │     name:'UserFiles.all') ─────►│
-  │                                  │── query MongoDB
-  │◄── added(collection:'UserFiles', │
-  │     id:'1', fields:{name:'a'}) ─│
-  │◄── ready(id:'s1') ──────────────│
-  │                                  │
-  │    [file uploaded by someone]    │
-  │                                  │── change stream fires
-  │◄── added(collection:'UserFiles', │
-  │     id:'2', fields:{name:'b'}) ─│
+Client                                    Server
+  │── subscribe(id:'s1',                    │
+  │     name:'files.all') ────────────────►│
+  │                                          │── query MongoDB
+  │◄── added(collection:'files', id:'1') ──│
+  │◄── ready(id:'s1', collection:'files') ─│
+  │                                          │
+  │      [someone uploads a file]            │
+  │                                          │── change stream fires
+  │◄── added(collection:'files', id:'2') ──│
 ```
 
 **Call a method:**
 
 ```
-Client                              Server
-  │── method(id:'m1',               │
-  │    name:'runCountC',            │
-  │    params:['/uploads']) ───────►│
-  │                                  │── ScriptRunner.exec('python3', ...)
-  │◄── result(id:'m1',              │
-  │     result:'count: 42') ────────│
+Client                                    Server
+  │── method(id:'m1', name:'runCountC',    │
+  │     params:['/uploads/x.bam']) ───────►│
+  │                                          │── ScriptRunner runs the script
+  │◄── result(id:'m1', result:'42') ───────│
 ```
 
-**Error case:**
+**A method that fails:**
 
 ```
-Client                              Server
-  │── method(id:'m2',               │
-  │    name:'doesNotExist',         │
-  │    params:[]) ─────────────────►│
-  │                                  │── Methods.call → not found
-  │◄── error(id:'m2',               │
-  │     error:{code:404,            │
-  │       message:'Method not       │
-  │       found: doesNotExist'}) ───│
+Client                                    Server
+  │── method(id:'m2',                       │
+  │     name:'doesNotExist') ─────────────►│
+  │                                          │── no such method
+  │◄── error(id:'m2', error:{code, message})│
 ```
 
 ---
 
-## 6. What Does the Current App Do
+## 3. Live Data
 
-A summary of the application's actual workflow, for context.
+`Publications` is the pub/sub engine. A publication is a named function that returns the collection to watch and the query that selects from it:
 
-### 6.1 The User Flow
-
-1. User opens the app → sees Home page with sidebar (file uploaders, color controls, submit button) and main area (chromosome selector, Hilbert curve view, linear signal view)
-2. User selects a `.bam` genomic file via one of the BamUploader components
-3. File uploads with progress bar → stored on server disk → metadata in MongoDB
-4. File appears in the file list (real-time via pub/sub)
-5. User clicks "Submit Job GO!" → calls `runCountC` method → Python script analyzes the BAM file → result returned
-6. Results displayed in HilbertCurveViewArea and LinearSignalArea charts
-
-### 6.2 The Current Component Tree
-
-```
-App (Router)
-├── Navbar
-├── Home
-│   ├── BamUploader (×3)     ← file upload with progress
-│   ├── GoSubmitButton       ← triggers Meteor.callAsync('runCountC')
-│   ├── HilbertCurveViewArea ← Highcharts visualization
-│   └── LinearSignalArea     ← Highcharts visualization
-├── About
-└── Usage
+```ts
+publications.define('files.all', () => ({ collection: 'files', query: {} }));
 ```
 
-### 6.3 What Stays the Same
+When a client subscribes, the server runs the query, sends one `added` per document, then `ready`. From that point a MongoDB change stream feeds `added`, `changed` and `removed` to every subscriber as the data moves.
 
-- React + Chakra UI components
-- React Router navigation
-- Highcharts visualizations
-- Python analysis script (`countC.py`)
-- The user experience
+Teardown is reference counted. Several clients can hold the same publication, and the change stream is only closed when the last one lets go. A client that never unsubscribes is not a leak: closing the socket disposes its subscriptions.
 
-### 6.4 What Changes (Under the Hood)
+Removals are bookkeeping-aware. The server tracks which documents each client actually holds, and only pushes a `removed` for a document that client knows about, so a client is never told to delete something it never had.
 
-- `Meteor.startup()` → Vite entry point
-- `Meteor.subscribe()` / `useTracker()` → `MeteorLight.subscribe()` + `store.on('change')`
-- `Meteor.callAsync()` → `MeteorLight.call()`
-- `BamCollection.insert()` → `MeteorLight.upload()`
-- `.meteor/` build system → Vite + tsx
+---
+
+## 4. Remote Calls
+
+`Methods` is a registry. A method is a named function on the server:
+
+```ts
+methods.define('runCountC', async (path) => scriptRunner.exec('python3', [script, path]));
+```
+
+`RpcHandler` routes an inbound `method` message to the registry and sends back `result` or `error`. Failures come back as a structured error with a code and a message, not a stack trace, and the client rejects the pending promise with it.
+
+---
+
+## 5. Files
+
+Files go over plain HTTP, not the socket.
+
+`POST /api/files` takes a multipart upload, `Files.validate()` decides whether the name is acceptable, `FileStorageWrapper` writes the bytes, and a metadata document goes into MongoDB. That insert is what makes the file appear: the change stream picks it up and pub/sub streams it into every subscribed client's list. Upload and live update are the same mechanism, not two.
+
+`GET /api/files/:id` streams the bytes back.
+
+The routes are open. There is no auth on them yet, and that is a known gap.
+
+---
+
+## 6. The Client Stack
+
+`ClientSocketWrapper` is the nullable WebSocket client: the same `create()` and `createNull()` pattern as the server wrappers, so client logic can be tested without a socket.
+
+`ConnectionManager` is the surface a page actually uses:
+
+```ts
+const handle = connection.subscribe('files.all'); // → SubscriptionHandle
+const store = connection.store('files'); // → ReactiveStore
+const count = await connection.call('runCountC', path);
+handle.stop();
+```
+
+`ReactiveStore` is client-side collection state: a `Map` fed by `added`, `changed` and `removed`, with `getAll()`, `getById()` and `onChange()` for the UI to listen to. It is about ninety lines, and it holds no query engine on purpose.
+
+`ConnectionManager.dispose()` stops every subscription and rejects every in-flight call, so a closed connection never leaves a promise hanging forever.
+
+---
+
+## 7. How It Is Tested
+
+Every infrastructure wrapper has `create()` and `createNull()`, and parity tests hold the two to the same behaviour. Logic is tested against nulled infrastructure, so the tests exercise real logic against substitutable edges rather than asserting that a mock was called. There is no mocking library in the project.
+
+Nullable unit tests and integration tests live in separate files, so the fast suite never touches the network or the disk. The full pipeline, real Mongo, real socket, real upload, is covered by integration tests that run separately.
+
+[nullables-how-much-should-the-stub-know.md](../manual/nullables-how-much-should-the-stub-know.md) works through the design question that comes up most: how much a nulled stub should know about the thing it stands in for.

--- a/docs/ekolite-overview/ekolite-tdd-training.md
+++ b/docs/ekolite-overview/ekolite-tdd-training.md
@@ -1,183 +1,119 @@
-# ekolite — TDD Training Guide
+# Test-Driven Development in EkoLite
 
-Start with [ekolite-overview.md](ekolite-overview.md) for the big picture. This document teaches the red-green-refactor loop and how it works with Testing Without Mocks. See `ekolite-tdd.md` for the technical reference.
+Every line of EkoLite was written test first, and there is no mocking library in the project. This walks through how that works in practice, using two pieces of the framework as they were actually built.
 
----
-
-## 1. What Is Red-Green-Refactor
-
-Every piece of production code starts with a failing test. The loop has three phases:
-
-```
-  ┌──────────────────────────────────────────────┐
-  │                                              │
-  │   RED ──────► GREEN ──────► REFACTOR ──┐     │
-  │   write a      write the     improve   │     │
-  │   failing      minimum       structure │     │
-  │   test         code to       without   │     │
-  │                pass          changing   │     │
-  │                              behavior  │     │
-  │                                        │     │
-  │            ◄────────────────────────────┘     │
-  │            next failing test                  │
-  └──────────────────────────────────────────────┘
-```
-
-**Red:** Write a test that describes the behavior you want. Run it. It must fail. If it passes, you either wrote the wrong test or the behavior already exists.
-
-**Green:** Write the simplest, dumbest code that makes the test pass. No cleverness. No "while I'm here" additions. Just make the red go green.
-
-**Refactor:** Now that the test is green, improve the code's structure. Rename variables, extract helpers, remove duplication. The tests stay green throughout. If they go red, you changed behavior — undo and try again.
-
-**Cycle time:** Each red-green-refactor cycle should take **5–20 minutes**. If you've been in "Red" for 30 minutes, your test is too ambitious — write a smaller one.
+Start with [ekolite-overview.md](ekolite-overview.md) if you want the big picture first, and [nullables-how-much-should-the-stub-know.md](../manual/nullables-how-much-should-the-stub-know.md) for the design question that comes up most once you start writing nulled infrastructure of your own.
 
 ---
 
-## 2. How It Works with Nullables (No Mocks)
+## 1. Red, Green, Refactor
 
-This project uses **Testing Without Mocks** (James Shore). There are no `vi.mock()`, no `vi.spyOn()`, no test doubles. Instead:
+Every piece of production code starts with a failing test. The loop has three phases.
 
-**Infrastructure wrappers** have two factories:
+**Red.** Write a test that describes the behaviour you want. Run it. It must fail. If it passes, either you wrote the wrong test or the behaviour already exists, and both are worth knowing before you write any code.
 
-- `create()` — connects to real external systems (MongoDB, file system, WebSocket)
-- `createNull()` — behaves identically but uses in-memory implementations
+**Green.** Write the simplest, dullest code that makes the test pass. No cleverness, no "while I am here" additions. Just make the red go green.
 
-See ADR-008 and ADR-009 for why we made this choice.
+**Refactor.** Now the test is green, improve the structure. Rename, extract, remove duplication. The tests stay green throughout. If they go red you changed behaviour, so undo and try again.
 
-### How Nullables work in each phase
-
-**In the Red phase** for a logic test:
-
-```ts
-// You instantiate real logic with Nulled infrastructure
-const mongo = MongoWrapper.createNull({ files: [{ _id: '1', name: 'a.bam' }] });
-const ws = WebSocketServer.createNull();
-const pubs = new Publications(mongo, ws);
-
-// You write an assertion about output or state
-const tracker = ws.trackMessages();
-// ... trigger behavior ...
-expect(tracker.messagesTo(client.id)).toContainEqual({ type: 'ready', id: 'sub1' });
-```
-
-**In the Green phase:** Implement the logic method. The Null infrastructure handles the external system behavior — you don't need to configure anything beyond seed data.
-
-**In the Refactor phase:** Extract helpers, rename for clarity, simplify the Null configuration. Tests stay green.
-
-### Output Tracking replaces spies
-
-| Traditional                                 | Nullables                                            |
-| ------------------------------------------- | ---------------------------------------------------- |
-| `vi.spyOn(ws, 'send')`                      | `ws.trackMessages()`                                 |
-| `expect(ws.send).toHaveBeenCalledWith(...)` | `expect(tracker.messagesTo(id)).toContainEqual(...)` |
-
-The difference: spies check _whether a function was called_. Output Tracking checks _what was produced_. You test state, not interactions.
-
-### The four kinds of tests in this project
-
-| Test Kind              | What It Tests                                        | Uses Real Systems? | Speed | When to Run    |
-| ---------------------- | ---------------------------------------------------- | ------------------ | ----- | -------------- |
-| **Narrow integration** | Infrastructure wrappers work with real MongoDB/fs/ws | Yes                | Slow  | CI or manually |
-| **Parity**             | Null version behaves same as real version            | Yes (runs both)    | Slow  | CI or manually |
-| **Sociable (logic)**   | Business logic with Nulled infrastructure            | No                 | Fast  | On every save  |
-| **Client-side**        | ReactiveStore, subscribe, call, upload               | No                 | Fast  | On every save  |
-
-See `ekolite-tdd.md` for the full test pyramid and file structure.
+A cycle should take five to twenty minutes. If you have been in red for half an hour, the test is too ambitious. Write a smaller one.
 
 ---
 
-## 3. Common Mistakes to Avoid
+## 2. How This Works Without Mocks
 
-| Mistake                                | Why It's Wrong                                                                                 | What to Do Instead                                              |
-| -------------------------------------- | ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| Reaching for `vi.mock()`               | Breaks the Nullable contract; hides real behavior                                              | Write a `createNull()` with seed data                           |
-| Writing implementation before the test | You can't know the test is testing the right thing if it never failed                          | Always start with Red                                           |
-| Making the Green step clever           | You'll refactor later — clever code in Green means you're doing two things at once             | Write the dumbest code that passes                              |
-| Skipping Refactor because "it works"   | Technical debt accumulates; the whole point of Green being dumb is that Refactor makes it good | Always take the Refactor step, even if it's "nothing to change" |
+EkoLite follows [Testing Without Mocks](https://www.jamesshore.com/v2/projects/nullables/testing-without-mocks). There is no `vi.mock()` and no `vi.spyOn()` anywhere in the suite.
+
+Every infrastructure wrapper has two factories. `create()` connects to the real thing: MongoDB, the file system, a WebSocket server. `createNull()` returns an in-memory one behind the identical interface. Logic classes take their infrastructure through the constructor and cannot tell which kind they were handed.
+
+So a logic test instantiates the real logic class with nulled infrastructure, and everything that runs is real code. Nothing is stubbed out at the seams.
+
+### Output tracking replaces spies
+
+| Traditional                                 | Nullable                                   |
+| ------------------------------------------- | ------------------------------------------ |
+| `vi.spyOn(ws, 'send')`                      | `ws.trackMessages()`                       |
+| `expect(ws.send).toHaveBeenCalledWith(...)` | `expect(client.messages).toContainEqual()` |
+
+A spy asks whether a function was called. Output tracking asks what was produced. The second question survives a refactor, the first one does not.
+
+### The kinds of test in this project
+
+| Kind               | What it tests                                          | Real systems?  | Speed |
+| ------------------ | ------------------------------------------------------ | -------------- | ----- |
+| Narrow integration | An infrastructure wrapper against real Mongo, fs or ws | Yes            | Slow  |
+| Parity             | The nulled wrapper behaves like the real one           | Yes, runs both | Slow  |
+| Sociable           | Logic against nulled infrastructure                    | No             | Fast  |
+| Client             | ReactiveStore, subscriptions, calls, uploads           | No             | Fast  |
+
+Nullable tests and integration tests live in separate files, so the fast suite never touches the network or the disk.
 
 ---
 
-## 4. Worked Example: Methods.define and Methods.call
+## 3. The Mistakes That Cost the Most Time
 
-This walks through **Developer Story 4.A.1** from the backlog — the simplest logic class in the project. No infrastructure dependencies. Pure TDD.
-
-### Why this example
-
-`Methods` is the best teaching example because:
-
-- Zero infrastructure dependencies (no Mongo, no WebSocket)
-- Two behaviors to implement (define/call + error handling)
-- Two clean red-green-refactor cycles
-- Maps directly to Meteor's `Meteor.methods()` / `Meteor.call()` (see System Design, Concept #8 and #9)
+| Mistake                            | Why it hurts                                                                 | Instead                                                  |
+| ---------------------------------- | ---------------------------------------------------------------------------- | -------------------------------------------------------- |
+| Reaching for `vi.mock()`           | Breaks the nullable contract and hides the real behaviour                    | Write a `createNull()` with seed data                    |
+| Writing the code before the test   | You cannot know a test tests the right thing if you never saw it fail        | Always start red                                         |
+| Being clever in green              | Green and refactor are two jobs. Doing both at once means doing neither well | Write the dullest code that passes                       |
+| Skipping refactor because it works | The whole reason green is allowed to be dull is that refactor comes next     | Take the step, even if the answer is "nothing to change" |
 
 ---
 
-### Cycle 1: Define and call a method
+## 4. Worked Example: Methods
 
-**RED** — Write the test first (`tests/logic/methods.test.ts`):
+`Methods` is the simplest logic class in the framework and it has no infrastructure at all, which makes it the clearest place to see the loop.
+
+### Cycle 1: define and call
+
+**Red.** The test comes first, in `tests/logic/methods.test.ts`:
 
 ```ts
 import { describe, it, expect } from 'vitest';
-import { Methods } from '../../server/logic/methods';
+import { Methods } from '../../server/logic/methods.ts';
 
 describe('Methods', () => {
   it('registers and calls a method', async () => {
     const methods = new Methods();
-    methods.define('echo', async (msg: string) => `echo: ${msg}`);
+    methods.define('echo', (msg) => Promise.resolve(`echo: ${String(msg)}`));
+
     const result = await methods.call('echo', ['hello']);
+
     expect(result).toBe('echo: hello');
   });
 });
 ```
 
-Run it: `vitest tests/logic/methods.test.ts`
+It fails: the module does not exist. That is red, and it is the right kind of red. The test says what we want before anything can possibly provide it.
 
-It fails: `Cannot find module '../../server/logic/methods'`. Good. That's Red.
-
-**What happened:** The module doesn't exist yet. The test describes the behavior we want: define a method by name, call it by name, get the result.
-
-**GREEN** — Write the minimum code (`server/logic/methods.ts`):
+**Green.** The dullest thing that passes:
 
 ```ts
-type MethodFn = (...args: any[]) => Promise<unknown>;
-
 export class Methods {
-  private registry = new Map<string, MethodFn>();
+  private methods = new Map<string, MethodFn>();
 
   define(name: string, fn: MethodFn): void {
-    this.registry.set(name, fn);
+    this.methods.set(name, fn);
   }
 
-  async call(name: string, params: unknown[]): Promise<unknown> {
-    const fn = this.registry.get(name)!;
-    return fn(...params);
+  async call(name: string, args: unknown[]): Promise<unknown> {
+    const method = this.methods.get(name);
+    return method(...args);
   }
 }
 ```
 
-Run the test. It passes. That's Green.
+A map of functions by name. Nothing more.
 
-**What happened:** A Map stores functions by name. `call()` looks up the function and invokes it with the params. Simplest thing that works.
+### Cycle 2: the unknown method
 
-**REFACTOR** — The code is small and clear. Export the `MethodFn` type so other modules can use it:
-
-```ts
-export type MethodFn = (...args: any[]) => Promise<unknown>;
-```
-
-Tests still pass. Done.
-
-**What happened:** We noticed `MethodFn` will be needed by `RpcHandler` later (see Story 4.B). Exporting it now is a small structural improvement.
-
----
-
-### Cycle 2: Error on unknown method
-
-**RED** — Add a second test:
+**Red.** What happens when nobody defined it?
 
 ```ts
 it('throws structured error for unknown method', async () => {
   const methods = new Methods();
+
   await expect(methods.call('nope', [])).rejects.toMatchObject({
     code: 404,
     message: 'Method not found: nope',
@@ -185,198 +121,75 @@ it('throws structured error for unknown method', async () => {
 });
 ```
 
-Run it. It fails: `Cannot read properties of undefined (reading 'apply')` because `registry.get()` returns `undefined` and we call `fn(...params)` on it. That's Red.
+This fails on `method is not a function`, because the map returned `undefined` and we called it anyway. Red again, and note what the test just did: it found a real hole in the code we just wrote, which is exactly what it is for.
 
-**What happened:** We discovered the current code doesn't handle missing methods. The test defines what should happen: a structured error with code 404.
-
-**GREEN** — Add a guard clause:
+**Green.** A guard:
 
 ```ts
-async call(name: string, params: unknown[]): Promise<unknown> {
-  const fn = this.registry.get(name);
-  if (!fn) {
-    throw { code: 404, message: `Method not found: ${name}` };
+async call(name: string, args: unknown[]): Promise<unknown> {
+  const method = this.methods.get(name);
+  if (!method) {
+    throw methodNotFound(name);
   }
-  return fn(...params);
+  return method(...args);
 }
 ```
 
-Test passes. That's Green.
+**Refactor.** `methodNotFound` moves to `shared/types.ts`, next to the error shape it builds, because the client needs to recognise that error too and both ends should agree on it in one place.
 
-**What happened:** One `if` statement. The error shape matches `MeteorLightError` from the spec. No extra framework — just a plain object.
+The class in the repo today is those two cycles plus one more, which refuses to redefine a method that already exists. Three tests, three behaviours, and every one of them failed before it passed.
 
-**REFACTOR** — Extract error creation into a helper:
+---
+
+## 5. Worked Example: Publications, With Nulled Infrastructure
+
+`Publications` depends on MongoDB and a WebSocket server. This is where mocking is the usual reflex, and where nullables earn their keep.
+
+**Red.** No mocks. Real `Publications`, nulled infrastructure with seed data:
 
 ```ts
-function methodNotFound(name: string) {
-  return { code: 404, message: `Method not found: ${name}` };
-}
-```
+import { Publications } from '../../server/logic/publications.ts';
+import { MongoWrapper } from '../../server/infrastructure/mongo.ts';
+import { WebSocketWrapper } from '../../server/infrastructure/websocket.ts';
 
-Tests still pass. Two cycles, two behaviors, clean code. That's the loop.
+it('sends error when subscribing to unknown publication', async () => {
+  const mongo = MongoWrapper.createNull();
+  const ws = WebSocketWrapper.createNull();
+  const client = ws.simulateConnection();
+  const pubs = new Publications(mongo, ws);
 
----
+  await pubs.handleMessage(client.id, {
+    type: 'subscribe',
+    id: 'sub1',
+    name: 'nonexistent',
+  });
 
-### What this connects to
-
-| What we just built                | Meteor equivalent                    | Backlog reference     |
-| --------------------------------- | ------------------------------------ | --------------------- |
-| `Methods.define('echo', fn)`      | `Meteor.methods({ echo() { ... } })` | Developer Story 4.A.1 |
-| `Methods.call('echo', ['hello'])` | `Meteor.call('echo', 'hello')`       | Developer Story 4.A.1 |
-| Structured error `{ code: 404 }`  | `Meteor.Error('not-found', ...)`     | Developer Story 4.A.2 |
-
-Next step in the backlog: Story 4.B wires this to WebSocket via `RpcHandler`, so clients can call methods over the network.
-
----
-
-## 5. Worked Example: Publications with Nulled Infrastructure
-
-This walks through **Developer Story 3.A.2** — the first story that uses Nulled infrastructure. It shows how the Red-Green-Refactor loop works when external systems are involved.
-
-### Why this example
-
-`Publications.handleSubscribe` depends on both `MongoWrapper` and `WebSocketServer`. In traditional testing you'd mock both. Here we use `createNull()` instead.
-
----
-
-### Cycle 1: Send initial documents on subscribe
-
-**RED** — Write the test (`tests/logic/publications.test.ts`):
-
-```ts
-import { describe, it, expect } from 'vitest';
-import { Publications } from '../../server/logic/publications';
-import { MongoWrapper } from '../../server/infrastructure/mongo';
-import { WebSocketServer } from '../../server/infrastructure/websocket';
-
-describe('Publications', () => {
-  it('sends initial documents on subscribe', async () => {
-    // Arrange — Nulled infrastructure with seed data
-    const mongo = MongoWrapper.createNull({
-      files: [{ _id: '1', name: 'existing.bam' }],
-    });
-    const ws = WebSocketServer.createNull();
-    const pubs = new Publications(mongo, ws);
-    const tracker = ws.trackMessages();
-
-    // Define a publication
-    pubs.define('files.all', () => ({ collection: 'files', query: {} }));
-
-    // Act — simulate a client subscribing
-    const client = ws.simulateConnection();
-    ws.simulateMessage(client.id, {
-      type: 'subscribe',
-      id: 'sub1',
-      name: 'files.all',
-    });
-
-    // Assert — client received the document and a ready signal
-    expect(tracker.messagesTo(client.id)).toContainEqual({
-      type: 'added',
-      collection: 'files',
-      id: '1',
-      fields: { name: 'existing.bam' },
-    });
-    expect(tracker.messagesTo(client.id)).toContainEqual({
-      type: 'ready',
-      id: 'sub1',
-    });
+  expect(client.messages).toContainEqual({
+    type: 'error',
+    id: 'sub1',
+    error: { code: 404, message: 'Unknown publication: nonexistent' },
   });
 });
 ```
 
-Run it. Fails because `Publications` class doesn't exist. Red.
+Read what that test is made of. `MongoWrapper.createNull()` is a real MongoWrapper with an in-memory store behind it. `ws.simulateConnection()` hands back a stubbed client that records what was sent to it. `Publications` is the real class, running its real code. The only thing that is not real is the database and the socket, and they are not stubs of MongoWrapper, they are MongoWrapper.
 
-**What's different from the Methods example:**
+The assertion is about what came out, `client.messages`, not about which functions were called on the way. That is the difference that matters. Rename a private method tomorrow, and this test does not notice.
 
-- We create Nulled `MongoWrapper` with seed data — no real MongoDB
-- We create Nulled `WebSocketServer` — no real WebSocket
-- We use `simulateConnection()` and `simulateMessage()` — behavior simulation
-- We use `trackMessages()` — output tracking instead of spies
-- All of this is **real code** running in-memory, not mocks
-
-**GREEN** — Implement Publications:
+For the happy path the nulled Mongo carries seed data:
 
 ```ts
-export class Publications {
-  private definitions = new Map<string, PublicationDef>();
-
-  constructor(
-    private mongo: MongoWrapper,
-    private ws: WebSocketServer,
-  ) {
-    this.ws.onMessage((clientId, msg) => {
-      if (msg.type === 'subscribe') {
-        this.handleSubscribe(clientId, msg.id, msg.name);
-      }
-    });
-  }
-
-  define(name: string, queryFn: () => MongoQuery): void {
-    this.definitions.set(name, queryFn);
-  }
-
-  private async handleSubscribe(clientId: string, subId: string, name: string): Promise<void> {
-    const queryFn = this.definitions.get(name);
-    if (!queryFn) {
-      this.ws.send(clientId, {
-        type: 'error',
-        id: subId,
-        error: { code: 404, message: `Unknown publication: ${name}` },
-      });
-      return;
-    }
-
-    const { collection, query } = queryFn();
-    const docs = await this.mongo.find(collection, query);
-
-    for (const doc of docs) {
-      const { _id, ...fields } = doc;
-      this.ws.send(clientId, { type: 'added', collection, id: _id, fields });
-    }
-
-    this.ws.send(clientId, { type: 'ready', id: subId });
-  }
-}
+const mongo = MongoWrapper.createNull({
+  find: [[{ _id: '1', name: 'existing.bam' }]],
+});
 ```
 
-Test passes. Green.
-
-**REFACTOR** — Extract message builders:
-
-```ts
-function toAddedMsg(collection: string, doc: any): DataMsg {
-  const { _id, ...fields } = doc;
-  return { type: 'added', collection, id: _id, fields };
-}
-
-function toReadyMsg(subId: string): ReadyMsg {
-  return { type: 'ready', id: subId };
-}
-```
-
-Tests still pass. Clean.
-
-**Key insight:** The test is fast (no I/O), readable (Arrange-Act-Assert), and tests real behavior (actual Publications logic running with in-memory infrastructure). No mocks, no spies, no fragility.
+Subscribe, and the client receives an `added` for the document and a `ready` to say the initial set is complete. Same structure, no mocks, and it runs in milliseconds because nothing leaves the process.
 
 ---
 
-## 6. How to Read a Developer Story's Sub-stories
+## 6. Why This Holds Up
 
-Every developer story in the backlog (tracked in Linear; the original written backlog is archived at `../archive/ekolite-backlog.md`) has sub-stories labeled **a**, **b**, **c**:
+The tests in this repository survived a series of refactors that would have destroyed a spy-based suite: infrastructure wrappers rewritten to the nullable pattern one at a time, the shutdown path rebuilt around `AsyncDisposableStack`, the whole graph pulled into an `App` class. Behaviour was asserted, not implementation, so the tests kept telling the truth while the code underneath them moved.
 
-| Sub-story | Phase    | What you do                                                  |
-| --------- | -------- | ------------------------------------------------------------ |
-| **a**     | Red      | Write the failing test. Run it. See it fail.                 |
-| **b**     | Green    | Write the minimum code to make it pass. Run it. See it pass. |
-| **c**     | Refactor | Improve structure. Run tests. Still green.                   |
-
-Example from backlog:
-
-> **Developer Story 0.A.1: Basic CRUD operations**
->
-> - Sub-story 0.A.1a — Red: Write narrow integration test: insert, find, assert length 1
-> - Sub-story 0.A.1b — Green: Implement MongoWrapper with real driver
-> - Sub-story 0.A.1c — Refactor: Extract connection logic, write parity test
-
-Each sub-story is one phase of the loop. You do them in order: a → b → c → move to next developer story.
+That is the return on writing them this way, and it does not show up on the day you write them. It shows up on the day you change your mind.

--- a/server/index.ts
+++ b/server/index.ts
@@ -7,7 +7,7 @@ import { WebSocketWrapper } from './infrastructure/websocket.ts';
 import { type Publications } from './logic/publications.ts';
 import { type Files } from './logic/files.ts';
 import { type RpcHandler } from './logic/rpcHandler.ts';
-import { type ClientMessage } from '../shared/protocol.ts';
+import { type ClientMessage, type PongMsg } from '../shared/protocol.ts';
 import { RpcError, toEkoLiteError } from '../shared/types.ts';
 
 // Public package surface for the `ekolite` entry: the app graph and its config sit
@@ -47,27 +47,39 @@ export async function createServer(options: ServerOptions) {
   const publications = options.publications;
   const rpcHandler = options.rpcHandler;
 
-  if (publications || rpcHandler) {
-    options.ws.onMessage((clientId, message) => {
-      const clientMessage = message as ClientMessage;
+  // Always registered, never gated on publications or an rpcHandler. The heartbeat belongs
+  // to the transport: a socket has to be able to prove it is alive before anything is
+  // published or called on it, and a client whose ping goes unanswered concludes the
+  // connection is dead and closes it.
+  options.ws.onMessage((clientId, message) => {
+    const clientMessage = message as ClientMessage;
 
-      switch (clientMessage.type) {
-        case 'method':
-          if (rpcHandler) {
-            void rpcHandler.handleMessage(clientId, clientMessage);
-          }
-          break;
-        case 'subscribe':
-        case 'unsubscribe':
-          if (publications) {
-            void publications.handleMessage(clientId, clientMessage);
-          }
-          break;
-        default:
-          break;
-      }
-    });
-  }
+    switch (clientMessage.type) {
+      case 'ping':
+        // exactOptionalPropertyTypes: an absent id and an explicit undefined are different
+        // types, so the id is only carried back when the ping actually sent one.
+        options.ws.send(
+          clientId,
+          clientMessage.id === undefined
+            ? ({ type: 'pong' } satisfies PongMsg)
+            : ({ type: 'pong', id: clientMessage.id } satisfies PongMsg),
+        );
+        break;
+      case 'method':
+        if (rpcHandler) {
+          void rpcHandler.handleMessage(clientId, clientMessage);
+        }
+        break;
+      case 'subscribe':
+      case 'unsubscribe':
+        if (publications) {
+          void publications.handleMessage(clientId, clientMessage);
+        }
+        break;
+      default:
+        break;
+    }
+  });
 
   const files = options.files;
   if (files) {

--- a/tests/server/createServerRouting.test.ts
+++ b/tests/server/createServerRouting.test.ts
@@ -44,6 +44,39 @@ describe('createServer routes inbound subscriptions into publications', () => {
     });
   });
 
+  // The heartbeat lives in the transport, not in a feature. A socket with no publications
+  // and no methods on it still has to prove it is alive, so the pong cannot be gated on
+  // either being configured. Red today: createServer only registers an onMessage handler
+  // when publications or an rpcHandler is passed, and its switch drops 'ping' on default.
+  it('answers a ping with a pong, with no publications or methods configured', async () => {
+    const ws = WebSocketWrapper.createNull();
+
+    await createServer({ ws });
+
+    const client = ws.simulateConnection();
+    client.send({ type: 'ping' });
+
+    await vi.waitFor(() => {
+      expect(client.messages).toContainEqual({ type: 'pong' });
+    });
+  });
+
+  // ClientSocketWrapper's Heartbeat sends a bare ping today, but PingMsg carries an
+  // optional id, so a pong has to carry it back or a client that correlates its pings
+  // cannot tell which one came home.
+  it('echoes the ping id back on the pong', async () => {
+    const ws = WebSocketWrapper.createNull();
+
+    await createServer({ ws });
+
+    const client = ws.simulateConnection();
+    client.send({ type: 'ping', id: 'p1' });
+
+    await vi.waitFor(() => {
+      expect(client.messages).toContainEqual({ type: 'pong', id: 'p1' });
+    });
+  });
+
   it('routes method messages to the rpc handler and returns results to the same client', async () => {
     const ws = WebSocketWrapper.createNull();
     const methods = new Methods();

--- a/tests/server/server.integration.test.ts
+++ b/tests/server/server.integration.test.ts
@@ -43,4 +43,30 @@ describe('Websocket fastify integration test', () => {
 
     expect(client.readyState).toBe(WebSocket.OPEN);
   });
+
+  // The nullable test proves createServer routes a ping. This proves the whole transport
+  // does it: a real socket, a real frame on the wire, a real pong coming back. It is the
+  // path ClientSocketWrapper's Heartbeat actually takes, and until the server answered it,
+  // a client with the heartbeat switched on closed a healthy connection on its own.
+  it('answers a ping over a real socket with a pong', async () => {
+    const ws = WebSocketWrapper.create();
+    server = await createServer({ ws });
+    await server.listen({ port: 0 });
+    const port = String(server.addresses()[0].port);
+
+    client = new WebSocket(`ws://localhost:${port}/ws`);
+    await new Promise((resolve, reject) => {
+      client.on('open', resolve);
+      client.on('error', reject);
+    });
+
+    const pong = new Promise((resolve) => {
+      client.on('message', (raw: Buffer) => {
+        resolve(JSON.parse(raw.toString()));
+      });
+    });
+    client.send(JSON.stringify({ type: 'ping', id: 'p1' }));
+
+    await expect(pong).resolves.toEqual({ type: 'pong', id: 'p1' });
+  });
 });


### PR DESCRIPTION
Publishes the architecture decisions, the system design guide and the TDD guide on the docs site, edited for a reader who has never seen the repository.

**Heartbeat fix.** The server now answers `ping` with `pong`. Both message types were in the protocol and the client heartbeat depended on the reply, but the server's router did not handle `ping`, so a client with the heartbeat enabled closed a healthy socket. Covered by a nullable test and a real socket integration test.

**Docs corrected to match the code.** The protocol has eleven message types, including the heartbeat, not six. The framework is about 3,500 lines, not 820. Both numbers appeared across the README, the overview, the spec and ADR-003.

**Overview** now says what works and what does not, including the two known gaps: no reconnect and resubscribe, and no auth on the file routes.

**Not published:** `ekolite-tdd.md`, which documents an API that no longer exists and needs a pass of its own.

Site builds with no dead links. Lint, typecheck and 261 tests pass.
