### PR TITLE
Story 8.D: publish the TDD engineering guide, unpublish the spec

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -10,9 +10,15 @@ export default defineConfig({
   description:
     'A lightweight, real-time backend framework: Fastify, MongoDB and WebSocket with typed pub/sub, RPC methods and file uploads.',
   base: '/ekolite/',
+  // Not published. Epics is the roadmap and customer is a stakeholder brief, so neither is a
+  // framework document. The spec is the original design target: it documents definePublication,
+  // defineMethod and defineUploadHandler, none of which were built. The API that exists is
+  // documented in api/ and in the system design guide, so publishing the spec would only teach
+  // a reader calls they cannot make. It stays in the repo as the record of what was intended.
   srcExclude: [
     'ekolite-overview/ekolite-epics.md',
     'ekolite-overview/ekolite-customer.md',
+    'ekolite-overview/ekolite-spec.md',
     'archive/**',
   ],
   themeConfig: {
@@ -28,7 +34,6 @@ export default defineConfig({
         items: [
           { text: 'Overview', link: '/ekolite-overview/ekolite-overview' },
           { text: 'Quick start', link: '/quick-start' },
-          { text: 'Specification', link: '/ekolite-overview/ekolite-spec' },
         ],
       },
       {

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -13,7 +13,6 @@ export default defineConfig({
   srcExclude: [
     'ekolite-overview/ekolite-epics.md',
     'ekolite-overview/ekolite-customer.md',
-    'ekolite-overview/ekolite-tdd.md',
     'archive/**',
   ],
   themeConfig: {
@@ -43,6 +42,7 @@ export default defineConfig({
         text: 'Manual',
         items: [
           { text: 'Test-driven development', link: '/ekolite-overview/ekolite-tdd-training' },
+          { text: 'TDD engineering guide', link: '/ekolite-overview/ekolite-tdd' },
           {
             text: 'Nullables: how much should the stub know?',
             link: '/manual/nullables-how-much-should-the-stub-know',

--- a/docs/ekolite-overview/ekolite-overview.md
+++ b/docs/ekolite-overview/ekolite-overview.md
@@ -24,13 +24,13 @@ EkoLite is a lightweight real-time backend framework. Five standard tools do the
 Three layers. Logic never touches external systems directly.
 
 ```
-        App (wires everything)
-       /         |         \
-  Publications  Methods  UploadHandler     ← Logic
-       \         |         /
-  MongoWrapper  WebSocket  FileStorage     ← Infrastructure
-       |         |         |
-    MongoDB    Fastify    Node fs          ← External systems
+              App (wires everything)
+           /         |          \
+  Publications    Methods      Files             ← Logic
+           \         |          /
+  MongoWrapper  WebSocketWrapper  FileStorageWrapper   ← Infrastructure
+           |         |          |
+       MongoDB    Fastify    Node fs              ← External systems
 ```
 
 Every infrastructure wrapper has two factories:
@@ -93,9 +93,10 @@ What is not built yet, and matters:
 
 Read these when you need detail on a specific topic:
 
-| Doc                                                | What's in it                                       |
-| -------------------------------------------------- | -------------------------------------------------- |
-| [System design](ekolite-system-design.md)          | How the framework is put together, and why         |
-| [Architecture decisions](ekolite-adrs.md)          | What was decided, and what it cost                 |
-| [Test-driven development](ekolite-tdd-training.md) | The red, green, refactor loop with worked examples |
-| [Specification](ekolite-spec.md)                   | API signatures and type definitions                |
+| Doc                                                | What's in it                                              |
+| -------------------------------------------------- | --------------------------------------------------------- |
+| [System design](ekolite-system-design.md)          | How the framework is put together, and why                |
+| [Architecture decisions](ekolite-adrs.md)          | What was decided, and what it cost                        |
+| [Test-driven development](ekolite-tdd-training.md) | The red, green, refactor loop with worked examples        |
+| [TDD engineering guide](ekolite-tdd.md)            | The wrappers, their signatures, and contract tests        |
+| [API reference](../api/connection-manager.md)      | The client surface: ConnectionManager, SubscriptionHandle |

--- a/docs/ekolite-overview/ekolite-system-design.md
+++ b/docs/ekolite-overview/ekolite-system-design.md
@@ -1,6 +1,6 @@
 # EkoLite, System Design
 
-Start with [ekolite-overview.md](ekolite-overview.md) for the big picture, and [ekolite-spec.md](ekolite-spec.md) for signatures and types. This document explains how the framework is put together and why it is shaped the way it is. The decisions behind it are recorded in [ekolite-adrs.md](ekolite-adrs.md).
+Start with [ekolite-overview.md](ekolite-overview.md) for the big picture, and the [API reference](../api/connection-manager.md) for the client signatures. This document explains how the framework is put together and why it is shaped the way it is. The decisions behind it are recorded in [ekolite-adrs.md](ekolite-adrs.md).
 
 ---
 

--- a/docs/ekolite-overview/ekolite-tdd-training.md
+++ b/docs/ekolite-overview/ekolite-tdd-training.md
@@ -2,7 +2,7 @@
 
 Every line of EkoLite was written test first, and there is no mocking library in the project. This walks through how that works in practice, using two pieces of the framework as they were actually built.
 
-Start with [ekolite-overview.md](ekolite-overview.md) if you want the big picture first, and [nullables-how-much-should-the-stub-know.md](../manual/nullables-how-much-should-the-stub-know.md) for the design question that comes up most once you start writing nulled infrastructure of your own.
+Start with [ekolite-overview.md](ekolite-overview.md) if you want the big picture first. [The TDD engineering guide](ekolite-tdd.md) is the reference behind this tour: the wrappers, their signatures, and how contract tests keep a nulled wrapper honest. And [nullables-how-much-should-the-stub-know.md](../manual/nullables-how-much-should-the-stub-know.md) takes on the design question that comes up most once you start writing nulled infrastructure of your own.
 
 ---
 

--- a/docs/ekolite-overview/ekolite-tdd.md
+++ b/docs/ekolite-overview/ekolite-tdd.md
@@ -1,775 +1,247 @@
-# ekolite — TDD Engineering Guide
+# EkoLite, TDD Engineering Guide
 
-Start with [ekolite-overview.md](ekolite-overview.md) for the big picture. This is the TDD technical reference — Testing Without Mocks (James Shore's Nullable pattern). Read `ekolite-tdd-training.md` first for worked examples.
+This is the reference for how EkoLite is tested: the nullable pattern, the wrappers, the layers and the shape of the suite. [Test-driven development](ekolite-tdd-training.md) is the tour with worked examples; start there if you want the loop rather than the catalogue. [ekolite-overview.md](ekolite-overview.md) is the big picture.
 
-Reference: https://www.jamesshore.com/v2/projects/nullables/testing-without-mocks
+The pattern comes from James Shore's [Testing Without Mocks](https://www.jamesshore.com/v2/projects/nullables/testing-without-mocks).
 
 ---
 
 ## Core Principles
 
-1. **No mocks.** Ever. Not for MongoDB, not for WebSocket, not for the file system.
-2. **Nullables.** Every infrastructure wrapper has a `create()` and a `createNull()` factory. The Null version behaves identically but doesn't touch external systems.
-3. **Sociable tests.** Tests use real dependency chains. If `Publications` depends on `MongoWrapper`, the test uses the real `Publications` with a Nulled `MongoWrapper`.
-4. **State-based assertions.** Check outputs and state, not whether a function was called.
-5. **A-Frame architecture.** Logic and infrastructure are peers. The application layer coordinates them.
+1. **No mocks.** Not for MongoDB, not for the WebSocket, not for the file system. There is no mocking library in the project.
+2. **Nullables.** Every infrastructure wrapper has `create()` and `createNull()`. The nulled one behaves the same and touches nothing outside the process.
+3. **Sociable tests.** Real dependency chains. `Publications` is tested as the real `Publications`, holding a nulled `MongoWrapper`.
+4. **State-based assertions.** Assert what came out, not which functions were called on the way.
+5. **A-Frame architecture.** Logic and infrastructure are peers, and the application layer wires them together.
 
 ---
 
-## A-Frame Architecture for ekolite
+## A-Frame Architecture
 
 ```
-         Application Layer
-        (server/index.ts)
-        /        |        \
-       V         V         V
-    Logic     Logic      Logic
-  (pubsub)  (methods)  (upload)
-       \        |        /
-        V       V       V
-      Infrastructure Wrappers
-   Mongo  WebSocket  FileSystem  ScriptRunner
+              Application layer
+                (server/app.ts)
+              /       |        \
+             v        v         v
+          Logic     Logic     Logic
+      (publications) (methods) (files)
+             \        |        /
+              v       v       v
+           Infrastructure wrappers
+      Mongo   WebSocket   FileStorage   ScriptRunner
 ```
 
-Logic doesn't import infrastructure directly. The application layer wires them together. This means logic is testable with Nulled infrastructure.
+Logic never imports infrastructure. It receives wrappers through the constructor, so it cannot tell a real one from a nulled one, and the application layer decides which it gets.
 
 ---
 
 ## Infrastructure Wrappers
 
-Each external system gets a wrapper class with two factories:
+Each wrapper owns one external system, and each has an embedded stub in the same file.
 
-### 1. MongoWrapper
+### MongoWrapper
 
-Wraps the `mongodb` Node.js driver.
+`server/infrastructure/mongo.ts`, over the `mongodb` driver.
 
 ```ts
-// server/infrastructure/mongo.ts
+static create(uri: string): MongoWrapper;
+static createNull(options?: StubbedMongoOptions): MongoWrapper;
 
-export class MongoWrapper {
-  static create(uri: string): MongoWrapper {
-    return new MongoWrapper(new RealMongoClient(uri));
-  }
+async find<T>(collection: string, query: object): Promise<T[]>;
+async insert(collection: string, doc: object): Promise<void>;
+async update(collection: string, query: object, changes: object): Promise<void>;
+async remove(collection: string, query: object): Promise<void>;
+async close(): Promise<void>;
 
-  static createNull(docs: Record<string, unknown[]> = {}): MongoWrapper {
-    return new MongoWrapper(new StubbedMongoClient(docs));
-  }
-
-  async find<T>(collection: string, query: object): Promise<T[]> { ... }
-  async insert(collection: string, doc: object): Promise<string> { ... }
-  async update(collection: string, query: object, changes: object): Promise<void> { ... }
-  async remove(collection: string, query: object): Promise<void> { ... }
-  watchChanges(collection: string, listener: ChangeListener): void { ... }
-}
-
-// Embedded Stub — lives in the same file
-class StubbedMongoClient {
-  private store: Map<string, unknown[]>;
-  private listeners: Map<string, ChangeListener[]>;
-
-  constructor(initialDocs: Record<string, unknown[]>) {
-    this.store = new Map(Object.entries(initialDocs));
-    this.listeners = new Map();
-  }
-
-  // Implements the same interface as the real client
-  // Stores documents in memory
-  // Fires change listeners on insert/update/remove
-}
+watcherCount(collection: string): number;
+async trackChanges(collection: string): Promise<OutputTracker>;
+trackClose(): OutputTracker;
 ```
 
-### 2. WebSocketServer
-
-Wraps `@fastify/websocket`.
+The nulled Mongo is configured with responses, not with a seeded database. Each key takes a list, and each entry is the answer to the next call:
 
 ```ts
-// server/infrastructure/websocket.ts
-
-export class WebSocketServer {
-  static create(fastify: FastifyInstance): WebSocketServer {
-    return new WebSocketServer(new RealWebSocketHandler(fastify));
-  }
-
-  static createNull(): WebSocketServer {
-    return new WebSocketServer(new StubbedWebSocketHandler());
-  }
-
-  onConnection(handler: ConnectionHandler): void { ... }
-  send(clientId: string, message: ServerMessage): void { ... }
-  broadcast(message: ServerMessage): void { ... }
-
-  // Output Tracking — observe what was sent without spying
-  trackMessages(): MessageTracker { ... }
-}
-
-// Embedded Stub
-class StubbedWebSocketHandler {
-  private connections: Map<string, StubbedConnection>;
-
-  // Simulates client connections in memory
-  // simulateConnection() — creates a fake client
-  // simulateMessage(clientId, msg) — simulates incoming message
-}
+const mongo = MongoWrapper.createNull({
+  find: [[{ _id: '1', name: 'existing.bam' }]],
+});
 ```
 
-### 3. FileStorage
+Pass an `Error` instead of a value to make the next call fail, which is how failure paths are tested without breaking a real database to get there.
 
-Wraps Node.js `fs`.
+### WebSocketWrapper
+
+`server/infrastructure/websocket.ts`, over `@fastify/websocket`.
 
 ```ts
-// server/infrastructure/fileStorage.ts
+static create(): WebSocketWrapper;
+static createRawWs(options: { port: number }): WebSocketWrapper;
+static createNull(options?: { close?: unknown[] }): WebSocketWrapper;
 
-export class FileStorage {
-  static create(basePath: string): FileStorage {
-    return new FileStorage(new RealFileSystem(basePath));
-  }
+async attach(fastify: FastifyInstance): Promise<void>;
+send(clientId: string, message: unknown): void;
+broadcast(message: unknown): void;
+onMessage(cb: (clientId: string, message: unknown) => void): void;
 
-  static createNull(): FileStorage {
-    return new FileStorage(new StubbedFileSystem());
-  }
-
-  async save(name: string, data: Buffer): Promise<string> { ... }
-  async exists(name: string): Promise<boolean> { ... }
-  async remove(name: string): Promise<void> { ... }
-  resolve(relativePath: string): string { ... }
-}
-
-// Embedded Stub
-class StubbedFileSystem {
-  private files: Map<string, Buffer>;
-  // Stores files in memory, same interface as real fs operations
-}
+simulateConnection(): StubbedClient; // null instance only
+trackMessages(): OutputTracker;
+trackConnections(): OutputTracker;
+trackDisconnections(): OutputTracker;
 ```
 
-### 4. ScriptRunner
+`create()` takes no Fastify instance. It is attached separately with `attach(fastify)`, which is what lets the wrapper be constructed before the server exists.
 
-Wraps Node.js `child_process.execFile`.
+`simulateConnection()` returns a `StubbedClient` that records everything sent to it. That recording is how the tests see the output:
 
 ```ts
-// server/infrastructure/scriptRunner.ts
+const ws = WebSocketWrapper.createNull();
+const client = ws.simulateConnection();
 
-export class ScriptRunner {
-  static create(): ScriptRunner {
-    return new ScriptRunner(new RealProcessRunner());
-  }
+client.send({ type: 'subscribe', id: 'sub1', name: 'files.all' });
 
-  static createNull(responses: Record<string, string> = {}): ScriptRunner {
-    return new ScriptRunner(new StubbedProcessRunner(responses));
-  }
+expect(client.messages).toContainEqual({ type: 'ready', id: 'sub1', collection: 'files' });
+```
 
-  async exec(command: string, args: string[]): Promise<ScriptResult> { ... }
-}
+### FileStorageWrapper
 
-// Embedded Stub
-class StubbedProcessRunner {
-  constructor(private responses: Record<string, string>) {}
-  // Returns configured responses based on command
-  // No child processes spawned
-}
+`server/infrastructure/fileStorage.ts`, over `node:fs`.
+
+```ts
+static create(basePath: string): FileStorageWrapper;
+static createNull(options?: StubbedFileSystemOptions): FileStorageWrapper;
+
+async save(name: string, data: Buffer): Promise<void>;
+async read(name: string): Promise<Buffer>;
+async exists(name: string): Promise<boolean>;
+async remove(name: string): Promise<void>;
+resolve(name: string): string;
+trackChanges(): OutputTracker;
+```
+
+### ScriptRunnerWrapper
+
+`server/infrastructure/scriptRunner.ts`, over `child_process`.
+
+```ts
+static create(): ScriptRunnerWrapper;
+static createNull(responses?: ScriptRunnerResponses): ScriptRunnerWrapper;
+
+async exec(command: string, args: string[]): Promise<ScriptResult>;
+trackChanges(): OutputTracker;
+```
+
+The nulled runner is keyed by command, so a test can say what `python3` returns without a Python interpreter anywhere near it.
+
+---
+
+## Logic Layer
+
+Logic classes take their infrastructure through the constructor and know nothing about where it came from.
+
+```ts
+new Publications(mongo, ws); // pub/sub over change streams
+new Methods(); // the method registry, no infrastructure at all
+new RpcHandler(methods, ws); // routes method messages, sends result or error
+new Files(mongo, storage, options); // upload, read, locate, validate
+new Shutdown(closable, proc, { graceMs }); // graceful stop
 ```
 
 ---
 
-## Logic Layer (No Infrastructure Knowledge)
+## Application Layer
 
-Logic classes accept infrastructure wrappers via constructor. They don't know or care if they're real or Null.
-
-### Publications
+`server/app.ts` is where the wiring lives, and it is the only place that decides real or nulled.
 
 ```ts
-// server/logic/publications.ts
-
-export class Publications {
-  constructor(
-    private mongo: MongoWrapper,
-    private ws: WebSocketServer,
-  ) {}
-
-  define(name: string, queryFn: () => MongoQuery): void { ... }
-  handleSubscribe(clientId: string, subId: string, name: string): void { ... }
-  handleUnsubscribe(clientId: string, subId: string): void { ... }
-}
+const app = App.create({ mongoUri, fileDir, countCScript, port });
+const app = App.createNull({ findResponses, scriptResponses });
 ```
 
-### Methods
-
-```ts
-// server/logic/methods.ts
-
-export class Methods {
-  private registry: Map<string, MethodFn> = new Map();
-
-  define(name: string, fn: MethodFn): void { ... }
-  async call(name: string, params: unknown[]): Promise<unknown> { ... }
-}
-```
-
-### UploadHandler
-
-```ts
-// server/logic/uploadHandler.ts
-
-export class UploadHandler {
-  constructor(
-    private fileStorage: FileStorage,
-    private mongo: MongoWrapper,
-  ) {}
-
-  async handle(file: UploadedFile): Promise<StoredFile> { ... }
-  validate(file: UploadedFile): boolean { ... }
-}
-```
+Both return the same graph. `App` exposes `publications`, `methods` and `files`. The assembly that boots in production is the assembly the tests drive, so there is no second wiring to drift out of step.
 
 ---
 
-## Application Layer (Wires Everything Together)
+## Output Tracking Replaces Spies
+
+An `OutputTracker` subscribes to an emitter and collects what passed through it. It exposes one thing, `data`:
 
 ```ts
-// server/index.ts
+const tracker = ws.trackMessages();
+// ... exercise the code ...
+expect(tracker.data).toContainEqual({ type: 'ready', id: 'sub1', collection: 'files' });
+```
 
-export class App {
-  static create(config: AppConfig): App {
-    return new App(
-      MongoWrapper.create(config.mongoUri),
-      WebSocketServer.create(config.fastify),
-      FileStorage.create(config.uploadPath),
-      ScriptRunner.create(),
-    );
-  }
+A spy asks whether a function was called. A tracker asks what was produced. Rename a private method and the spy assertion breaks while the tracker assertion does not, because the tracker was never coupled to the implementation in the first place.
 
-  static createNull(options: NullAppOptions = {}): App {
-    return new App(
-      MongoWrapper.createNull(options.docs),
-      WebSocketServer.createNull(),
-      FileStorage.createNull(),
-      ScriptRunner.createNull(options.scriptResponses),
-    );
-  }
+---
 
-  constructor(
-    private mongo: MongoWrapper,
-    private ws: WebSocketServer,
-    private files: FileStorage,
-    private scripts: ScriptRunner,
-  ) {
-    this.publications = new Publications(mongo, ws);
-    this.methods = new Methods();
-    this.uploads = new UploadHandler(files, mongo);
-  }
+## Contract Tests Keep the Null Honest
+
+A nulled wrapper is only useful while it behaves like the real one. The guard against drift is a shared contract: one list of behaviours, run twice, once against `create()` and once against `createNull()`.
+
+`tests/infrastructure/fileStorageContract.ts` exports the list:
+
+```ts
+export function fileStorageContract(makeStorage: () => FileStorageWrapper): void {
+  it('reports a saved file as existing', async () => {
+    const storage = makeStorage();
+    await storage.save('report.bam', Buffer.from('content'));
+    expect(await storage.exists('report.bam')).toBe(true);
+  });
+  // ...
 }
 ```
+
+The fast suite runs it against the null:
+
+```ts
+fileStorageContract(() => FileStorageWrapper.createNull());
+```
+
+The integration suite runs the same list against the real file system:
+
+```ts
+fileStorageContract(() => FileStorageWrapper.create(TEST_DIR));
+```
+
+If the two ever disagree, one of them goes red. That is the whole mechanism, and it is why a nulled wrapper can be trusted.
 
 ---
 
 ## Test Stack
 
 ```json
-{
-  "devDependencies": {
-    "vitest": "^3.0"
-  }
-}
+{ "devDependencies": { "vitest": "^4.1" } }
 ```
 
-Just vitest. No supertest, no mock libraries, no test containers. Nullables replace all of that.
+Vitest, and nothing else. No supertest, no mocking library, no test containers.
 
 ---
 
-## Tests
-
-### Infrastructure Wrapper Tests (Narrow Integration)
-
-These are the **only tests that touch real external systems**. Run against a real local MongoDB, real file system, real WebSocket. They verify the wrappers work correctly.
-
-```ts
-// tests/infrastructure/mongo.test.ts
-
-describe('MongoWrapper (narrow integration)', () => {
-  const mongo = MongoWrapper.create('mongodb://localhost:27017/ekolite-test');
-
-  afterEach(async () => {
-    await mongo.remove('testDocs', {});
-  });
-
-  it('inserts and finds documents', async () => {
-    await mongo.insert('testDocs', { name: 'test.bam' });
-    const docs = await mongo.find('testDocs', {});
-    expect(docs).toHaveLength(1);
-    expect(docs[0].name).toBe('test.bam');
-  });
-
-  it('fires change listener on insert', async () => {
-    const changes: ChangeEvent[] = [];
-    mongo.watchChanges('testDocs', (event) => changes.push(event));
-
-    await mongo.insert('testDocs', { name: 'new.bam' });
-
-    // Wait for change stream
-    await eventually(() => {
-      expect(changes).toHaveLength(1);
-      expect(changes[0].type).toBe('insert');
-    });
-  });
-});
-```
-
-```ts
-// tests/infrastructure/fileStorage.test.ts
-
-describe('FileStorage (narrow integration)', () => {
-  const storage = FileStorage.create('/tmp/ekolite-test');
-
-  afterEach(async () => {
-    await storage.remove('test.bam');
-  });
-
-  it('saves and checks file existence', async () => {
-    await storage.save('test.bam', Buffer.from('content'));
-    expect(await storage.exists('test.bam')).toBe(true);
-  });
-});
-```
-
-### Nullable Parity Tests
-
-Verify that the Null version behaves the same as the real version. Run the **same test suite** against both.
-
-```ts
-// tests/infrastructure/mongo.parity.ts
-
-function mongoParityTests(createMongo: () => MongoWrapper) {
-  describe('insert and find', () => {
-    it('returns inserted documents', async () => {
-      const mongo = createMongo();
-      await mongo.insert('files', { name: 'a.bam' });
-      const docs = await mongo.find('files', {});
-      expect(docs).toHaveLength(1);
-      expect(docs[0].name).toBe('a.bam');
-    });
-  });
-
-  describe('change events', () => {
-    it('fires on insert', async () => {
-      const mongo = createMongo();
-      const changes: ChangeEvent[] = [];
-      mongo.watchChanges('files', (e) => changes.push(e));
-
-      await mongo.insert('files', { name: 'b.bam' });
-
-      await eventually(() => {
-        expect(changes[0].type).toBe('insert');
-      });
-    });
-  });
-}
-
-// Run against real
-describe('MongoWrapper (real)', () => {
-  mongoParityTests(() => MongoWrapper.create('mongodb://localhost:27017/test'));
-});
-
-// Run against Null
-describe('MongoWrapper (null)', () => {
-  mongoParityTests(() => MongoWrapper.createNull());
-});
-```
-
-### Logic Tests (Sociable, Using Nullables)
-
-These tests instantiate real logic classes with Nulled infrastructure. Fast, no external systems, no mocks.
-
-```ts
-// tests/logic/publications.test.ts
-
-describe('Publications', () => {
-  it('sends initial documents on subscribe', async () => {
-    const mongo = MongoWrapper.createNull({
-      files: [{ _id: '1', name: 'existing.bam' }],
-    });
-    const ws = WebSocketServer.createNull();
-    const pubs = new Publications(mongo, ws);
-    const tracker = ws.trackMessages();
-
-    pubs.define('files.all', () => ({ collection: 'files', query: {} }));
-
-    const client = ws.simulateConnection();
-    ws.simulateMessage(client.id, {
-      type: 'subscribe',
-      id: 'sub1',
-      name: 'files.all',
-    });
-
-    expect(tracker.messagesTo(client.id)).toContainEqual({
-      type: 'added',
-      collection: 'files',
-      id: '1',
-      fields: { name: 'existing.bam' },
-    });
-    expect(tracker.messagesTo(client.id)).toContainEqual({
-      type: 'ready',
-      id: 'sub1',
-    });
-  });
-
-  it('pushes changes when documents are inserted', async () => {
-    const mongo = MongoWrapper.createNull();
-    const ws = WebSocketServer.createNull();
-    const pubs = new Publications(mongo, ws);
-    const tracker = ws.trackMessages();
-
-    pubs.define('files.all', () => ({ collection: 'files', query: {} }));
-
-    const client = ws.simulateConnection();
-    ws.simulateMessage(client.id, {
-      type: 'subscribe',
-      id: 'sub1',
-      name: 'files.all',
-    });
-
-    await mongo.insert('files', { _id: '2', name: 'new.bam' });
-
-    expect(tracker.messagesTo(client.id)).toContainEqual({
-      type: 'added',
-      collection: 'files',
-      id: '2',
-      fields: { name: 'new.bam' },
-    });
-  });
-});
-```
-
-```ts
-// tests/logic/methods.test.ts
-
-describe('Methods', () => {
-  it('registers and calls a method', async () => {
-    const methods = new Methods();
-    methods.define('echo', async (msg: string) => `echo: ${msg}`);
-    const result = await methods.call('echo', ['hello']);
-    expect(result).toBe('echo: hello');
-  });
-
-  it('throws structured error for unknown method', async () => {
-    const methods = new Methods();
-    await expect(methods.call('nope', [])).rejects.toMatchObject({
-      code: 404,
-      message: 'Method not found: nope',
-    });
-  });
-});
-```
-
-```ts
-// tests/logic/methods-rpc.test.ts
-
-describe('Methods over WebSocket', () => {
-  it('receives result message', async () => {
-    const ws = WebSocketServer.createNull();
-    const methods = new Methods();
-    methods.define('echo', async (msg: string) => `echo: ${msg}`);
-    const rpc = new RpcHandler(methods, ws);
-    const tracker = ws.trackMessages();
-
-    const client = ws.simulateConnection();
-    ws.simulateMessage(client.id, {
-      type: 'method',
-      id: 'm1',
-      name: 'echo',
-      params: ['test'],
-    });
-
-    await eventually(() => {
-      expect(tracker.messagesTo(client.id)).toContainEqual({
-        type: 'result',
-        id: 'm1',
-        result: 'echo: test',
-      });
-    });
-  });
-});
-```
-
-```ts
-// tests/logic/uploadHandler.test.ts
-
-describe('UploadHandler', () => {
-  it('stores file and saves metadata', async () => {
-    const files = FileStorage.createNull();
-    const mongo = MongoWrapper.createNull();
-    const handler = new UploadHandler(files, mongo);
-
-    const result = await handler.handle({
-      name: 'sample.bam',
-      data: Buffer.from('bam content'),
-      size: 11,
-    });
-
-    expect(result.name).toBe('sample.bam');
-    expect(await files.exists('sample.bam')).toBe(true);
-
-    const docs = await mongo.find('UserFiles', {});
-    expect(docs).toHaveLength(1);
-    expect(docs[0].name).toBe('sample.bam');
-  });
-
-  it('rejects non-.bam files', async () => {
-    const files = FileStorage.createNull();
-    const mongo = MongoWrapper.createNull();
-    const handler = new UploadHandler(files, mongo);
-
-    await expect(
-      handler.handle({
-        name: 'bad.txt',
-        data: Buffer.from('not bam'),
-        size: 7,
-      }),
-    ).rejects.toMatchObject({ code: 400 });
-
-    expect(await files.exists('bad.txt')).toBe(false);
-  });
-});
-```
-
-```ts
-// tests/logic/scriptRunner.test.ts
-
-describe('ScriptRunner with Methods', () => {
-  it('runs configured script and returns output', async () => {
-    const scripts = ScriptRunner.createNull({
-      python3: 'count: 42',
-    });
-    const methods = new Methods();
-    const fileStorage = FileStorage.createNull();
-
-    methods.define('runCountC', async (targetPath: string) => {
-      const scriptPath = fileStorage.resolve('scripts/countC.py');
-      const result = await scripts.exec('python3', [scriptPath, targetPath]);
-      return result.stdout;
-    });
-
-    const result = await methods.call('runCountC', ['/uploads']);
-    expect(result).toBe('count: 42');
-  });
-});
-```
-
-### Application Tests (Full Wiring, Still Nulled)
-
-```ts
-// tests/app.test.ts
-
-describe('App', () => {
-  it('creates with all Nulled infrastructure', () => {
-    const app = App.createNull();
-    expect(app).toBeDefined();
-  });
-
-  it('full pipeline: upload → subscribe → method', async () => {
-    const app = App.createNull({
-      scriptResponses: { python3: 'count: 7' },
-    });
-    const tracker = app.ws.trackMessages();
-
-    // 1. Client connects and subscribes
-    const client = app.ws.simulateConnection();
-    app.ws.simulateMessage(client.id, {
-      type: 'subscribe',
-      id: 'sub1',
-      name: 'UserFiles.all',
-    });
-
-    // 2. Upload a file
-    const stored = await app.uploads.handle({
-      name: 'test.bam',
-      data: Buffer.from('bam data'),
-      size: 8,
-    });
-
-    // 3. Client should see the file via pub/sub
-    expect(tracker.messagesTo(client.id)).toContainEqual(
-      expect.objectContaining({ type: 'added', collection: 'UserFiles' }),
-    );
-
-    // 4. Call analysis method
-    app.ws.simulateMessage(client.id, {
-      type: 'method',
-      id: 'm1',
-      name: 'runCountC',
-      params: [stored.path],
-    });
-
-    await eventually(() => {
-      expect(tracker.messagesTo(client.id)).toContainEqual({
-        type: 'result',
-        id: 'm1',
-        result: 'count: 7',
-      });
-    });
-  });
-});
-```
-
-### Client-Side Tests (Sociable, Nulled WebSocket)
-
-```ts
-// tests/client/store.test.ts
-
-describe('ReactiveStore', () => {
-  it('adds document and emits change', () => {
-    const store = new ReactiveStore<{ _id: string; name: string }>();
-    const changes: unknown[] = [];
-    store.on('change', (docs) => changes.push(docs));
-
-    store.handleMessage({
-      type: 'added',
-      collection: 'files',
-      id: '1',
-      fields: { name: 'a.bam' },
-    });
-
-    expect(store.getAll()).toEqual([{ _id: '1', name: 'a.bam' }]);
-    expect(changes).toHaveLength(1);
-  });
-
-  it('updates document on changed message', () => {
-    const store = new ReactiveStore<{ _id: string; name: string }>();
-    store.handleMessage({
-      type: 'added',
-      collection: 'files',
-      id: '1',
-      fields: { name: 'a.bam' },
-    });
-    store.handleMessage({
-      type: 'changed',
-      collection: 'files',
-      id: '1',
-      fields: { name: 'b.bam' },
-    });
-
-    expect(store.getById('1')?.name).toBe('b.bam');
-  });
-
-  it('removes document on removed message', () => {
-    const store = new ReactiveStore<{ _id: string; name: string }>();
-    store.handleMessage({
-      type: 'added',
-      collection: 'files',
-      id: '1',
-      fields: { name: 'a.bam' },
-    });
-    store.handleMessage({ type: 'removed', collection: 'files', id: '1' });
-
-    expect(store.getAll()).toEqual([]);
-  });
-});
-```
-
----
-
-## Test Structure
+## The Shape of the Suite
 
 ```
 tests/
-├── infrastructure/          # Narrow integration — real external systems
-│   ├── mongo.test.ts
-│   ├── mongo.parity.ts      # Same tests run against real AND null
-│   ├── fileStorage.test.ts
-│   ├── fileStorage.parity.ts
-│   ├── websocket.test.ts
-│   └── scriptRunner.test.ts
-├── logic/                   # Sociable tests — Nulled infrastructure
-│   ├── publications.test.ts
-│   ├── methods.test.ts
-│   ├── methods-rpc.test.ts
-│   ├── uploadHandler.test.ts
-│   └── scriptRunner.test.ts
-├── client/                  # Client-side — no external systems
-│   ├── store.test.ts
-│   ├── connection.test.ts
-│   └── call.test.ts
-└── app.test.ts              # Full wiring — all Nulled
+├── infrastructure/   wrappers: nullable tests, contract lists, narrow integration
+├── logic/            publications, methods, rpcHandler, files, shutdown, analysis
+├── client/           clientSocket, connectionManager, reactiveStore, uploader
+├── server/           createServer routing, app wiring, and the full pipeline
+└── shared/           protocol types and helpers
 ```
 
----
+Nullable tests and integration tests live in separate files, `x.test.ts` and `x.integration.test.ts`, and that split is what keeps the fast suite honest. It never touches the network or the disk, so it can run on every save.
 
-## Test Pyramid
-
-```
-                 ┌──────────┐
-                 │ Narrow   │  4 test files — real MongoDB, real fs
-                 │ Integr.  │  SLOW — run in CI or manually
-                 ├──────────┤
-                 │ Parity   │  4 test files — same tests, real vs null
-                 │          │  Proves Nullables match real behavior
-            ┌────┴──────────┴────┐
-            │   Logic (Sociable) │  5+ test files — Nulled infra
-            │   + Client tests   │  FAST — run on every save
-            ├────────────────────┤
-            │   App (Full Null)  │  1 test file — everything wired
-            │                    │  FAST — run on every save
-            └────────────────────┘
+```bash
+npm test                  # the fast suite: nullable and sociable tests
+npm run test:integration  # narrow integration, needs a real local MongoDB
 ```
 
 ---
 
 ## What Replaces What
 
-| Traditional Approach      | Testing Without Mocks                            |
-| ------------------------- | ------------------------------------------------ |
-| `jest.mock('mongodb')`    | `MongoWrapper.createNull()`                      |
-| `jest.spyOn(ws, 'send')`  | `ws.trackMessages()` (Output Tracking)           |
-| `jest.fn()` for callbacks | Real callbacks, check state                      |
-| Mock file system          | `FileStorage.createNull()` (in-memory)           |
-| Mock child_process        | `ScriptRunner.createNull({ responses })`         |
-| Test containers / docker  | Narrow integration tests (local MongoDB)         |
-| Supertest for HTTP        | `app.ws.simulateMessage()` (Behavior Simulation) |
-
----
-
-## TDD Rules
-
-1. **Red → Green → Refactor.** No exceptions.
-2. **No mocks.** Use Nullables. If you reach for `vi.mock()`, stop and write a Nullable instead.
-3. **Parity tests for every wrapper.** If the Null version drifts from the real version, bugs hide.
-4. **Logic tests are fast.** They use Nulled infrastructure. If a logic test takes >50ms, something is wrong.
-5. **Narrow integration tests are slow.** That's fine. Run them separately. They prove the wrappers work.
-6. **State, not interactions.** Assert on what happened, not how it happened.
-7. **Output Tracking over spying.** Use `trackMessages()`, `trackFiles()`, etc. — built into the wrappers.
-8. **One story at a time.** Don't jump ahead.
-
----
-
-## Build Order (Test-First)
-
-| Order | What to Build                     | Test With                       | Story |
-| :---: | --------------------------------- | ------------------------------- | :---: |
-|   1   | `MongoWrapper` + Null + parity    | Narrow integration + parity     |   —   |
-|   2   | `WebSocketServer` + Null + parity | Narrow integration + parity     |   —   |
-|   3   | `FileStorage` + Null + parity     | Narrow integration + parity     |   —   |
-|   4   | `ScriptRunner` + Null + parity    | Narrow integration + parity     |   —   |
-|   5   | Fastify serves static files       | Narrow integration              |   1   |
-|   6   | WebSocket connection via Fastify  | Narrow integration              |   2   |
-|   7   | `Publications` logic              | Sociable (Nulled mongo + ws)    |   3   |
-|   8   | `ReactiveStore` client            | Unit (no infra)                 |   3   |
-|   9   | `Methods` logic                   | Sociable (Nulled)               |   4   |
-|  10   | `RpcHandler` (methods over WS)    | Sociable (Nulled ws)            |   4   |
-|  11   | `UploadHandler` logic             | Sociable (Nulled files + mongo) | 5, 6  |
-|  12   | `App` full wiring                 | All Nulled                      |   7   |
-
----
-
-## Running Tests
-
-```bash
-# Fast tests (logic + client + app) — run on every save
-vitest --watch --exclude='**/infrastructure/**'
-
-# Narrow integration tests — run manually or in CI
-vitest tests/infrastructure/
-
-# All tests
-vitest
-
-# Type check
-tsc --noEmit
-```
+| Traditional               | Testing Without Mocks                                  |
+| ------------------------- | ------------------------------------------------------ |
+| `vi.mock('mongodb')`      | `MongoWrapper.createNull()`                            |
+| `vi.spyOn(ws, 'send')`    | `ws.trackMessages()`, or the stubbed client's messages |
+| Asserting a call happened | Asserting what was produced                            |
+| A mock that drifts        | A contract test run against real and null              |

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -23,5 +23,5 @@ await app.methods.call('greet', ['world']); // 'hello world'
 ## Where next
 
 - [Overview](/ekolite-overview/ekolite-overview) — what EkoLite is and how the pieces fit together.
-- [Specification](/ekolite-overview/ekolite-spec) — the API and type reference.
+- [System design](/ekolite-overview/ekolite-system-design) — how the framework is put together, and the wire protocol.
 - [API reference](/api/connection-manager) — the client `ConnectionManager` and `SubscriptionHandle`.


### PR DESCRIPTION
The TDD engineering guide was held back from 8.C because its code samples described an API that no longer exists. This verifies it against the source and publishes it. Checking it surfaced the same problem in the specification, which was already live.

**The engineering guide** is rewritten against the real code. Every signature is taken from source: `MongoWrapper`, `WebSocketWrapper`, `FileStorageWrapper` and `ScriptRunnerWrapper`, their `createNull()` option shapes, and `OutputTracker.data`. It previously documented a `WebSocketServer` class, a `simulateMessage()` helper and a `tracker.messagesTo()` method, none of which exist. It now also documents the contract test mechanism, which is what stops a nulled wrapper drifting from the real one, and was missing entirely.

**The specification is no longer published.** It documents `definePublication`, `defineMethod` and `defineUploadHandler`. None of those three symbols appear anywhere in the codebase. The real API is `publications.define`, `methods.define` and the `Files` class, and the client surface is `ConnectionManager`, not `EkoLite.subscribe`. It was a design target that the framework grew past, served under the label "Specification" to readers who would code against it. It stays in the repository as the record of what was intended, and the pages that pointed at it now point at the API reference and the system design guide, both of which are true.

**The overview's architecture diagram** named an `UploadHandler` class that does not exist. It names `Files` now.

Site builds with no dead links. Lint, typecheck and 261 tests pass.
