### PR TITLE
docs: stop hardcoding the version in the README status line

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Full docs: <https://ekohacks.github.io/ekolite/>
 
 ## Status
 
-Work in progress, published early at `0.x` (currently `0.1.0`) to claim the name and share the shape. The public API is still settling and can change between `0.x` releases, so pin a version and read the notes before upgrading. Not recommended for production yet.
+Work in progress, published early at `0.x` to claim the name and share the shape. The public API is still settling and can change between `0.x` releases, so pin a version and read the [release notes](https://github.com/ekohacks/ekolite/releases) before upgrading. Not recommended for production yet.
 
 ## Install
 


### PR DESCRIPTION
The Status line read "published early at `0.x` (currently `0.1.0`)". 0.2.0 shipped with that verbatim, so the npm page header says 0.2.0 while the body says 0.1.0.

Drops the hardcoded number so it cannot drift again, and links the [releases](https://github.com/ekohacks/ekolite/releases) page (which now carries the 0.2.0 notes) for "read the notes before upgrading".

Docs only, no code change. Reaches the npm page on the next publish, so it rides a `0.2.1` patch (or the next release, whichever comes first).