### PR TITLE
app.armShutdown(): a consumer can arm graceful shutdown

### DIFF
--- a/docs/ekolite-overview/ekolite-system-design.md
+++ b/docs/ekolite-overview/ekolite-system-design.md
@@ -29,7 +29,7 @@ shared/
   protocol.ts         the wire protocol, typed for both ends
 ```
 
-What `App` does not do is define anything. It wires infrastructure into logic and stops, so the registries it hands back are empty and whatever you define is all that is on them. EkoLite's own demo definitions live with the demo boot, not in the framework, and a consumer inherits none of them.
+What `App` does not do is define anything. It wires infrastructure into logic and stops, so the registries it hands back are empty and whatever you define is all that is on them. The framework carries no publications or methods of its own, the way `meteor run` boots your app rather than one of ours.
 
 ---
 
@@ -101,8 +101,8 @@ Client                                    Server
 
 ```
 Client                                    Server
-  │── method(id:'m1', name:'runCountC',    │
-  │     params:['/uploads/x.bam']) ───────►│
+  │── method(id:'m1', name:'runReport',    │
+  │     params:['/uploads/x.csv']) ───────►│
   │                                          │── ScriptRunner runs the script
   │◄── result(id:'m1', result:'42') ───────│
 ```
@@ -140,7 +140,7 @@ Removals are bookkeeping-aware. The server tracks which documents each client ac
 `Methods` is a registry. A method is a named function on the server:
 
 ```ts
-methods.define('runCountC', async (path) => scriptRunner.exec('python3', [script, path]));
+methods.define('runReport', async (path) => scriptRunner.exec('python3', [script, path]));
 ```
 
 `RpcHandler` routes an inbound `method` message to the registry and sends back `result` or `error`. Failures come back as a structured error with a code and a message, not a stack trace, and the client rejects the pending promise with it.
@@ -168,7 +168,7 @@ The routes are open. There is no auth on them yet, and that is a known gap.
 ```ts
 const handle = connection.subscribe('files.all'); // → SubscriptionHandle
 const store = connection.store('files'); // → ReactiveStore
-const count = await connection.call('runCountC', path);
+const count = await connection.call('runReport', path);
 handle.stop();
 ```
 

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -5,7 +5,7 @@
 //
 // Red until the package actually emits a loadable server entry and exports App. Run it
 // with `node scripts/package-smoke.mjs`.
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
 import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
@@ -23,7 +23,74 @@ function run(cmd, args, opts = {}) {
   }
 }
 
-function main() {
+// Arm graceful shutdown from the consumer side and prove the process exits clean on a
+// signal, rather than being killed. A real consumer boot: App.create holds the real
+// process, so armShutdown binds the OS signal handlers. Mongo connects lazily and nothing
+// here touches it, so no database needs to be running. Resolves on a clean exit 0, rejects
+// on anything else (a non-zero code, or death by signal).
+function assertGracefulShutdown(dir) {
+  writeFileSync(
+    join(dir, 'serve-and-wait.mjs'),
+    [
+      "import { App, createServer } from 'ekolite';",
+      '',
+      'const app = App.create({',
+      "  mongoUri: 'mongodb://localhost:27017/ekolite_smoke_shutdown',",
+      "  fileDir: './uploads',",
+      '  port: 0,',
+      '});',
+      'const server = await createServer({ ws: app.ws });',
+      "await server.listen({ port: 0, host: '127.0.0.1' });",
+      'app.armShutdown();',
+      "process.stdout.write('consumer-ready\\n');",
+    ].join('\n'),
+  );
+
+  return new Promise((resolve, reject) => {
+    const child = spawn('node', ['serve-and-wait.mjs'], {
+      cwd: dir,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let out = '';
+    let err = '';
+    let signalled = false;
+
+    const giveUp = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(`consumer never became ready or never exited:\n${out}\n${err}`));
+    }, 20000);
+
+    child.stdout.on('data', (chunk) => {
+      out += chunk;
+      if (!signalled && out.includes('consumer-ready')) {
+        signalled = true;
+        child.kill('SIGTERM');
+      }
+    });
+    child.stderr.on('data', (chunk) => {
+      err += chunk;
+    });
+    child.on('error', (spawnErr) => {
+      clearTimeout(giveUp);
+      reject(spawnErr);
+    });
+    child.on('exit', (code, signal) => {
+      clearTimeout(giveUp);
+      if (code === 0 && signal === null) {
+        resolve();
+        return;
+      }
+      reject(
+        new Error(
+          `a consumer armed shutdown but the process exited (code=${code}, signal=${signal}) ` +
+            `instead of a clean 0:\n${err}`,
+        ),
+      );
+    });
+  });
+}
+
+async function main() {
   // 1. Build the library from the repo.
   run('npm', ['run', 'build'], { cwd: REPO });
 
@@ -154,11 +221,22 @@ function main() {
       );
     }
 
+    // 8. A consumer arms graceful shutdown through the package surface, and the process
+    //    exits clean on a signal rather than being killed. Only asserted on POSIX: Windows
+    //    cannot deliver a signal to a child, the same reason smoke.integration.test.ts
+    //    skips its signal test there.
+    if (process.platform !== 'win32') {
+      await assertGracefulShutdown(dir);
+    }
+
     console.log('package smoke: PASS');
     console.log(`  consumer said: ${out}`);
     console.log('  declarations resolve to shipped files only');
     console.log('  a TS consumer compiles against ekolite, ekolite/shared and ekolite/client');
     console.log('  a consumer serves their own client through createServer');
+    if (process.platform !== 'win32') {
+      console.log('  a consumer arms graceful shutdown and the process exits 0 on a signal');
+    }
   } finally {
     rmSync(dir, { recursive: true, force: true });
     rmSync(tarball, { force: true });
@@ -169,7 +247,7 @@ function main() {
 }
 
 try {
-  main();
+  await main();
 } catch (err) {
   console.error(`package smoke: FAIL\n${err.message}`);
   process.exit(1);

--- a/server/app.ts
+++ b/server/app.ts
@@ -2,10 +2,12 @@ import { MongoWrapper } from './infrastructure/mongo.ts';
 import { WebSocketWrapper } from './infrastructure/websocket.ts';
 import { FileStorageWrapper } from './infrastructure/fileStorage.ts';
 import { ScriptRunnerWrapper } from './infrastructure/scriptRunner.ts';
+import { ProcessWrapper } from './infrastructure/process.ts';
 import { Publications } from './logic/publications.ts';
 import { RpcHandler } from './logic/rpcHandler.ts';
 import { Methods } from './logic/methods.ts';
 import { Files } from './logic/files.ts';
+import { Shutdown } from './logic/shutdown.ts';
 import { type StoredFile } from '../shared/types.ts';
 
 // Config for the real boot. The same knobs start.ts reads from the environment.
@@ -22,6 +24,7 @@ interface AppParts {
   ws: WebSocketWrapper;
   storage: FileStorageWrapper;
   scriptRunner: ScriptRunnerWrapper;
+  proc: ProcessWrapper;
 }
 
 // Test affordances for createNull. scriptResponses is the stdout the Nulled runner
@@ -37,6 +40,9 @@ interface NullConfig {
   findResponses?: StoredFile[][];
   mongo?: MongoWrapper;
   ws?: WebSocketWrapper;
+  // A Nulled process, injected so a test can drive a shutdown request and watch the exit
+  // that armShutdown ends in. Left out, createNull supplies its own Nulled process.
+  proc?: ProcessWrapper;
 }
 
 // The application layer. One place the subsystems are wired: the socket, the
@@ -59,11 +65,13 @@ export class App {
   // reachable. Which script, and what method calls it, is the caller's business.
   readonly scriptRunner: ScriptRunnerWrapper;
   private readonly mongo: MongoWrapper;
+  private readonly proc: ProcessWrapper;
 
   private constructor(parts: AppParts) {
     this.ws = parts.ws;
     this.mongo = parts.mongo;
     this.scriptRunner = parts.scriptRunner;
+    this.proc = parts.proc;
     this.methods = new Methods();
     this.rpcHandler = new RpcHandler(this.methods, parts.ws);
     this.publications = new Publications(parts.mongo, parts.ws);
@@ -76,6 +84,7 @@ export class App {
       ws: WebSocketWrapper.create(),
       storage: FileStorageWrapper.create(config.fileDir),
       scriptRunner: ScriptRunnerWrapper.create(),
+      proc: ProcessWrapper.create(),
     });
   }
 
@@ -95,7 +104,17 @@ export class App {
       ws: nullConfig.ws ?? WebSocketWrapper.createNull(),
       storage: FileStorageWrapper.createNull(),
       scriptRunner: ScriptRunnerWrapper.createNull(nullConfig.scriptResponses ?? {}),
+      proc: nullConfig.proc ?? ProcessWrapper.createNull(),
     });
+  }
+
+  // Arm graceful shutdown. On a signal, a Ctrl+C, or a supervisor's stop message, close
+  // the app within the grace period and exit: 0 if it drained cleanly, 1 if it did not.
+  // This is the whole surface a consumer needs to stop a long-running server; the Shutdown
+  // policy and the process it binds to stay inside the package. start.ts arms it the same
+  // way, so EkoLite's own boot is just the first consumer of this method.
+  armShutdown(options: { graceMs?: number } = {}): void {
+    new Shutdown(this, this.proc, options).arm();
   }
 
   // Graceful shutdown. Closing the socket also closes the Fastify server it

--- a/server/start.ts
+++ b/server/start.ts
@@ -1,7 +1,5 @@
 import { createServer } from './index.ts';
 import { App, type AppConfig } from './app.ts';
-import { ProcessWrapper } from './infrastructure/process.ts';
-import { Shutdown } from './logic/shutdown.ts';
 import { READY_MESSAGE } from '../shared/serverMessages.ts';
 
 // Real boot. Read config from the environment, let App wire the graph (Mongo, the
@@ -31,15 +29,16 @@ const server = await createServer(app);
 await server.listen({ port: config.port, host: '0.0.0.0' });
 
 // Graceful shutdown: stop taking requests, then drop the database connection.
-// The policy (deadline, exit codes, second signal) lives in Shutdown, tested on
-// the nulled process; the shell only wires it to the real one.
+// The policy (deadline, exit codes, second signal) lives in Shutdown, tested on the
+// nulled process; App.armShutdown() binds it to the real one, and this boot is just the
+// first consumer of that method, arming it the same way any app would.
 //
 // This must come before the ready line. Whoever reads that line may act on it at once,
 // and a supervisor's first act is often to stop us. Announce first and there is a window
 // where the server is listening and has no SIGTERM handler, so the default action kills
 // it and the exit is (null, 'SIGTERM') rather than a clean 0. The window is microseconds
 // wide and the child usually wins it, which is the worst size for a window to be.
-new Shutdown(app, ProcessWrapper.create()).arm();
+app.armShutdown();
 
 // The smoke test waits for this exact line on stdout, so it goes to stdout (not the
 // stderr that console.warn writes to) and carries the port, so a spawned harness can

--- a/tests/server/appArmShutdown.test.ts
+++ b/tests/server/appArmShutdown.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { App } from '../../server/app.ts';
+import { ProcessWrapper } from '../../server/infrastructure/process.ts';
+
+// EKO-308 — a consumer can arm graceful shutdown without reaching into the package.
+//
+// Shutdown policy (the deadline, the exit codes, the second-signal hard exit) is already
+// proven against the Nulled process in tests/logic/shutdown.test.ts and is not repeated
+// here. This is the reach: App.armShutdown() ties that policy to App's OWN close() and the
+// process App holds, so `app.armShutdown()` is the whole of what a consumer writes and
+// ProcessWrapper never leaves the package.
+//
+// App.create() holds ProcessWrapper.create(); App.createNull() holds a Nulled one, which
+// the test injects so it can drive the request and watch the exit. Handing a real process
+// to a unit test would call process.exit and take the runner down with it.
+
+// Let the async close() run its disposers before asserting the exit, the same flush the
+// Shutdown unit tests use.
+const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+describe('App.armShutdown', () => {
+  it('arms graceful shutdown: a shutdown request closes the app and exits 0', async () => {
+    const proc = ProcessWrapper.createNull();
+    const app = App.createNull({ proc });
+    const exits = proc.trackExits();
+
+    app.armShutdown();
+    proc.simulateShutdownRequest('SIGTERM');
+    await flush();
+
+    // A clean close is the only path to exit 0: Shutdown exits 1 on a reject or a timeout.
+    // So this exit code alone proves armShutdown wired App.close() to the process.
+    expect(exits.data).toEqual([{ code: 0 }]);
+  });
+});


### PR DESCRIPTION
## The gap

`Shutdown` is what stops EkoLite cleanly: on a signal or a supervisor's message it stops taking requests, drains the change streams, closes Mongo and exits, with a deadline and the right exit codes. None of it left the package. `server/index.ts` exported `App`, `AppConfig`, `createServer` and `flattenSuppressed`, so a consumer who installed from npm got `app.close()` and nothing to call it from.

Left to wire their own signal handling, a consumer would get it wrong in the ways this project already did and fixed: closing before the change streams drain, exiting with a stream still open on a closed Mongo connection, or announcing readiness before the handler is armed and dying on the first SIGTERM. That knowledge lives in `Shutdown`, and until now a consumer could not reach it.

## The surface, and why this one

The ticket left the surface open to argue. Two ways to give a consumer the reach:

1. Export `Shutdown` and `ProcessWrapper`, so a consumer writes `new Shutdown(app, ProcessWrapper.create()).arm()`.
2. One method on the thing they already hold: `app.armShutdown()`.

This takes the second. Exporting `ProcessWrapper` would put an infrastructure wrapper into the public API, something a consumer never needs to name, only to have wired correctly. `app.armShutdown()` keeps both `Shutdown` and `ProcessWrapper` internal and adds nothing to the export surface: a consumer arms shutdown on the `App` they already built. The grace period stays configurable through `app.armShutdown({ graceMs })`. The one thing this surface withholds is arming some closable that is not the `App`, which no consumer has needed.

## What changed

- `App` holds a `ProcessWrapper` (real under `create`, nulled under `createNull`) and gains `armShutdown`, which arms the existing `Shutdown` policy against its own `close`.
- `start.ts` drops the raw `new Shutdown(app, ProcessWrapper.create()).arm()` for `app.armShutdown()`. EkoLite's own boot is now the first consumer of the method, so if the surface were not enough to stop EkoLite itself, we would know at once.

## Tests

- A nullable unit test arms shutdown against a nulled process, fires a request, and asserts a clean exit 0. Shutdown policy is already covered against the nulled process, so this covers only the reach.
- The end to end smoke that spawns `start.ts` and stops it over a real SIGTERM and a real supervisor message now doubles as proof that `armShutdown` meets the operating system.
- The consumer package smoke installs the tarball, boots a consumer that imports only from `ekolite`, arms shutdown, and asserts the process exits 0 on a signal rather than being killed. Asserted on POSIX, where a parent can deliver a signal to a child.

## Out of scope

No change to shutdown behaviour itself. This is reach, not policy.

Closes #135
