### PR TITLE
Story 8.E: App.create is a clean framework surface, not EkoLite's demo

### DIFF
--- a/docs/ekolite-overview/ekolite-system-design.md
+++ b/docs/ekolite-overview/ekolite-system-design.md
@@ -29,7 +29,7 @@ shared/
   protocol.ts         the wire protocol, typed for both ends
 ```
 
-`App` exposes exactly three things: `publications`, `methods` and `files`.
+What `App` does not do is define anything. It wires infrastructure into logic and stops, so the registries it hands back are empty and whatever you define is all that is on them. EkoLite's own demo definitions live with the demo boot, not in the framework, and a consumer inherits none of them.
 
 ---
 

--- a/docs/ekolite-overview/ekolite-tdd.md
+++ b/docs/ekolite-overview/ekolite-tdd.md
@@ -152,7 +152,7 @@ new Shutdown(closable, proc, { graceMs }); // graceful stop
 `server/app.ts` is where the wiring lives, and it is the only place that decides real or nulled.
 
 ```ts
-const app = App.create({ mongoUri, fileDir, countCScript, port });
+const app = App.create({ mongoUri, fileDir, port });
 const app = App.createNull({ findResponses, scriptResponses });
 ```
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -18,7 +18,16 @@ app.methods.define('greet', (name) => `hello ${String(name)}`);
 await app.methods.call('greet', ['world']); // 'hello world'
 ```
 
-`App.createNull()` assembles the whole graph in memory, so you can exercise methods, publications and files without a running MongoDB. Swap it for `App.create(config)` to talk to the real thing.
+`App.createNull()` assembles the whole graph in memory, so you can exercise methods, publications and files without a running MongoDB. Swap it for `App.create({ mongoUri, fileDir, port })` to talk to the real thing.
+
+What comes back is empty. `App` wires the infrastructure and stops, so `app.publications` and `app.methods` hold exactly what you put on them and nothing of EkoLite's own:
+
+```ts
+const app = App.create({ mongoUri, fileDir, port });
+
+app.publications.define('tasks.mine', (p) => ({ collection: 'tasks', query: { owner: p.owner } }));
+app.methods.define('addTask', (title) => createTask(title));
+```
 
 ## Where next
 

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -55,7 +55,10 @@ function main() {
     run('npm', ['init', '-y'], { cwd: dir });
     run('npm', ['install', tarball], { cwd: dir });
 
-    // 3. A consumer that knows only the published package.
+    // 3. A consumer that knows only the published package. It defines its own surface,
+    //    and it must inherit none of EkoLite's: a fresh app carries no files.all
+    //    publication, no echo and no runCountC. Those belong to the demo, which boots in
+    //    start.ts, not to the framework a consumer installs.
     const consumer = [
       "import { App } from 'ekolite';",
       '',
@@ -63,6 +66,13 @@ function main() {
       "app.methods.define('sum', (a, b) => a + b);",
       "const result = await app.methods.call('sum', [2, 3]);",
       'console.log(`sum(2,3)=${result}`);',
+      '',
+      "for (const inherited of ['echo', 'runCountC']) {",
+      '  const outcome = await app.methods',
+      '    .call(inherited, [])',
+      "    .then(() => 'defined', (err) => (err?.code === 404 ? 'absent' : 'defined'));",
+      '  console.log(`${inherited}=${outcome}`);',
+      '}',
     ].join('\n');
     writeFileSync(join(dir, 'consumer.mjs'), consumer);
 
@@ -70,6 +80,14 @@ function main() {
     const out = run('node', ['consumer.mjs'], { cwd: dir }).trim();
     if (!out.includes('sum(2,3)=5')) {
       throw new Error(`unexpected consumer output:\n${out}`);
+    }
+    for (const inherited of ['echo', 'runCountC']) {
+      if (!out.includes(`${inherited}=absent`)) {
+        throw new Error(
+          `a fresh App.createNull() still carries EkoLite's own '${inherited}' method.\n` +
+            `The framework is shipping its demo as if it were the framework.\n${out}`,
+        );
+      }
     }
 
     // 5. The shipped types must resolve from the consumer side: every declaration file

--- a/server/app.ts
+++ b/server/app.ts
@@ -6,14 +6,12 @@ import { Publications } from './logic/publications.ts';
 import { RpcHandler } from './logic/rpcHandler.ts';
 import { Methods } from './logic/methods.ts';
 import { Files } from './logic/files.ts';
-import { defineRunCountC } from './logic/analysis.ts';
 import { type StoredFile } from '../shared/types.ts';
 
 // Config for the real boot. The same knobs start.ts reads from the environment.
 export interface AppConfig {
   mongoUri: string;
   fileDir: string;
-  countCScript: string;
   port: number;
 }
 
@@ -24,7 +22,6 @@ interface AppParts {
   ws: WebSocketWrapper;
   storage: FileStorageWrapper;
   scriptRunner: ScriptRunnerWrapper;
-  countCScript: string;
 }
 
 // Test affordances for createNull. scriptResponses is the stdout the Nulled runner
@@ -38,38 +35,39 @@ type ScriptResponses = Parameters<typeof ScriptRunnerWrapper.createNull>[0];
 interface NullConfig {
   scriptResponses?: ScriptResponses;
   findResponses?: StoredFile[][];
-  countCScript?: string;
   mongo?: MongoWrapper;
   ws?: WebSocketWrapper;
 }
 
-const DEFAULT_COUNTC_SCRIPT = 'scripts/countC.py';
-
 // The application layer. One place the subsystems are wired: the socket, the
-// publications engine over Mongo, the method registry behind the RPC handler, and
-// the file store behind uploads. create() supplies real infrastructure, createNull()
-// supplies Nulled infrastructure; the constructor wires both the same way and
-// registers the standard files.all publication and echo / runCountC methods. Logic
-// classes never learn which kind of wrapper they received.
+// publications engine over Mongo, the method registry behind the RPC handler, the
+// file store behind uploads, and the script runner. create() supplies real
+// infrastructure, createNull() supplies Nulled infrastructure, and the constructor
+// wires both the same way. Logic classes never learn which kind of wrapper they got.
+//
+// What App does not do is define anything. It wires infrastructure into logic and
+// stops. A consumer's App.create() comes back with empty registries, and whatever they
+// define is all that is on them. EkoLite's own demo definitions live in demo.ts, which
+// start.ts calls; the framework does not carry them.
 export class App {
   readonly ws: WebSocketWrapper;
   readonly publications: Publications;
   readonly methods: Methods;
   readonly files: Files;
   readonly rpcHandler: RpcHandler;
+  // Running a script is a framework capability, so the wrapper stays wired here and is
+  // reachable. Which script, and what method calls it, is the caller's business.
+  readonly scriptRunner: ScriptRunnerWrapper;
   private readonly mongo: MongoWrapper;
 
   private constructor(parts: AppParts) {
     this.ws = parts.ws;
     this.mongo = parts.mongo;
+    this.scriptRunner = parts.scriptRunner;
     this.methods = new Methods();
     this.rpcHandler = new RpcHandler(this.methods, parts.ws);
     this.publications = new Publications(parts.mongo, parts.ws);
     this.files = new Files(parts.mongo, parts.storage);
-
-    this.publications.define('files.all', () => ({ collection: 'files', query: {} }));
-    this.methods.define('echo', (message) => Promise.resolve(`echo: ${String(message)}`));
-    defineRunCountC(this.methods, parts.scriptRunner, this.files, parts.countCScript);
   }
 
   static create(config: AppConfig): App {
@@ -78,7 +76,6 @@ export class App {
       ws: WebSocketWrapper.create(),
       storage: FileStorageWrapper.create(config.fileDir),
       scriptRunner: ScriptRunnerWrapper.create(),
-      countCScript: config.countCScript,
     });
   }
 
@@ -98,7 +95,6 @@ export class App {
       ws: nullConfig.ws ?? WebSocketWrapper.createNull(),
       storage: FileStorageWrapper.createNull(),
       scriptRunner: ScriptRunnerWrapper.createNull(nullConfig.scriptResponses ?? {}),
-      countCScript: nullConfig.countCScript ?? DEFAULT_COUNTC_SCRIPT,
     });
   }
 

--- a/server/demo.ts
+++ b/server/demo.ts
@@ -1,0 +1,30 @@
+import { type App } from './app.ts';
+import { defineRunCountC } from './logic/analysis.ts';
+
+// EkoLite's own demo, and nothing a consumer inherits.
+//
+// These three definitions used to live in the App constructor, which meant every
+// consumer's first App.create() came back with a files.all publication, an echo
+// method and a runCountC method wired to a Python script they had never heard of.
+// The framework was shipping its demo as if it were the framework.
+//
+// They live here now. start.ts calls this, so the demo still boots exactly as it did,
+// and App hands a consumer an empty stage. This is deliberately not exported from
+// server/index.ts: it is not part of the package surface.
+
+export const DEFAULT_COUNTC_SCRIPT = 'scripts/countC.py';
+
+export interface DemoOptions {
+  countCScript?: string;
+}
+
+export function defineDemo(app: App, options: DemoOptions = {}): void {
+  app.publications.define('files.all', () => ({ collection: 'files', query: {} }));
+  app.methods.define('echo', (message) => Promise.resolve(`echo: ${String(message)}`));
+  defineRunCountC(
+    app.methods,
+    app.scriptRunner,
+    app.files,
+    options.countCScript ?? DEFAULT_COUNTC_SCRIPT,
+  );
+}

--- a/server/start.ts
+++ b/server/start.ts
@@ -1,14 +1,19 @@
 import { createServer } from './index.ts';
 import { App, type AppConfig } from './app.ts';
+import { defineDemo, DEFAULT_COUNTC_SCRIPT } from './demo.ts';
 import { ProcessWrapper } from './infrastructure/process.ts';
 import { Shutdown } from './logic/shutdown.ts';
 import { READY_MESSAGE } from '../shared/serverMessages.ts';
 
 // Real boot. Read config from the environment, let App wire the graph (Mongo, the
-// websocket, the pub/sub engine, the file store, and the standard files.all / echo /
-// runCountC definitions), then serve it over Fastify. The wiring that used to live
-// here now lives in App.create, so the same assembly the end-to-end test drives is
-// the one that boots in production.
+// websocket, the pub/sub engine, the file store and the script runner), define the
+// demo on top of it, then serve it over Fastify. The wiring that used to live here
+// now lives in App.create, so the same assembly the end-to-end test drives is the one
+// that boots in production.
+//
+// The demo definitions are ours, not the framework's, which is why defineDemo is called
+// here rather than baked into App. A consumer who installs ekolite calls App.create and
+// gets an empty stage; this file is what puts EkoLite's own furniture on it.
 //
 // EKOLITE_PORT and EKOLITE_MONGO_DB are the isolation knobs the smoke test sets so a
 // spawned run never collides with `npm run dev:server` on 3001 or its data. A db name
@@ -19,11 +24,11 @@ const config: AppConfig = {
     ? `mongodb://localhost:27017/${mongoDb}?replicaSet=rs0`
     : (process.env.MONGO_URI ?? 'mongodb://localhost:27017/ekolite'),
   fileDir: process.env.FILE_DIR ?? './uploads',
-  countCScript: process.env.COUNTC_SCRIPT ?? 'scripts/countC.py',
   port: Number(process.env.EKOLITE_PORT ?? process.env.PORT ?? 3001),
 };
 
 const app = App.create(config);
+defineDemo(app, { countCScript: process.env.COUNTC_SCRIPT ?? DEFAULT_COUNTC_SCRIPT });
 const server = await createServer(app);
 await server.listen({ port: config.port, host: '0.0.0.0' });
 

--- a/tests/server/app.test.ts
+++ b/tests/server/app.test.ts
@@ -101,42 +101,25 @@ describe('App.createNull assembles all parts', () => {
     ]);
   });
 
-  it('registers runCountC, wired to files and the nulled script runner', async () => {
-    const app = App.createNull({
-      scriptResponses: { python3: '7' },
-      findResponses: [[bamFile('f1')]],
-    });
-
-    // locate('f1') finds the seeded document, the runner answers '7', the count
-    // comes back to the caller: proof the scriptResponses reached the Nulled runner.
-    expect(await app.methods.call('runCountC', ['f1'])).toBe(7);
-  });
-
-  it('registers the files.all publication', async () => {
+  // Empty is not the same as broken. The registries start with nothing in them, and
+  // whatever the caller defines works and is all that is there. The demo's own
+  // definitions are asserted in demo.test.ts, where they now live.
+  it('registers what the caller defines, and only that', async () => {
     const app = App.createNull({ findResponses: [[bamFile('f1')]] });
     const client = app.ws.simulateConnection();
+
+    app.publications.define('tasks.mine', () => ({ collection: 'tasks', query: {} }));
+    app.methods.define('addTask', (title) => Promise.resolve(`added: ${String(title)}`));
+
+    expect(await app.methods.call('addTask', ['write the test'])).toBe('added: write the test');
 
     await app.publications.handleMessage(client.id, {
       type: 'subscribe',
       id: 'sub1',
-      name: 'files.all',
+      name: 'tasks.mine',
     });
 
-    // A registered publication runs its query and readies the subscription; an
-    // unknown name comes back as a 404 error instead (the control below).
     expect(client.messages).toContainEqual(expect.objectContaining({ type: 'ready', id: 'sub1' }));
-
-    await app.publications.handleMessage(client.id, {
-      type: 'subscribe',
-      id: 'sub2',
-      name: 'no-such-publication',
-    });
-
-    expect(client.messages).toContainEqual({
-      type: 'error',
-      id: 'sub2',
-      error: { code: 404, message: 'Unknown publication: no-such-publication' },
-    });
   });
 
   it('rejects a config that sets both mongo and findResponses', () => {

--- a/tests/server/app.test.ts
+++ b/tests/server/app.test.ts
@@ -43,10 +43,37 @@ describe('App.createNull assembles all parts', () => {
     expect(app.ws).toBeInstanceOf(WebSocketWrapper);
   });
 
-  it('registers echo, callable through the assembled methods', async () => {
+  // 8.E — the framework hands back an empty stage. A consumer's first line is
+  // App.create(...), and what comes back must carry none of EkoLite's own demo:
+  // no files.all, no echo, no runCountC. They belong to the demo boot, not to App.
+  it('defines no methods of its own', async () => {
     const app = App.createNull();
 
-    expect(await app.methods.call('echo', ['ping'])).toBe('echo: ping');
+    await expect(app.methods.call('echo', ['ping'])).rejects.toMatchObject({
+      code: 404,
+      message: 'Method not found: echo',
+    });
+    await expect(app.methods.call('runCountC', ['f1'])).rejects.toMatchObject({
+      code: 404,
+      message: 'Method not found: runCountC',
+    });
+  });
+
+  it('defines no publications of its own', async () => {
+    const app = App.createNull();
+    const client = app.ws.simulateConnection();
+
+    await app.publications.handleMessage(client.id, {
+      type: 'subscribe',
+      id: 'sub1',
+      name: 'files.all',
+    });
+
+    expect(client.messages).toContainEqual({
+      type: 'error',
+      id: 'sub1',
+      error: { code: 404, message: 'Unknown publication: files.all' },
+    });
   });
 
   it('still closes Mongo when the nulled socket close rejects', async () => {

--- a/tests/server/appCreate.integration.test.ts
+++ b/tests/server/appCreate.integration.test.ts
@@ -30,7 +30,6 @@ describe('App.create wires real infrastructure', () => {
     app = App.create({
       mongoUri: 'mongodb://localhost:27017/ekolite-test',
       fileDir: './uploads',
-      countCScript: 'scripts/countC.py',
       port: 0,
     });
 

--- a/tests/server/appGate.integration.test.ts
+++ b/tests/server/appGate.integration.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { createServer } from '../../server/index.ts';
 import { App } from '../../server/app.ts';
+import { defineDemo } from '../../server/demo.ts';
 import { WebSocketWrapper } from '../../server/infrastructure/websocket.ts';
 import { ClientSocketWrapper } from '../../client/clientSocket.ts';
 import { ConnectionManager } from '../../client/connectionManager.ts';
@@ -48,6 +49,10 @@ describe('the gate: the full pipeline runs through App over a real socket', () =
       findResponses: [[file], [file]],
       ws: WebSocketWrapper.create(),
     });
+    // The app no longer arrives with files.all and runCountC on it, so the gate asks for
+    // them the same way start.ts does. This is the point of 8.E: what the demo needs, the
+    // demo says.
+    defineDemo(app);
 
     server = await createServer(app);
     await server.listen({ port: 0 });

--- a/tests/server/demo.test.ts
+++ b/tests/server/demo.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { App } from '../../server/app.ts';
+import { defineDemo } from '../../server/demo.ts';
+import { StoredFile } from '../../shared/types.ts';
+
+// 8.E — the demo definitions moved out of App and into demo.ts, so these are the tests
+// that used to live in app.test.ts asserting App registered them. The behaviour did not
+// change, only its owner: what the framework used to hand every consumer, the demo boot
+// now asks for by name.
+
+const bamFile = (id: string): StoredFile => ({
+  _id: id,
+  name: 'reads.bam',
+  path: `/data/${id}.bam`,
+  size: 9,
+  extension: 'bam',
+  uploadedAt: new Date(),
+});
+
+describe('the demo definitions', () => {
+  it('defines echo on the app it is given', async () => {
+    const app = App.createNull();
+
+    defineDemo(app);
+
+    expect(await app.methods.call('echo', ['ping'])).toBe('echo: ping');
+  });
+
+  it('defines runCountC, wired to the app files and its script runner', async () => {
+    const app = App.createNull({
+      scriptResponses: { python3: '7' },
+      findResponses: [[bamFile('f1')]],
+    });
+
+    defineDemo(app);
+
+    // locate('f1') finds the seeded document, the runner answers '7', the count comes
+    // back to the caller: proof defineDemo reached the app's own nulled script runner.
+    expect(await app.methods.call('runCountC', ['f1'])).toBe(7);
+  });
+
+  it('defines the files.all publication', async () => {
+    const app = App.createNull({ findResponses: [[bamFile('f1')]] });
+    const client = app.ws.simulateConnection();
+
+    defineDemo(app);
+
+    await app.publications.handleMessage(client.id, {
+      type: 'subscribe',
+      id: 'sub1',
+      name: 'files.all',
+    });
+
+    expect(client.messages).toContainEqual(expect.objectContaining({ type: 'ready', id: 'sub1' }));
+  });
+});


### PR DESCRIPTION
`App.create` wired the infrastructure and then defined three things that are not the framework: a `files.all` publication, an `echo` method, and `runCountC` bound to a Python script. `AppConfig` required a `countCScript` path that existed only to feed the last of them. Since 8.A made EkoLite installable, a consumer's first line is `App.create(...)`, and what came back was a stage with our furniture already on it.

Now `App` wires infrastructure into logic and stops. The registries it hands back are empty, and whatever you define is all that is on them.

**Where the demo lives.** `server/demo.ts` exports `defineDemo(app)`, and `start.ts` calls it, so the live demo boots exactly as before. A module rather than three inline lines in `start.ts`, because the end-to-end gate test needs the same set, and a named function means the boot and the test ask for the same thing instead of drifting apart. It is deliberately not exported from `server/index.ts`: it is not package surface.

**ScriptRunner stays, `countCScript` goes.** Option (a) from the story. Running a script is a capability, like reaching MongoDB or the file system, so `ScriptRunnerWrapper` remains wired in `App` and is now reachable as `app.scriptRunner`. What was demo was never the runner: it was `runCountC` and the path to `countC.py`. Those move out, and `countCScript` leaves `AppConfig`. The alternative, pushing the runner out to the demo, would have left a consumer unable to run scripts at all, since the wrappers are not exported.

**createNull affordances.** `countCScript` is gone. `scriptResponses` stays, because it configures nulled infrastructure exactly as `findResponses` configures the nulled Mongo. The line is that `createNull` configures infrastructure, never definitions, and no demo-shaped option is left on it.

**Tests.** `app.test.ts` now asserts the registries are empty and that what the caller defines is all that is there. The three tests that asserted `App` registered the demo move to `demo.test.ts`, where the behaviour went. The end-to-end gate calls `defineDemo` the same way `start.ts` does: a test that wants `echo` now says so.

The consumer smoke gains the proof the story asked for. It installs the tarball into a throwaway project, defines its own method, and asserts `echo` and `runCountC` come back 404: `sum(2,3)=5`, `echo=absent`, `runCountC=absent`.

**Docs.** The quick start showed a consumer calling `App.create` and said nothing about what came with it. It now shows the empty surface and a consumer defining their own. The TDD guide's config drops `countCScript`.

Lint, typecheck and 264 tests pass. The package smoke passes. The live boot was verified by spawning `start.ts` and calling `echo` over a real socket.

**Verified against a real database.** The full integration suite passes: 17 files, 43 tests, against a live MongoDB replica set. That includes `smoke.integration`, which spawns the real `start.ts` and is the only test covering its wiring, and the end-to-end tests that drive `files.all` and `runCountC` over a real socket. The live demo boots exactly as it did.
