### PR TITLE
Enable the heartbeat, with reconnect and resubscribe

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ Verify the packaged shape from a consumer's point of view with `npm run test:pac
 - **File storage over HTTP** (`Files`): `POST /api/files` saves the bytes and inserts a document that streams into the live list through pub/sub; `GET /api/files/:id` streams them back
 - **Client stack**: `ClientSocketWrapper` (nullable WebSocket client), `ConnectionManager` (subscription lifecycle) and `ReactiveStore` (client side collection state)
 - **Mini DDP protocol** ([`shared/protocol.ts`](shared/protocol.ts)): eleven message types, typed end to end
-- **Heartbeat** (`ping` / `pong`): a socket can die while both ends still think it is open, so the client pings and closes a connection that stops answering
+- **Heartbeat and reconnect** (`ping` / `pong`): a socket can die while both ends still think it is open, so the client pings and closes a connection that stops answering, then reopens it: instant first retry, exponential backoff with jitter, capped, forever. Subscriptions replay with their original ids and each store swaps to the fresh documents in one move, so the page never renders empty in between. On by default with 15 second pings and a 10 second pong window; `reconnect: false` or a zero interval opts out, and `status` reports connecting / connected / reconnecting / closed
 - **Graceful shutdown** (`Shutdown`): on a stop signal, or a shutdown message from a supervisor, it stops taking requests, closes the streams, drops the database connection, and exits cleanly
 - **Runnable boot** (`start.ts`): wires real Mongo, websocket, publications, methods and file store through `App.create` and serves it over Fastify. It boots a bare server with nothing defined on it; a developer adds their own publications, methods and client on top, the way `meteor run` boots your app rather than one of ours
 
 ## What is planned, not yet built
 
-- Reconnect and resubscribe after a dropped socket, and auth on the HTTP routes. Today a closed socket disposes and stays disposed, and the file routes are open.
+- Auth on the HTTP routes. The file routes are open today.
 
 ## Quick start
 

--- a/client/clientSocket.ts
+++ b/client/clientSocket.ts
@@ -3,6 +3,7 @@ import { ClientMessage, ServerMessage } from '../shared/protocol.ts';
 
 const EVENT_OUTBOUND = 'outbound';
 const EVENT_INBOUND = 'inbound';
+const EVENT_OPEN = 'open';
 const CLIENT_DISCONNECTION_EVENT = 'disconnection';
 
 // The switch is mostly permissive and validates only fields we read.
@@ -365,6 +366,10 @@ export class ClientSocketWrapper {
 
         this.heartbeat.start();
 
+        // Fires on every open, first connection and reconnects alike, so a
+        // listener can restore whatever the previous socket was carrying.
+        this.emitter.emit(EVENT_OPEN);
+
         if (!settled) {
           settled = true;
           resolve();
@@ -417,6 +422,13 @@ export class ClientSocketWrapper {
     this.emitter.on(EVENT_INBOUND, handler);
     return () => {
       this.emitter.off(EVENT_INBOUND, handler);
+    };
+  }
+
+  onOpen(listener: () => void): () => void {
+    this.emitter.on(EVENT_OPEN, listener);
+    return () => {
+      this.emitter.off(EVENT_OPEN, listener);
     };
   }
 

--- a/client/clientSocket.ts
+++ b/client/clientSocket.ts
@@ -6,6 +6,12 @@ const EVENT_INBOUND = 'inbound';
 const EVENT_OPEN = 'open';
 const CLIENT_DISCONNECTION_EVENT = 'disconnection';
 
+// Meteor's neighbourhood: pings comfortably inside common proxy idle
+// timeouts, with the pong window shorter than the interval so at most one
+// ping is ever in flight. Zero switches the heartbeat off.
+const DEFAULT_PING_INTERVAL_MS = 15_000;
+const DEFAULT_PONG_TIMEOUT_MS = 10_000;
+
 // The switch is mostly permissive and validates only fields we read.
 // Some cases intentionally reject contradictory payload shapes.
 export function isServerMessage(data: unknown): data is ServerMessage {
@@ -359,8 +365,8 @@ export class ClientSocketWrapper {
             this.socket.close();
           },
           {
-            pingIntervalMs: this.clientOptions?.pingIntervalMs ?? 0,
-            pongTimeoutMs: this.clientOptions?.pongTimeoutMs ?? 0,
+            pingIntervalMs: this.clientOptions?.pingIntervalMs ?? DEFAULT_PING_INTERVAL_MS,
+            pongTimeoutMs: this.clientOptions?.pongTimeoutMs ?? DEFAULT_PONG_TIMEOUT_MS,
           },
         );
 

--- a/client/clientSocket.ts
+++ b/client/clientSocket.ts
@@ -44,6 +44,10 @@ interface ClientSocketOptions {
   pingIntervalMs?: number;
   pongTimeoutMs?: number;
   reconnect?: boolean;
+  reconnectBaseMs?: number;
+  reconnectMaxMs?: number;
+  // Seam for deterministic jitter in tests. Defaults to Math.random.
+  reconnectRandom?: () => number;
 }
 
 export interface SocketCloseEvent {
@@ -157,12 +161,20 @@ class NullWebSocket implements WebSocketLike {
   onclose: WebSocketLike['onclose'] = null;
   readyState = NullWebSocket.CONNECTING;
 
-  constructor(_url: string) {
+  constructor(_url: string, options?: { failToOpen?: boolean }) {
     queueMicrotask(() => {
-      if (this.readyState === NullWebSocket.CONNECTING) {
-        this.readyState = NullWebSocket.OPEN;
-        this.onopen?.({});
+      if (this.readyState !== NullWebSocket.CONNECTING) {
+        return;
       }
+      if (options?.failToOpen) {
+        // A refused connection, as a real socket reports it: error, then close.
+        this.readyState = NullWebSocket.CLOSED;
+        this.onerror?.({});
+        this.onclose?.({});
+        return;
+      }
+      this.readyState = NullWebSocket.OPEN;
+      this.onopen?.({});
     });
   }
 
@@ -207,6 +219,7 @@ export class ClientSocketWrapper {
   // when a pong never arrives, but that is a detected failure, not a goodbye.
   private deliberateClose = false;
   private retryTimer?: ReturnType<typeof setTimeout> | undefined;
+  private reconnectAttempts = 0;
 
   private constructor(
     url: string,
@@ -257,13 +270,29 @@ export class ClientSocketWrapper {
     if (this.retryTimer) {
       return; // one pending attempt at a time
     }
+    const delay = this.nextRetryDelay();
+    this.reconnectAttempts += 1;
     this.retryTimer = setTimeout(() => {
       this.retryTimer = undefined;
       this.socket = this.openSocket();
       this.connect().catch(() => {
         // the failed socket's close event schedules the next attempt
       });
-    }, 0);
+    }, delay);
+  }
+
+  // The first retry is instant, catching blips. From there the wait doubles
+  // from reconnectBaseMs up to reconnectMaxMs, spread by jitter so a fleet of
+  // clients does not stampede a recovering server.
+  private nextRetryDelay(): number {
+    if (this.reconnectAttempts === 0) {
+      return 0;
+    }
+    const base = this.clientOptions?.reconnectBaseMs ?? 1000;
+    const max = this.clientOptions?.reconnectMaxMs ?? 30_000;
+    const random = this.clientOptions?.reconnectRandom ?? Math.random;
+    const doubled = Math.min(base * 2 ** (this.reconnectAttempts - 1), max);
+    return doubled * (0.75 + 0.5 * random());
   }
 
   static create(
@@ -281,8 +310,26 @@ export class ClientSocketWrapper {
     return new ClientSocketWrapper(parsed.toString(), (u) => new RealWebSocket(u), clientOptions);
   }
 
-  static createNull(clientOptions?: ClientSocketOptions): ClientSocketWrapper {
-    return new ClientSocketWrapper('wss://null', (u) => new NullWebSocket(u), clientOptions);
+  // The initial socket always opens; failReconnects makes the next n
+  // reconnect attempts fail, so the backoff schedule is observable.
+  static createNull(
+    clientOptions?: ClientSocketOptions,
+    nullOptions?: { failReconnects?: number },
+  ): ClientSocketWrapper {
+    let socketsCreated = 0;
+    let failuresLeft = nullOptions?.failReconnects ?? 0;
+    return new ClientSocketWrapper(
+      'wss://null',
+      (u) => {
+        socketsCreated += 1;
+        if (socketsCreated > 1 && failuresLeft > 0) {
+          failuresLeft -= 1;
+          return new NullWebSocket(u, { failToOpen: true });
+        }
+        return new NullWebSocket(u);
+      },
+      clientOptions,
+    );
   }
 
   get isConnected(): boolean {
@@ -302,6 +349,7 @@ export class ClientSocketWrapper {
 
       let settled = false;
       this.socket.onopen = () => {
+        this.reconnectAttempts = 0; // a live connection restarts the schedule
         this.heartbeat = new Heartbeat(
           () => {
             void this.send({ type: 'ping' });

--- a/client/clientSocket.ts
+++ b/client/clientSocket.ts
@@ -43,6 +43,7 @@ export function isServerMessage(data: unknown): data is ServerMessage {
 interface ClientSocketOptions {
   pingIntervalMs?: number;
   pongTimeoutMs?: number;
+  reconnect?: boolean;
 }
 
 export interface SocketCloseEvent {
@@ -197,20 +198,31 @@ export class StubbedServer {
 }
 
 export class ClientSocketWrapper {
-  private readonly socket: WebSocketLike;
+  private socket: WebSocketLike;
+  private readonly url: string;
+  private readonly createSocket: WebSocketFactory;
   private readonly emitter = new EventEmitter();
   private heartbeat?: Heartbeat;
   // Set only by the public close() path. The heartbeat also closes this socket
   // when a pong never arrives, but that is a detected failure, not a goodbye.
   private deliberateClose = false;
+  private retryTimer?: ReturnType<typeof setTimeout> | undefined;
 
   private constructor(
     url: string,
     create: WebSocketFactory,
     private readonly clientOptions?: ClientSocketOptions,
   ) {
-    this.socket = create(url);
-    this.socket.onmessage = (event) => {
+    this.url = url;
+    this.createSocket = create;
+    this.socket = this.openSocket();
+  }
+
+  // One socket per attempt: every close retires its socket, and reconnect
+  // builds a fresh one through the same factory.
+  private openSocket(): WebSocketLike {
+    const socket = this.createSocket(this.url);
+    socket.onmessage = (event) => {
       try {
         const raw: unknown = typeof event.data === 'string' ? JSON.parse(event.data) : event.data;
         if (!isServerMessage(raw)) {
@@ -227,12 +239,31 @@ export class ClientSocketWrapper {
         console.error('Failed to parse server message', error);
       }
     };
-    this.socket.onclose = () => {
+    socket.onclose = () => {
       this.heartbeat?.stop();
       this.emitter.emit(CLIENT_DISCONNECTION_EVENT, {
         deliberate: this.deliberateClose,
       } satisfies SocketCloseEvent);
+      if (!this.deliberateClose && (this.clientOptions?.reconnect ?? true)) {
+        this.scheduleReconnect();
+      }
     };
+    return socket;
+  }
+
+  // An unexpected close reopens the connection. The first retry is instant;
+  // a failed attempt closes its own socket, which lands back here.
+  private scheduleReconnect(): void {
+    if (this.retryTimer) {
+      return; // one pending attempt at a time
+    }
+    this.retryTimer = setTimeout(() => {
+      this.retryTimer = undefined;
+      this.socket = this.openSocket();
+      this.connect().catch(() => {
+        // the failed socket's close event schedules the next attempt
+      });
+    }, 0);
   }
 
   static create(
@@ -302,11 +333,15 @@ export class ClientSocketWrapper {
 
   close(): Promise<void> {
     return new Promise((resolve) => {
+      this.deliberateClose = true;
+      if (this.retryTimer) {
+        clearTimeout(this.retryTimer);
+        this.retryTimer = undefined;
+      }
       if (this.socket.readyState === WebSocket.CLOSED) {
         resolve();
         return;
       }
-      this.deliberateClose = true;
       const teardown = this.onClose(() => {
         teardown();
         resolve();

--- a/client/clientSocket.ts
+++ b/client/clientSocket.ts
@@ -387,6 +387,12 @@ export class ClientSocketWrapper {
         this.retryTimer = undefined;
       }
       if (this.socket.readyState === WebSocket.CLOSED) {
+        // The socket is already gone, but the goodbye still has to be heard:
+        // listeners that survived the unexpected close are waiting to be told
+        // that this close is deliberate.
+        this.emitter.emit(CLIENT_DISCONNECTION_EVENT, {
+          deliberate: true,
+        } satisfies SocketCloseEvent);
         resolve();
         return;
       }

--- a/client/clientSocket.ts
+++ b/client/clientSocket.ts
@@ -61,6 +61,8 @@ export interface SocketCloseEvent {
   deliberate: boolean;
 }
 
+export type ConnectionStatus = 'connecting' | 'connected' | 'reconnecting' | 'closed';
+
 type HeartbeatSender = () => void;
 type HeartbeatCloser = () => void;
 
@@ -341,6 +343,24 @@ export class ClientSocketWrapper {
 
   get isConnected(): boolean {
     return this.socket.readyState === WebSocket.OPEN;
+  }
+
+  // What a page should render right now. 'reconnecting' covers the whole
+  // outage: the retry gap and the attempts alike, until a socket opens.
+  get status(): ConnectionStatus {
+    if (this.deliberateClose) {
+      return 'closed';
+    }
+    if (this.socket.readyState === WebSocket.OPEN) {
+      return 'connected';
+    }
+    if (this.retryTimer || this.reconnectAttempts > 0) {
+      return 'reconnecting';
+    }
+    if (this.socket.readyState === WebSocket.CONNECTING) {
+      return 'connecting';
+    }
+    return 'closed'; // died with reconnect off: nothing is coming back
   }
 
   connect(): Promise<void> {

--- a/client/clientSocket.ts
+++ b/client/clientSocket.ts
@@ -45,6 +45,10 @@ interface ClientSocketOptions {
   pongTimeoutMs?: number;
 }
 
+export interface SocketCloseEvent {
+  deliberate: boolean;
+}
+
 type HeartbeatSender = () => void;
 type HeartbeatCloser = () => void;
 
@@ -196,6 +200,9 @@ export class ClientSocketWrapper {
   private readonly socket: WebSocketLike;
   private readonly emitter = new EventEmitter();
   private heartbeat?: Heartbeat;
+  // Set only by the public close() path. The heartbeat also closes this socket
+  // when a pong never arrives, but that is a detected failure, not a goodbye.
+  private deliberateClose = false;
 
   private constructor(
     url: string,
@@ -222,7 +229,9 @@ export class ClientSocketWrapper {
     };
     this.socket.onclose = () => {
       this.heartbeat?.stop();
-      this.emitter.emit(CLIENT_DISCONNECTION_EVENT);
+      this.emitter.emit(CLIENT_DISCONNECTION_EVENT, {
+        deliberate: this.deliberateClose,
+      } satisfies SocketCloseEvent);
     };
   }
 
@@ -297,6 +306,7 @@ export class ClientSocketWrapper {
         resolve();
         return;
       }
+      this.deliberateClose = true;
       const teardown = this.onClose(() => {
         teardown();
         resolve();
@@ -321,10 +331,13 @@ export class ClientSocketWrapper {
     };
   }
 
-  onClose(listener: () => void): () => void {
-    this.emitter.on(CLIENT_DISCONNECTION_EVENT, listener);
+  onClose(listener: (event: SocketCloseEvent) => void): () => void {
+    const handler = (data: unknown) => {
+      listener(data as SocketCloseEvent);
+    };
+    this.emitter.on(CLIENT_DISCONNECTION_EVENT, handler);
     return () => {
-      this.emitter.off(CLIENT_DISCONNECTION_EVENT, listener);
+      this.emitter.off(CLIENT_DISCONNECTION_EVENT, handler);
     };
   }
 

--- a/client/connectionManager.ts
+++ b/client/connectionManager.ts
@@ -72,8 +72,14 @@ export class ConnectionManager {
         this.handleServerMessage(message);
       }
     });
-    this.teardownCloseListener = this.socket.onClose(() => {
-      this.dispose();
+    this.teardownCloseListener = this.socket.onClose((event) => {
+      if (event.deliberate) {
+        this.dispose();
+        return;
+      }
+      // The socket comes back on its own, so subscriptions and stores wait
+      // for it. Calls cannot: their results died with the connection.
+      this.rejectPendingCalls();
     });
   }
 
@@ -172,17 +178,21 @@ export class ConnectionManager {
       this.stopSubscription(id);
     }
 
-    // No result can arrive over a closed connection, so settle every call still
-    // waiting as a rejection the caller can catch, rather than leaving its
-    // promise pending forever.
+    this.rejectPendingCalls();
+
+    this.subscriptions.clear();
+    this.stores.clear();
+    this.pendingData = [];
+  }
+
+  // No result can arrive over a closed connection, so settle every call still
+  // waiting as a rejection the caller can catch, rather than leaving its
+  // promise pending forever.
+  private rejectPendingCalls(): void {
     for (const { reject } of this.pendingRequests.values()) {
       reject(new Error('connection closed'));
     }
-
-    this.subscriptions.clear();
     this.pendingRequests.clear();
-    this.stores.clear();
-    this.pendingData = [];
   }
 
   // Test seam: exposes internal state so tests can assert teardown happened.

--- a/client/connectionManager.ts
+++ b/client/connectionManager.ts
@@ -16,6 +16,9 @@ export interface SubscriptionHandle {
 }
 
 interface SubscriptionState {
+  // Kept so the subscription can be replayed verbatim over a reopened socket.
+  name: string;
+  params?: Record<string, unknown> | undefined;
   readyResolver: () => void;
   readyRejector: (error: unknown) => void;
   // Learned from the server: ready.collection when present, otherwise inferred
@@ -54,6 +57,7 @@ export class ConnectionManager {
   private readonly subscriptions = new Map<string, SubscriptionState>();
   private readonly teardownMessageListener: () => void;
   private readonly teardownCloseListener: () => void;
+  private readonly teardownOpenListener: () => void;
   private disposed = false;
   // Initial `added` documents that arrive before their subscription has learned
   // its collection. Held here until the matching `ready` binds the collection,
@@ -81,6 +85,26 @@ export class ConnectionManager {
       // for it. Calls cannot: their results died with the connection.
       this.rejectPendingCalls();
     });
+    this.teardownOpenListener = this.socket.onOpen(() => {
+      this.resubscribeAll();
+    });
+  }
+
+  // The reopened socket is a blank slate for the server: replay every live
+  // subscription with its original id and params, so the same ready comes
+  // back and the stores can catch up.
+  private resubscribeAll(): void {
+    for (const [id, subscription] of this.subscriptions) {
+      const message: SubscribeMsg = {
+        type: 'subscribe',
+        id,
+        name: subscription.name,
+        ...(subscription.params ? { params: subscription.params } : {}),
+      };
+      this.socket.send(message).catch((error: unknown) => {
+        console.error('Failed to resubscribe:', error);
+      });
+    }
   }
 
   call(name: string, ...args: unknown[]): Promise<unknown> {
@@ -119,6 +143,8 @@ export class ConnectionManager {
     });
 
     this.subscriptions.set(id, {
+      name,
+      params,
       readyResolver: resolveReady,
       readyRejector: rejectReady,
     });
@@ -173,6 +199,7 @@ export class ConnectionManager {
     this.disposed = true;
     this.teardownMessageListener();
     this.teardownCloseListener();
+    this.teardownOpenListener();
 
     for (const id of Array.from(this.subscriptions.keys())) {
       this.stopSubscription(id);

--- a/client/connectionManager.ts
+++ b/client/connectionManager.ts
@@ -24,6 +24,9 @@ interface SubscriptionState {
   // Learned from the server: ready.collection when present, otherwise inferred
   // from the initial data buffered before ready. Undefined until then.
   collection?: string;
+  // Set when the socket dies unexpectedly. A reviving subscription buffers its
+  // incoming initial documents, and its next ready swaps them into the store.
+  reviving?: boolean;
 }
 
 class SubscriptionHandleImpl implements SubscriptionHandle {
@@ -84,6 +87,9 @@ export class ConnectionManager {
       // The socket comes back on its own, so subscriptions and stores wait
       // for it. Calls cannot: their results died with the connection.
       this.rejectPendingCalls();
+      for (const subscription of this.subscriptions.values()) {
+        subscription.reviving = true;
+      }
     });
     this.teardownOpenListener = this.socket.onOpen(() => {
       this.resubscribeAll();
@@ -233,6 +239,15 @@ export class ConnectionManager {
     }
   }
 
+  private isCollectionReviving(collection: string): boolean {
+    for (const sub of this.subscriptions.values()) {
+      if (sub.collection === collection && sub.reviving) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   private isCollectionLive(collection: string): boolean {
     for (const sub of this.subscriptions.values()) {
       if (sub.collection === collection) {
@@ -269,10 +284,31 @@ export class ConnectionManager {
     this.pendingData = remaining;
   }
 
+  // The replacement ready swaps the store's contents for the buffered initial
+  // documents in one move: a document deleted while offline disappears, and
+  // no observer ever sees the store empty in between.
+  private replaceFromPending(collection: string): void {
+    const replacement: DataMsg[] = [];
+    const remaining: DataMsg[] = [];
+    for (const message of this.pendingData) {
+      if (message.collection === collection) {
+        replacement.push(message);
+      } else {
+        remaining.push(message);
+      }
+    }
+    this.pendingData = remaining;
+    this.store(collection).replaceAll(replacement);
+  }
+
   private handleServerMessage(message: ServerMessage): void {
     switch (message.type) {
       case 'added': {
-        if (this.isCollectionLive(message.collection)) {
+        if (this.isCollectionReviving(message.collection)) {
+          // Initial documents of a resubscribe. Hold them so the stale view
+          // stays on screen until the ready swaps it wholesale.
+          this.pendingData.push(message);
+        } else if (this.isCollectionLive(message.collection)) {
           this.store(message.collection).handleMessage(message);
         } else if (this.hasUnboundSubscription()) {
           // Initial data for a subscription that has not learned its collection
@@ -297,7 +333,12 @@ export class ConnectionManager {
           // The server names the collection on ready, so bind the subscription
           // to it and flush any initial data buffered before it arrived.
           subscription.collection = message.collection;
-          this.flushPending(message.collection);
+          if (subscription.reviving) {
+            subscription.reviving = false;
+            this.replaceFromPending(message.collection);
+          } else {
+            this.flushPending(message.collection);
+          }
           subscription.readyResolver();
         }
         break;

--- a/client/index.ts
+++ b/client/index.ts
@@ -4,4 +4,9 @@
 // until a consumer shows a need for them.
 export { ConnectionManager, type SubscriptionHandle } from './connectionManager.ts';
 export { ReactiveStore } from './reactiveStore.ts';
-export { ClientSocketWrapper, type WebSocketLike } from './clientSocket.ts';
+export {
+  ClientSocketWrapper,
+  type ConnectionStatus,
+  type SocketCloseEvent,
+  type WebSocketLike,
+} from './clientSocket.ts';

--- a/client/reactiveStore.ts
+++ b/client/reactiveStore.ts
@@ -72,6 +72,13 @@ export class ReactiveStore {
     this.emitter.emit('change');
   }
 
+  // Swaps the whole contents in one move and notifies once, so an observer
+  // never sees the empty store a clear-then-add would expose.
+  replaceAll(docs: { id: string; fields?: Record<string, unknown> | undefined }[]): void {
+    this.docs = new Map(docs.map((doc) => [doc.id, doc.fields ?? {}]));
+    this.emitter.emit('change');
+  }
+
   getAll(): StoredDocWithId[] {
     return Array.from(this.docs.entries()).map(([id, fields]) => withId(id, fields));
   }

--- a/server/infrastructure/websocket.ts
+++ b/server/infrastructure/websocket.ts
@@ -79,6 +79,14 @@ export class WebSocketWrapper implements WebSocketInterface {
     return this.clients.size;
   }
 
+  // Kick every connected client while the server stays up. Each socket's own
+  // close event runs the normal disconnect teardown.
+  dropAllClients(): void {
+    for (const { socket } of this.clients.values()) {
+      socket.close();
+    }
+  }
+
   simulateConnection(): StubbedClient {
     const sourceWithSimulate = this.source as {
       simulateConnection?: () => StubbedClient;

--- a/tests/client/clientSocket.closeIntent.test.ts
+++ b/tests/client/clientSocket.closeIntent.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ClientSocketWrapper } from '../../client/clientSocket.ts';
+
+describe('ClientSocketWrapper - a close carries intent', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reports a deliberate close when the application calls close()', async () => {
+    const socket = ClientSocketWrapper.createNull();
+    await socket.connect();
+
+    const events: { deliberate: boolean }[] = [];
+    socket.onClose((event: { deliberate: boolean }) => events.push(event));
+
+    await socket.close();
+
+    expect(events).toEqual([{ deliberate: true }]);
+  });
+
+  it('reports an unexpected close when the socket dies under the client', async () => {
+    const socket = ClientSocketWrapper.createNull();
+    const server = socket.simulateServer();
+    await socket.connect();
+
+    const events: { deliberate: boolean }[] = [];
+    socket.onClose((event: { deliberate: boolean }) => events.push(event));
+
+    server.simulateClose();
+
+    expect(events).toEqual([{ deliberate: false }]);
+  });
+
+  it('counts the heartbeat closing a dead connection as unexpected, not deliberate', async () => {
+    vi.useFakeTimers();
+    const socket = ClientSocketWrapper.createNull({ pingIntervalMs: 1000, pongTimeoutMs: 500 });
+    await socket.connect();
+    vi.advanceTimersByTime(0);
+
+    const events: { deliberate: boolean }[] = [];
+    socket.onClose((event: { deliberate: boolean }) => events.push(event));
+
+    vi.advanceTimersByTime(1500);
+
+    expect(events).toEqual([{ deliberate: false }]);
+  });
+});

--- a/tests/client/clientSocket.defaults.test.ts
+++ b/tests/client/clientSocket.defaults.test.ts
@@ -30,6 +30,7 @@ describe('ClientSocketWrapper - the heartbeat is on out of the box', () => {
 
     // the ping at 15s goes unanswered, so the pong window shuts at 25s
     await vi.advanceTimersByTimeAsync(25_000);
+    await vi.advanceTimersByTimeAsync(50); // the instant retry lands just after
 
     expect(closes).toEqual([{ deliberate: false }]);
     expect(socket.isConnected).toBe(true); // and it is already back

--- a/tests/client/clientSocket.defaults.test.ts
+++ b/tests/client/clientSocket.defaults.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ClientSocketWrapper } from '../../client/clientSocket.ts';
+
+const pings = (data: unknown[]) => data.filter((m) => (m as { type: string }).type === 'ping');
+
+describe('ClientSocketWrapper - the heartbeat is on out of the box', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('pings with no configuration at all', async () => {
+    vi.useFakeTimers();
+    const socket = ClientSocketWrapper.createNull();
+    await socket.connect();
+    vi.advanceTimersByTime(0);
+    const tracker = socket.trackMessages();
+
+    vi.advanceTimersByTime(15_000);
+
+    expect(pings(tracker.data)).toHaveLength(1);
+  });
+
+  it('closes a silent connection and brings it back, all by itself', async () => {
+    vi.useFakeTimers();
+    const socket = ClientSocketWrapper.createNull();
+    await socket.connect();
+    vi.advanceTimersByTime(0);
+    const closes: { deliberate: boolean }[] = [];
+    socket.onClose((event) => closes.push(event));
+
+    // the ping at 15s goes unanswered, so the pong window shuts at 25s
+    await vi.advanceTimersByTimeAsync(25_000);
+
+    expect(closes).toEqual([{ deliberate: false }]);
+    expect(socket.isConnected).toBe(true); // and it is already back
+  });
+
+  it('a zero interval switches the heartbeat off', async () => {
+    vi.useFakeTimers();
+    const socket = ClientSocketWrapper.createNull({ pingIntervalMs: 0 });
+    await socket.connect();
+    vi.advanceTimersByTime(0);
+    const tracker = socket.trackMessages();
+
+    vi.advanceTimersByTime(120_000);
+
+    expect(pings(tracker.data)).toHaveLength(0);
+  });
+});

--- a/tests/client/clientSocket.reconnect.test.ts
+++ b/tests/client/clientSocket.reconnect.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ClientSocketWrapper } from '../../client/clientSocket.ts';
+import { ServerMessage } from '../../shared/protocol.ts';
+
+describe('ClientSocketWrapper - the socket comes back', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reopens after an unexpected close', async () => {
+    vi.useFakeTimers();
+    const socket = ClientSocketWrapper.createNull();
+    await socket.connect();
+
+    socket.simulateServer().simulateClose();
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(socket.isConnected).toBe(true);
+  });
+
+  it('delivers messages arriving over the reopened socket to existing listeners', async () => {
+    vi.useFakeTimers();
+    const socket = ClientSocketWrapper.createNull();
+    await socket.connect();
+    const received: ServerMessage[] = [];
+    socket.onMessage((message) => received.push(message));
+
+    socket.simulateServer().simulateClose();
+    await vi.advanceTimersByTimeAsync(50);
+    expect(socket.isConnected).toBe(true);
+    socket.simulateServer().send({ type: 'ready', id: '1', collection: 'files' });
+
+    expect(received).toEqual([{ type: 'ready', id: '1', collection: 'files' }]);
+  });
+
+  it('reopens again when the replacement socket also dies', async () => {
+    vi.useFakeTimers();
+    const socket = ClientSocketWrapper.createNull();
+    await socket.connect();
+
+    socket.simulateServer().simulateClose();
+    await vi.advanceTimersByTimeAsync(50);
+    socket.simulateServer().simulateClose();
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(socket.isConnected).toBe(true);
+  });
+
+  it('stays closed after a deliberate close()', async () => {
+    vi.useFakeTimers();
+    const socket = ClientSocketWrapper.createNull();
+    await socket.connect();
+
+    await socket.close();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(socket.isConnected).toBe(false);
+  });
+
+  it('cancels a pending reconnect when close() lands in the retry gap', async () => {
+    vi.useFakeTimers();
+    const socket = ClientSocketWrapper.createNull();
+    await socket.connect();
+
+    socket.simulateServer().simulateClose();
+    await socket.close();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(socket.isConnected).toBe(false);
+  });
+
+  it('never reopens when the application opts out of reconnect', async () => {
+    vi.useFakeTimers();
+    const socket = ClientSocketWrapper.createNull({ reconnect: false });
+    await socket.connect();
+
+    socket.simulateServer().simulateClose();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(socket.isConnected).toBe(false);
+  });
+});

--- a/tests/client/clientSocket.reconnect.test.ts
+++ b/tests/client/clientSocket.reconnect.test.ts
@@ -80,3 +80,102 @@ describe('ClientSocketWrapper - the socket comes back', () => {
     expect(socket.isConnected).toBe(false);
   });
 });
+
+describe('ClientSocketWrapper - reconnect backs off', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('doubles the wait between failed attempts', async () => {
+    vi.useFakeTimers();
+    const socket = ClientSocketWrapper.createNull(
+      { reconnectBaseMs: 1000, reconnectMaxMs: 60_000, reconnectRandom: () => 0.5 },
+      { failReconnects: 3 },
+    );
+    await socket.connect();
+
+    socket.simulateServer().simulateClose();
+    await vi.advanceTimersByTimeAsync(0); // retry 1 is instant, fails
+    await vi.advanceTimersByTimeAsync(1000); // retry 2 fails
+    await vi.advanceTimersByTimeAsync(2000); // retry 3 fails
+    await vi.advanceTimersByTimeAsync(3999); // retry 4 is due 4000 after retry 3
+    expect(socket.isConnected).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(socket.isConnected).toBe(true);
+  });
+
+  it('stops doubling at the cap', async () => {
+    vi.useFakeTimers();
+    const socket = ClientSocketWrapper.createNull(
+      { reconnectBaseMs: 1000, reconnectMaxMs: 2000, reconnectRandom: () => 0.5 },
+      { failReconnects: 3 },
+    );
+    await socket.connect();
+
+    socket.simulateServer().simulateClose();
+    await vi.advanceTimersByTimeAsync(0); // retry 1 is instant, fails
+    await vi.advanceTimersByTimeAsync(1000); // retry 2 fails
+    await vi.advanceTimersByTimeAsync(2000); // retry 3 fails, capped
+    await vi.advanceTimersByTimeAsync(1999); // retry 4 is capped at 2000, not 4000
+    expect(socket.isConnected).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(socket.isConnected).toBe(true);
+  });
+
+  it('spreads the wait with jitter so a fleet of clients cannot stampede', async () => {
+    vi.useFakeTimers();
+    // random() = 1 pushes the wait to 1.25x, the top of the jitter window
+    const socket = ClientSocketWrapper.createNull(
+      { reconnectBaseMs: 1000, reconnectMaxMs: 60_000, reconnectRandom: () => 1 },
+      { failReconnects: 1 },
+    );
+    await socket.connect();
+
+    socket.simulateServer().simulateClose();
+    await vi.advanceTimersByTimeAsync(0); // retry 1 is instant, fails
+    await vi.advanceTimersByTimeAsync(1249); // retry 2 is due at 1250, not 1000
+    expect(socket.isConnected).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(socket.isConnected).toBe(true);
+  });
+
+  it('never gives up, however long the server stays away', async () => {
+    vi.useFakeTimers();
+    const socket = ClientSocketWrapper.createNull(
+      { reconnectBaseMs: 1000, reconnectMaxMs: 1000, reconnectRandom: () => 0.5 },
+      { failReconnects: 30 },
+    );
+    await socket.connect();
+
+    socket.simulateServer().simulateClose();
+    for (let i = 0; i <= 30; i++) {
+      await vi.advanceTimersByTimeAsync(1000);
+    }
+
+    expect(socket.isConnected).toBe(true);
+  });
+
+  it('a successful connection resets the backoff', async () => {
+    vi.useFakeTimers();
+    const socket = ClientSocketWrapper.createNull(
+      { reconnectBaseMs: 1000, reconnectMaxMs: 60_000, reconnectRandom: () => 0.5 },
+      { failReconnects: 2 },
+    );
+    await socket.connect();
+
+    socket.simulateServer().simulateClose();
+    await vi.advanceTimersByTimeAsync(0); // retry 1 is instant, fails
+    await vi.advanceTimersByTimeAsync(1000); // retry 2 fails
+    await vi.advanceTimersByTimeAsync(2000); // retry 3 succeeds
+    expect(socket.isConnected).toBe(true);
+
+    // the next drop starts the schedule from the top: instant, not 4000
+    socket.simulateServer().simulateClose();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(socket.isConnected).toBe(true);
+  });
+});

--- a/tests/client/clientSocket.status.test.ts
+++ b/tests/client/clientSocket.status.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ClientSocketWrapper } from '../../client/clientSocket.ts';
+
+type ConnectionStatus = 'connecting' | 'connected' | 'reconnecting' | 'closed';
+
+// The shape this red demands: a status the application can read at any
+// moment, so an outage is something a page can render instead of hide.
+const statusOf = (socket: ClientSocketWrapper): ConnectionStatus =>
+  (socket as unknown as { status: ConnectionStatus }).status;
+
+describe('ClientSocketWrapper - connection status', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reports connecting before the socket first opens', () => {
+    const socket = ClientSocketWrapper.createNull();
+
+    expect(statusOf(socket)).toBe('connecting');
+  });
+
+  it('reports connected once the socket is open', async () => {
+    const socket = ClientSocketWrapper.createNull();
+
+    await socket.connect();
+
+    expect(statusOf(socket)).toBe('connected');
+  });
+
+  it('reports reconnecting from the unexpected close until the socket is back', async () => {
+    vi.useFakeTimers();
+    const socket = ClientSocketWrapper.createNull(
+      { reconnectBaseMs: 1000, reconnectMaxMs: 60_000, reconnectRandom: () => 0.5 },
+      { failReconnects: 1 },
+    );
+    await socket.connect();
+
+    socket.simulateServer().simulateClose();
+    expect(statusOf(socket)).toBe('reconnecting');
+
+    await vi.advanceTimersByTimeAsync(0); // retry 1 fails
+    expect(statusOf(socket)).toBe('reconnecting');
+
+    await vi.advanceTimersByTimeAsync(1000); // retry 2 opens
+
+    expect(statusOf(socket)).toBe('connected');
+  });
+
+  it('reports closed after a deliberate close', async () => {
+    const socket = ClientSocketWrapper.createNull();
+    await socket.connect();
+
+    await socket.close();
+
+    expect(statusOf(socket)).toBe('closed');
+  });
+
+  it('reports closed when reconnect is off and the socket dies', async () => {
+    const socket = ClientSocketWrapper.createNull({ reconnect: false });
+    await socket.connect();
+
+    socket.simulateServer().simulateClose();
+
+    expect(statusOf(socket)).toBe('closed');
+  });
+});

--- a/tests/client/clientSocket.test.ts
+++ b/tests/client/clientSocket.test.ts
@@ -176,7 +176,11 @@ describe('ClientSocketWrapper (null)', () => {
     await socket.connect();
     vi.advanceTimersByTime(0);
 
-    const closed = new Promise<void>((resolve) => socket.onClose(resolve));
+    const closed = new Promise<void>((resolve) =>
+      socket.onClose(() => {
+        resolve();
+      }),
+    );
 
     vi.advanceTimersByTime(2000);
 

--- a/tests/client/clientSocket.test.ts
+++ b/tests/client/clientSocket.test.ts
@@ -169,9 +169,12 @@ describe('ClientSocketWrapper (null)', () => {
 
   it('closes the socket when no pong arrives within the configured window', async () => {
     vi.useFakeTimers();
+    // Reconnect off: this test pins detection, the comeback is pinned in
+    // clientSocket.reconnect.test.ts.
     const socket = ClientSocketWrapper.createNull({
       pingIntervalMs: 1000,
       pongTimeoutMs: 500,
+      reconnect: false,
     });
     await socket.connect();
     vi.advanceTimersByTime(0);
@@ -217,9 +220,12 @@ describe('ClientSocketWrapper (null)', () => {
 
   it('closes when a ping gets no pong within the window', async () => {
     vi.useFakeTimers();
+    // Reconnect off: this test pins detection, the comeback is pinned in
+    // clientSocket.reconnect.test.ts.
     const socket = ClientSocketWrapper.createNull({
       pingIntervalMs: 1000,
       pongTimeoutMs: 500,
+      reconnect: false,
     });
     await socket.connect();
     vi.advanceTimersByTime(0);

--- a/tests/client/clientSocket.test.ts
+++ b/tests/client/clientSocket.test.ts
@@ -191,8 +191,8 @@ describe('ClientSocketWrapper (null)', () => {
     expect(socket.isConnected).toBe(false);
   });
 
-  it('does not close the connection when no heartbeat is configured', async () => {
-    const socket = ClientSocketWrapper.createNull();
+  it('stays open when the heartbeat is switched off', async () => {
+    const socket = ClientSocketWrapper.createNull({ pingIntervalMs: 0 });
     await socket.connect();
 
     await new Promise((resolve) => setTimeout(resolve, 20));

--- a/tests/client/connectionManager.call.test.ts
+++ b/tests/client/connectionManager.call.test.ts
@@ -55,7 +55,7 @@ describe('ClientSocketWrapper call', () => {
     // A call whose reply will never come, because the socket drops first.
     const result = manager.call('slow');
 
-    // Dropping the connection runs dispose() via the onClose listener.
+    // Dropping the connection rejects the call via the onClose listener.
     server.simulateClose();
 
     // The call must settle, not wait forever. Race it against a short timer so

--- a/tests/client/connectionManager.catchUp.test.ts
+++ b/tests/client/connectionManager.catchUp.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ClientSocketWrapper } from '../../client/clientSocket.ts';
+import { ConnectionManager } from '../../client/connectionManager.ts';
+import { SubscribeMsg } from '../../shared/protocol.ts';
+
+// Builds a manager with one ready subscription on 'files' holding doc1 and
+// doc2, then kills the socket and lets it reopen and resubscribe.
+async function droppedAndReopened() {
+  const socket = ClientSocketWrapper.createNull();
+  const manager = new ConnectionManager(socket);
+  await socket.connect();
+  const messages = socket.trackMessages();
+
+  const handle = manager.subscribe('files.all');
+  const subscriptionId = (messages.data[0] as SubscribeMsg).id;
+  const server = socket.simulateServer();
+  server.send({ type: 'added', collection: 'files', id: 'doc1', fields: { name: 'one' } });
+  server.send({ type: 'ready', id: subscriptionId, collection: 'files' });
+  await handle.ready;
+  server.send({ type: 'added', collection: 'files', id: 'doc2', fields: { name: 'two' } });
+
+  server.simulateClose();
+  await vi.advanceTimersByTimeAsync(50);
+
+  return { socket, manager, subscriptionId };
+}
+
+describe('ConnectionManager - the store catches up after resubscribe', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('the ready after resubscribe replaces the store: a doc deleted while offline is gone', async () => {
+    vi.useFakeTimers();
+    const { socket, manager, subscriptionId } = await droppedAndReopened();
+    const server = socket.simulateServer();
+
+    // The server's new truth: doc1 was deleted during the outage.
+    server.send({ type: 'added', collection: 'files', id: 'doc2', fields: { name: 'two' } });
+    server.send({ type: 'added', collection: 'files', id: 'doc3', fields: { name: 'three' } });
+    server.send({ type: 'ready', id: subscriptionId, collection: 'files' });
+
+    expect(manager.store('files').getAll()).toEqual([
+      { _id: 'doc2', name: 'two' },
+      { _id: 'doc3', name: 'three' },
+    ]);
+  });
+
+  it('keeps the stale view on screen until the replacement ready lands', async () => {
+    vi.useFakeTimers();
+    const { socket, manager } = await droppedAndReopened();
+    const server = socket.simulateServer();
+
+    server.send({ type: 'added', collection: 'files', id: 'doc2', fields: { name: 'two v2' } });
+    server.send({ type: 'added', collection: 'files', id: 'doc3', fields: { name: 'three' } });
+
+    expect(manager.store('files').getAll()).toEqual([
+      { _id: 'doc1', name: 'one' },
+      { _id: 'doc2', name: 'two' },
+    ]);
+  });
+
+  it('never lets a change event expose an empty store during the swap', async () => {
+    vi.useFakeTimers();
+    const { socket, manager, subscriptionId } = await droppedAndReopened();
+    const store = manager.store('files');
+    const sizesSeen: number[] = [];
+    store.onChange(() => sizesSeen.push(store.getAll().length));
+    const server = socket.simulateServer();
+
+    server.send({ type: 'added', collection: 'files', id: 'doc2', fields: { name: 'two' } });
+    server.send({ type: 'added', collection: 'files', id: 'doc3', fields: { name: 'three' } });
+    server.send({ type: 'ready', id: subscriptionId, collection: 'files' });
+
+    expect(sizesSeen.length).toBeGreaterThan(0);
+    expect(sizesSeen).not.toContain(0);
+  });
+
+  it('live updates flow again once the catch up completes', async () => {
+    vi.useFakeTimers();
+    const { socket, manager, subscriptionId } = await droppedAndReopened();
+    const server = socket.simulateServer();
+
+    server.send({ type: 'added', collection: 'files', id: 'doc2', fields: { name: 'two' } });
+    server.send({ type: 'ready', id: subscriptionId, collection: 'files' });
+    server.send({ type: 'changed', collection: 'files', id: 'doc2', fields: { name: 'two v2' } });
+    server.send({ type: 'added', collection: 'files', id: 'doc4', fields: { name: 'four' } });
+
+    expect(manager.store('files').getAll()).toEqual([
+      { _id: 'doc2', name: 'two v2' },
+      { _id: 'doc4', name: 'four' },
+    ]);
+  });
+});

--- a/tests/client/connectionManager.realSocketClose.test.ts
+++ b/tests/client/connectionManager.realSocketClose.test.ts
@@ -4,7 +4,7 @@ import { ClientSocketWrapper } from '../../client/clientSocket.ts';
 import { ConnectionManager } from '../../client/connectionManager.ts';
 
 describe('ConnectionManager with a real socket', () => {
-  it('disposes when the server closes the socket', async () => {
+  it('survives the server closing the socket, and disposes on its own deliberate close', async () => {
     const server = new WebSocketServer({ port: 0 });
     const port = (server.address() as { port: number }).port;
 
@@ -24,10 +24,13 @@ describe('ConnectionManager with a real socket', () => {
       client.close();
     }
 
-    await expect(handle.ready).rejects.toThrow('subscription stopped before ready');
-
     await new Promise<void>((resolve) => setTimeout(resolve, 100));
 
+    expect(manager.activeSubscriptionCount()).toBe(1);
+
+    await socket.close();
+
+    await expect(handle.ready).rejects.toThrow('subscription stopped before ready');
     expect(manager.activeSubscriptionCount()).toBe(0);
 
     server.close();

--- a/tests/client/connectionManager.realSocketClose.test.ts
+++ b/tests/client/connectionManager.realSocketClose.test.ts
@@ -8,7 +8,11 @@ describe('ConnectionManager with a real socket', () => {
     const server = new WebSocketServer({ port: 0 });
     const port = (server.address() as { port: number }).port;
 
-    const socket = ClientSocketWrapper.create(`ws://localhost:${String(port)}`);
+    // Reconnect off: with it on, the client would reopen against the still
+    // running server and hold the process alive past server.close().
+    const socket = ClientSocketWrapper.create(`ws://localhost:${String(port)}`, undefined, {
+      reconnect: false,
+    });
     await socket.connect();
     const manager = new ConnectionManager(socket);
 

--- a/tests/client/connectionManager.resubscribe.test.ts
+++ b/tests/client/connectionManager.resubscribe.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ClientSocketWrapper } from '../../client/clientSocket.ts';
+import { ConnectionManager } from '../../client/connectionManager.ts';
+import { SubscribeMsg } from '../../shared/protocol.ts';
+
+const subscribeMessages = (data: unknown[]): SubscribeMsg[] =>
+  data.filter((m): m is SubscribeMsg => (m as { type: string }).type === 'subscribe');
+
+describe('ConnectionManager - resubscribe after the socket comes back', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('resends every subscription with its original id, name and params', async () => {
+    vi.useFakeTimers();
+    const socket = ClientSocketWrapper.createNull();
+    const manager = new ConnectionManager(socket);
+    await socket.connect();
+    const messages = socket.trackMessages();
+
+    manager.subscribe('files.all', { room: 'evros' });
+    manager.subscribe('counts.byFile');
+    const before = subscribeMessages(messages.data);
+
+    socket.simulateServer().simulateClose();
+    await vi.advanceTimersByTimeAsync(50);
+
+    const after = subscribeMessages(messages.data);
+    expect(after).toHaveLength(4);
+    expect(after.slice(2)).toEqual(before);
+  });
+
+  it('does not resubscribe until a socket actually reopens', async () => {
+    vi.useFakeTimers();
+    const socket = ClientSocketWrapper.createNull(
+      { reconnectBaseMs: 1000, reconnectMaxMs: 60_000, reconnectRandom: () => 0.5 },
+      { failReconnects: 1 },
+    );
+    const manager = new ConnectionManager(socket);
+    await socket.connect();
+    const messages = socket.trackMessages();
+
+    manager.subscribe('files.all');
+
+    socket.simulateServer().simulateClose();
+    await vi.advanceTimersByTimeAsync(0); // retry 1 fails to open
+    expect(subscribeMessages(messages.data)).toHaveLength(1);
+
+    await vi.advanceTimersByTimeAsync(1000); // retry 2 opens
+
+    expect(subscribeMessages(messages.data)).toHaveLength(2);
+  });
+});

--- a/tests/client/connectionManager.socketClose.test.ts
+++ b/tests/client/connectionManager.socketClose.test.ts
@@ -3,8 +3,11 @@ import { ClientSocketWrapper } from '../../client/clientSocket.ts';
 import { ConnectionManager } from '../../client/connectionManager.ts';
 import { SubscribeMsg } from '../../shared/protocol.ts';
 
-describe('ConnectionManager - after socket dies', () => {
-  it('disposes when the socket closes, without an explicit dispose call', async () => {
+// Until this story, any close disposed the manager. Now the socket comes back
+// on its own, so an unexpected close is something to survive, and only a
+// deliberate close is the end.
+describe('ConnectionManager - after the socket dies unexpectedly', () => {
+  it('survives: subscriptions and stores are waiting for the socket to come back', async () => {
     const socket = ClientSocketWrapper.createNull();
     const server = socket.simulateServer();
     const manager = new ConnectionManager(socket);
@@ -16,6 +19,28 @@ describe('ConnectionManager - after socket dies', () => {
 
     server.simulateClose();
 
-    expect(manager.activeSubscriptionCount()).toBe(0);
+    expect(manager.activeSubscriptionCount()).toBe(1);
+    expect(() => manager.store('files')).not.toThrow();
+  });
+
+  it('rejects a call in flight: its result died with the connection', async () => {
+    const socket = ClientSocketWrapper.createNull();
+    const server = socket.simulateServer();
+    const manager = new ConnectionManager(socket);
+
+    const pending = manager.call('files.rename', 'a.bam');
+    server.simulateClose();
+
+    await expect(pending).rejects.toThrow('connection closed');
+  });
+
+  it('still disposes on a deliberate close', async () => {
+    const socket = ClientSocketWrapper.createNull();
+    const manager = new ConnectionManager(socket);
+    await socket.connect();
+
+    await socket.close();
+
+    expect(() => manager.store('files')).toThrow('ConnectionManager is disposed');
   });
 });

--- a/tests/client/reconnect.integration.test.ts
+++ b/tests/client/reconnect.integration.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createServer } from '../../server/index.ts';
+import { WebSocketWrapper } from '../../server/infrastructure/websocket.ts';
+import { MongoWrapper } from '../../server/infrastructure/mongo.ts';
+import { Publications } from '../../server/logic/publications.ts';
+import { ClientSocketWrapper } from '../../client/clientSocket.ts';
+import { ConnectionManager } from '../../client/connectionManager.ts';
+
+const withReadyTimeout = <T>(promise: Promise<T>): Promise<T> => {
+  return Promise.race([
+    promise,
+    new Promise<T>((_resolve, reject) =>
+      setTimeout(() => {
+        reject(new Error('subscription never became ready'));
+      }, 1000),
+    ),
+  ]);
+};
+
+// The shape this red demands: the server can kick its clients while staying
+// up, which is what a mid flight network death looks like from the client.
+const dropAllClients = (ws: WebSocketWrapper): void => {
+  (ws as unknown as { dropAllClients(): void }).dropAllClients();
+};
+
+describe('reconnect and resubscribe over a real server', () => {
+  let server: Awaited<ReturnType<typeof createServer>>;
+  let socket: ClientSocketWrapper;
+
+  afterEach(async () => {
+    await socket.close();
+    await server.close();
+  });
+
+  it('a dropped client comes back, resubscribes with the same id, and its store catches up', async () => {
+    // One canned response per find call: the initial subscribe sees doc 1,
+    // the resubscribe sees the new truth. A publication registered twice
+    // would exhaust the queue and fail loudly.
+    const mongo = MongoWrapper.createNull({
+      find: [
+        [{ _id: '1', name: 'existing.bam' }],
+        [
+          { _id: '1', name: 'existing.bam' },
+          { _id: '2', name: 'fresh.bam' },
+        ],
+      ],
+    });
+    const ws = WebSocketWrapper.create();
+    const publications = new Publications(mongo, ws);
+    publications.define('files.all', () => ({ collection: 'files', query: {} }));
+
+    server = await createServer({ ws, publications });
+    await server.listen({ port: 0 });
+    const port = String(server.addresses()[0].port);
+
+    socket = ClientSocketWrapper.create(`ws://localhost:${port}/ws`);
+    await socket.connect();
+    const manager = new ConnectionManager(socket);
+
+    const handle = manager.subscribe('files.all');
+    await withReadyTimeout(handle.ready);
+    expect(manager.store('files').getAll()).toEqual([{ _id: '1', name: 'existing.bam' }]);
+
+    dropAllClients(ws);
+
+    await vi.waitFor(
+      () => {
+        expect(manager.store('files').getById('2')).toEqual({ _id: '2', name: 'fresh.bam' });
+      },
+      { timeout: 3000 },
+    );
+    expect(socket.status).toBe('connected');
+    expect(manager.activeSubscriptionCount()).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #131.

## Why

The heartbeat has worked since Story 8.C: the client pings, the server pongs, and a client that hears nothing back closes the socket. Nothing switched it on, and for a reason: EkoLite had no reconnect, so a heartbeat alone converts a connection that is silently dead into one that is deliberately dead, and the reader still watches a page that has stopped updating. The heartbeat only pays for itself once the client can come back. So this PR ships reconnect first and flips the heartbeat on last.

## What changed, in the order it landed

**1. A close carries intent.** The disconnection event now carries `{ deliberate: boolean }`. Only the public `close()` is a goodbye; the heartbeat closing a dead connection is a detected failure and reports as one. Everything below hangs off this distinction.

**2. The socket comes back.** An unexpected close reopens the connection: instant first retry to catch blips, then the wait doubles from 1s to a 30s cap with jitter in the 0.75x to 1.25x window, and it never gives up. A deliberate close stays closed, a `close()` landing in the retry gap cancels the pending attempt, and `reconnect: false` opts out entirely. One subtlety worth knowing: `close()` on a socket that already died still emits a deliberate close event, so a listener that survived the drop is always told the goodbye happened.

**3. Resubscribe and catch up.** `ConnectionManager` survives an unexpected close instead of disposing, and replays every subscription with its original id and params on each reopen. While a subscription is reviving, its incoming initial documents are buffered, and the ready swaps them into the store in one move (`ReactiveStore.replaceAll`): a document deleted during the outage is gone afterwards, and no observer ever sees the store empty mid swap, so the page keeps the stale view until the fresh one is whole. In flight method calls reject rather than being resent, because a method that half ran on the server must not run twice.

**4. On by default.** 15 second pings with a 10 second pong window, deliberately inside the interval so at most one ping is in flight. Zero disables either knob. The socket now reports `status` (`connecting | connected | reconnecting | closed`) so an application can render an outage instead of hiding it. The README stops listing reconnect as a gap.

## What Meteor taught this design

Retry forever with capped, jittered backoff; record intent at disconnect time; resubscribe with the same id; keep stale data on screen and swap once the replacement is complete. What we deliberately skipped: Meteor 3.5's server side session resume with a grace period. Full resubscribe was Meteor's only path for fifteen years and is the right scope here.

## Retired pins

Two tests said "any close disposes the manager". They described the old world and were retired deliberately in the red commit of part 3, replaced by the survival contract. The heartbeat detection tests now run with reconnect off, so they keep pinning detection alone.

## Proven end to end

A new integration test drives the whole loop against a real server: the server kicks its clients (new `WebSocketWrapper.dropAllClients()` seam), the client notices, reconnects, resubscribes with the same id, the publication runs again, and the store catches up. The null Mongo hands out one canned response per `find` call, so a publication registered twice would exhaust the queue and fail loudly.

## Tests

Every behaviour landed as a red commit followed by a green commit, 20 commits in all. Unit suite: 289 passing. Integration suite: 40 passing.

## Out of scope

Auth on the file routes, now the only gap the README names. Server side session resume.
