### PR TITLE
chore: release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to `ekolite` are recorded here. The project is pre-1.0, so a minor version may carry a breaking change.
+
+## 0.2.0
+
+### Added
+
+- **Client auto-reconnect.** A socket that drops reopens on its own: instant first retry, then a wait that doubles from 1 second to a 30 second cap with jitter, and it never gives up. `reconnect: false` opts out. (#140)
+- **Heartbeat on by default.** The live client sends a `ping` every 15 seconds and closes a socket that does not `pong` within 10 seconds, so a silently dead connection is detected. Set either knob to zero to disable it. (#140)
+- **Resubscribe and catch up.** On reconnect, subscriptions replay with their original ids and the store swaps its contents whole on the `ready`, so the page keeps its stale view and never renders empty. (#140)
+- **`ClientSocketWrapper.status`** (`connecting | connected | reconnecting | closed`), the surface a page renders during an outage. (#140)
+- **`App.armShutdown()`.** Consumers can arm graceful shutdown, on a signal or a supervisor's stop message, without reaching into the package internals. (#137)
+- **`createServer({ staticRoot })`.** Serve your own built client from any directory. An absent root serves nothing rather than a server that looks healthy and 404s every static request. (#134)
+
+### Changed
+
+- **`App.create` is a clean framework surface.** It no longer defines EkoLite's own demo publications and methods (`files.all`, `echo`, `runCountC`), and `AppConfig` no longer carries `countCScript`. Define your own publications and methods on the empty registries `App.create` returns. This is a breaking change for anyone who relied on the built-in demo. (#133)
+
+### Fixed
+
+- **Shutdown drains change streams before closing Mongo,** so a clean shutdown no longer logs `MongoClientClosedError`. (#113)
+- **Graceful shutdown works for a supervisor on Windows** via a stop message, not only an interactive Ctrl+C. (#125)
+
+## 0.1.0
+
+- First published release: the pub/sub engine over a live socket, the method registry and RPC, file upload over HTTP, the reactive client store, `App` wiring, and the npm package with a three-entry export map (`ekolite`, `ekolite/client`, `ekolite/shared`). (#119)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ekolite",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ekolite",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@fastify/multipart": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ekolite",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A lightweight, real-time backend framework for data-driven apps. Fastify + MongoDB + WebSocket with typed pub/sub, RPC methods, and file uploads.",
   "homepage": "https://ekohacks.github.io/ekolite/",
   "bugs": {


### PR DESCRIPTION
## Release 0.2.0

First minor since 0.1.0 (#119). Bumps `package.json` to 0.2.0 and adds `CHANGELOG.md`.

### What ships to consumers

- Client **auto-reconnect** with backoff and jitter, **heartbeat on by default** (15s / 10s), resubscribe and catch up on reconnect, and `ClientSocketWrapper.status` (#140)
- **`App.armShutdown()`** so a consumer can arm graceful shutdown without reaching into internals (#137)
- **`createServer({ staticRoot })`** so a consumer serves their own built client; an absent root serves nothing rather than 404ing (#134)
- **Breaking (0.x):** `App.create` no longer defines the demo `files.all` / `echo` / `runCountC`, and `countCScript` is dropped from `AppConfig`. Define your own on the empty registries (#133)
- Shutdown drains change streams before closing Mongo (#113); a supervisor can stop the server on Windows (#125)

### Verified

`npm run test:package` passes on the 0.2.0 tarball: it builds, packs, installs into a throwaway project outside the repo, and a consumer imports `ekolite`, `ekolite/client` and `ekolite/shared`, serves its own client through `createServer`, and arms graceful shutdown to a clean exit 0 on a signal.

### To publish, after merge

From `main`:

```
npm publish --access public
```

`prepublishOnly` re-runs typecheck, tests, and build as the gate. Tagging `v0.2.0` on the merge commit is worth doing since there is no version tag history yet.
