### PR TITLE
feat: ekolite run - boot a developer's app from ekolite.config.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "ekolite",
   "version": "0.2.0",
+  "bin": {
+    "ekolite": "dist/server/cli.js"
+  },
   "description": "A lightweight, real-time backend framework for data-driven apps. Fastify + MongoDB + WebSocket with typed pub/sub, RPC methods, and file uploads.",
   "homepage": "https://ekohacks.github.io/ekolite/",
   "bugs": {
@@ -19,6 +22,10 @@
     ".": {
       "types": "./dist/server/index.d.ts",
       "import": "./dist/server/index.js"
+    },
+    "./config": {
+      "types": "./dist/server/config.d.ts",
+      "import": "./dist/server/config.js"
     },
     "./shared": {
       "types": "./dist/shared/protocol.d.ts",

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -6,7 +6,7 @@
 // Red until the package actually emits a loadable server entry and exports App. Run it
 // with `node scripts/package-smoke.mjs`.
 import { execFileSync, spawn } from 'node:child_process';
-import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -90,6 +90,100 @@ function assertGracefulShutdown(dir) {
   });
 }
 
+// Prove `ekolite run` from the outside: a consumer's project carries only an
+// ekolite.config.ts and its (eko) => void app entry, no start.ts of its own. The installed
+// `ekolite` bin reads the config, applies the app's definitions, and serves the consumer's
+// own client. Their config and entry are TypeScript, imported by Node's native type
+// stripping, so there is no build step between the developer and `ekolite run`.
+function assertRunBootsTheApp(dir) {
+  const READY = 'ekolite: ready on'; // mirrors READY_MESSAGE in shared/serverMessages.ts
+  const port = 3987;
+
+  mkdirSync(join(dir, 'eko-client'), { recursive: true });
+  writeFileSync(join(dir, 'eko-client', 'index.html'), '<!-- served by ekolite run -->\n');
+  writeFileSync(
+    join(dir, 'ekolite.config.ts'),
+    [
+      "import { defineConfig } from 'ekolite/config';",
+      "export default defineConfig({ app: './eko-app.ts', clientDir: './eko-client' });",
+      '',
+    ].join('\n'),
+  );
+  writeFileSync(
+    join(dir, 'eko-app.ts'),
+    [
+      "import type { AppEntry } from 'ekolite/config';",
+      'const app: AppEntry = (eko) => {',
+      "  eko.methods.define('greet', (name) => Promise.resolve(`hi ${String(name)}`));",
+      '};',
+      'export default app;',
+      '',
+    ].join('\n'),
+  );
+
+  const bin = join(dir, 'node_modules', 'ekolite', 'dist', 'server', 'cli.js');
+
+  return new Promise((resolve, reject) => {
+    const child = spawn('node', [bin, 'run'], {
+      cwd: dir,
+      env: { ...process.env, EKOLITE_PORT: String(port) },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let out = '';
+    let err = '';
+    let settled = false;
+
+    const finish = (fn) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(giveUp);
+      fn();
+    };
+
+    const giveUp = setTimeout(() => {
+      child.kill('SIGKILL');
+      finish(() => reject(new Error(`ekolite run never became ready:\n${out}\n${err}`)));
+    }, 20000);
+
+    child.stdout.on('data', (chunk) => {
+      out += chunk;
+      if (!out.includes(READY)) return;
+      // Ready: the consumer's own client is served at /, then stop cleanly.
+      fetch(`http://127.0.0.1:${String(port)}/`)
+        .then(async (res) => ({ status: res.status, body: await res.text() }))
+        .then(({ status, body }) => {
+          if (status !== 200 || !body.includes('served by ekolite run')) {
+            child.kill('SIGKILL');
+            finish(() =>
+              reject(new Error(`ekolite run did not serve the app's client: status=${status}\n${body}`)),
+            );
+            return;
+          }
+          child.kill('SIGTERM');
+        })
+        .catch((fetchErr) => {
+          child.kill('SIGKILL');
+          finish(() => reject(fetchErr));
+        });
+    });
+    child.stderr.on('data', (chunk) => {
+      err += chunk;
+    });
+    child.on('error', (spawnErr) => finish(() => reject(spawnErr)));
+    child.on('exit', (code, signal) => {
+      finish(() => {
+        if (code === 0 && signal === null) {
+          resolve();
+          return;
+        }
+        reject(
+          new Error(`ekolite run exited (code=${code}, signal=${signal}) instead of a clean 0:\n${err}`),
+        );
+      });
+    });
+  });
+}
+
 async function main() {
   // 1. Build the library from the repo.
   run('npm', ['run', 'build'], { cwd: REPO });
@@ -121,6 +215,13 @@ async function main() {
   let clientDir;
   try {
     run('npm', ['init', '-y'], { cwd: dir });
+    // A modern ESM consumer: .ts and .js resolve as ES modules. This is what ekolite run's
+    // native type stripping needs to load an ekolite.config.ts, and EkoLite is ESM anyway.
+    const pkgPath = join(dir, 'package.json');
+    writeFileSync(
+      pkgPath,
+      JSON.stringify({ ...JSON.parse(readFileSync(pkgPath, 'utf8')), type: 'module' }, null, 2),
+    );
     run('npm', ['install', tarball], { cwd: dir });
 
     // 3. A consumer that knows only the published package: import App, define a method on
@@ -229,6 +330,12 @@ async function main() {
       await assertGracefulShutdown(dir);
     }
 
+    // 9. The `ekolite run` bin boots a consumer's app from its ekolite.config.ts and serves
+    //    the consumer's own client, no start.ts of theirs. SIGTERM here, so POSIX only.
+    if (process.platform !== 'win32') {
+      await assertRunBootsTheApp(dir);
+    }
+
     console.log('package smoke: PASS');
     console.log(`  consumer said: ${out}`);
     console.log('  declarations resolve to shipped files only');
@@ -236,6 +343,7 @@ async function main() {
     console.log('  a consumer serves their own client through createServer');
     if (process.platform !== 'win32') {
       console.log('  a consumer arms graceful shutdown and the process exits 0 on a signal');
+      console.log('  a consumer boots their own app with `ekolite run` and it serves their client');
     }
   } finally {
     rmSync(dir, { recursive: true, force: true });

--- a/server/cli.ts
+++ b/server/cli.ts
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+import { parseArgs } from 'node:util';
+import { runApp } from './run.ts';
+
+// The `ekolite` command. `ekolite run` boots the app in the current directory from its
+// ekolite.config.ts. Other verbs (create, build) are later stories.
+async function main(): Promise<void> {
+  const { positionals } = parseArgs({ allowPositionals: true });
+  const verb = positionals[0];
+
+  if (verb === 'run') {
+    await runApp();
+    return;
+  }
+
+  process.stderr.write(`ekolite: unknown command ${verb ?? '(none)'}. Try: ekolite run\n`);
+  process.exitCode = 1;
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(`ekolite: ${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/server/config.ts
+++ b/server/config.ts
@@ -1,5 +1,9 @@
 import { type AppEntry } from './run.ts';
 
+// Re-export the app-authoring types so a consumer types their config and entry from one
+// place: `import { defineConfig, type AppEntry } from 'ekolite/config'`.
+export type { AppEntry, AppContext } from './run.ts';
+
 // The shape of an ekolite.config.ts. `app` is the app entry: a path to the module the
 // runner imports, or the entry function inline. The dirs point the runner at the app's own
 // files: the built client to serve at /, the scripts and assets to resolve at runtime, and

--- a/server/config.ts
+++ b/server/config.ts
@@ -14,6 +14,6 @@ export interface EkoConfig {
 
 // Identity, but typed: a consumer writes `export default defineConfig({ ... })` and gets
 // autocomplete and a compile error on a wrong or missing key. Wired in the green step.
-export function defineConfig(_config: EkoConfig): EkoConfig {
-  throw new Error('defineConfig not implemented');
+export function defineConfig(config: EkoConfig): EkoConfig {
+  return config;
 }

--- a/server/config.ts
+++ b/server/config.ts
@@ -1,0 +1,19 @@
+import { type AppEntry } from './run.ts';
+
+// The shape of an ekolite.config.ts. `app` is the app entry: a path to the module the
+// runner imports, or the entry function inline. The dirs point the runner at the app's own
+// files: the built client to serve at /, the scripts and assets to resolve at runtime, and
+// where uploads land. mongoUri and port stay env driven, so a deploy overrides them without
+// editing this file.
+export interface EkoConfig {
+  app: string | AppEntry;
+  clientDir?: string;
+  assetsDir?: string;
+  fileDir?: string;
+}
+
+// Identity, but typed: a consumer writes `export default defineConfig({ ... })` and gets
+// autocomplete and a compile error on a wrong or missing key. Wired in the green step.
+export function defineConfig(_config: EkoConfig): EkoConfig {
+  throw new Error('defineConfig not implemented');
+}

--- a/server/run.ts
+++ b/server/run.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { type App } from './app.ts';
+import { type ServerOptions } from './index.ts';
 import { type Publications } from './logic/publications.ts';
 import { type Methods } from './logic/methods.ts';
 import { type Files } from './logic/files.ts';
@@ -66,4 +67,12 @@ export async function resolveEntry(config: EkoConfig, dir: string): Promise<AppE
   const href = pathToFileURL(resolve(dir, config.app)).href;
   const mod = (await import(href)) as { default: AppEntry };
   return mod.default;
+}
+
+// Turn the assembled app and the project's config into the options createServer wants: the
+// app's own wiring, plus the built client resolved to an absolute staticRoot. No clientDir
+// means no static handler, which createServer reads as an honest "serves nothing". Wired in
+// the green step.
+export function buildServerOptions(_app: App, _config: EkoConfig, _dir: string): ServerOptions {
+  throw new Error('buildServerOptions not implemented');
 }

--- a/server/run.ts
+++ b/server/run.ts
@@ -1,0 +1,25 @@
+import { type App } from './app.ts';
+import { type Publications } from './logic/publications.ts';
+import { type Methods } from './logic/methods.ts';
+import { type Files } from './logic/files.ts';
+import { type ScriptRunnerWrapper } from './infrastructure/scriptRunner.ts';
+
+// The narrow surface a developer's app entry defines against. It exposes what you define
+// (publications, methods, files, scriptRunner) and nothing else, so the runner's lifecycle
+// (armShutdown, close, mongo, proc) stays the runner's.
+export interface AppContext {
+  publications: Publications;
+  methods: Methods;
+  files: Files;
+  scriptRunner: ScriptRunnerWrapper;
+}
+
+// A developer's app entry: a function the runner calls with the context, where the app
+// registers its publications and methods. The default export of their app module.
+export type AppEntry = (eko: AppContext) => void;
+
+// Run the app entry against the app the runner assembled, so the entry's definitions land
+// on the registries the runner is about to serve. Wired in the green step.
+export function applyAppEntry(_app: App, _entry: AppEntry): void {
+  throw new Error('applyAppEntry not implemented');
+}

--- a/server/run.ts
+++ b/server/run.ts
@@ -15,6 +15,10 @@ export interface AppContext {
   methods: Methods;
   files: Files;
   scriptRunner: ScriptRunnerWrapper;
+  // Resolve a bundled asset (a script, a fixture) to an absolute path, against the config's
+  // assetsDir. The equivalent of Meteor's Assets.absoluteFilePath: an app ships countC.py
+  // and asks the runner where it landed rather than hardcoding a path.
+  asset: (name: string) => string;
 }
 
 // A developer's app entry: a function the runner calls with the context, where the app
@@ -23,12 +27,19 @@ export type AppEntry = (eko: AppContext) => void;
 
 // Run the app entry against the app the runner assembled, so the entry's definitions land
 // on the registries the runner is about to serve. Wired in the green step.
-export function applyAppEntry(app: App, entry: AppEntry): void {
+export function applyAppEntry(
+  app: App,
+  entry: AppEntry,
+  _options: { assetsDir?: string } = {},
+): void {
   entry({
     publications: app.publications,
     methods: app.methods,
     files: app.files,
     scriptRunner: app.scriptRunner,
+    asset: () => {
+      throw new Error('asset not implemented');
+    },
   });
 }
 

--- a/server/run.ts
+++ b/server/run.ts
@@ -20,6 +20,6 @@ export type AppEntry = (eko: AppContext) => void;
 
 // Run the app entry against the app the runner assembled, so the entry's definitions land
 // on the registries the runner is about to serve. Wired in the green step.
-export function applyAppEntry(_app: App, _entry: AppEntry): void {
-  throw new Error('applyAppEntry not implemented');
+export function applyAppEntry(app: App, entry: AppEntry): void {
+  entry(app);
 }

--- a/server/run.ts
+++ b/server/run.ts
@@ -30,15 +30,19 @@ export type AppEntry = (eko: AppContext) => void;
 export function applyAppEntry(
   app: App,
   entry: AppEntry,
-  _options: { assetsDir?: string } = {},
+  options: { assetsDir?: string } = {},
 ): void {
+  const { assetsDir } = options;
   entry({
     publications: app.publications,
     methods: app.methods,
     files: app.files,
     scriptRunner: app.scriptRunner,
-    asset: () => {
-      throw new Error('asset not implemented');
+    asset: (name) => {
+      if (assetsDir === undefined) {
+        throw new Error(`Cannot resolve asset "${name}": no assetsDir configured`);
+      }
+      return resolve(assetsDir, name);
     },
   });
 }

--- a/server/run.ts
+++ b/server/run.ts
@@ -73,6 +73,15 @@ export async function resolveEntry(config: EkoConfig, dir: string): Promise<AppE
 // app's own wiring, plus the built client resolved to an absolute staticRoot. No clientDir
 // means no static handler, which createServer reads as an honest "serves nothing". Wired in
 // the green step.
-export function buildServerOptions(_app: App, _config: EkoConfig, _dir: string): ServerOptions {
-  throw new Error('buildServerOptions not implemented');
+export function buildServerOptions(app: App, config: EkoConfig, dir: string): ServerOptions {
+  const base: ServerOptions = {
+    ws: app.ws,
+    publications: app.publications,
+    rpcHandler: app.rpcHandler,
+    files: app.files,
+  };
+  if (config.clientDir === undefined) {
+    return base;
+  }
+  return { ...base, staticRoot: resolve(dir, config.clientDir) };
 }

--- a/server/run.ts
+++ b/server/run.ts
@@ -21,5 +21,10 @@ export type AppEntry = (eko: AppContext) => void;
 // Run the app entry against the app the runner assembled, so the entry's definitions land
 // on the registries the runner is about to serve. Wired in the green step.
 export function applyAppEntry(app: App, entry: AppEntry): void {
-  entry(app);
+  entry({
+    publications: app.publications,
+    methods: app.methods,
+    files: app.files,
+    scriptRunner: app.scriptRunner,
+  });
 }

--- a/server/run.ts
+++ b/server/run.ts
@@ -1,7 +1,8 @@
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { type App } from './app.ts';
-import { type ServerOptions } from './index.ts';
+import { App, type AppConfig } from './app.ts';
+import { createServer, type ServerOptions } from './index.ts';
+import { READY_MESSAGE } from '../shared/serverMessages.ts';
 import { type Publications } from './logic/publications.ts';
 import { type Methods } from './logic/methods.ts';
 import { type Files } from './logic/files.ts';
@@ -84,4 +85,29 @@ export function buildServerOptions(app: App, config: EkoConfig, dir: string): Se
     return base;
   }
   return { ...base, staticRoot: resolve(dir, config.clientDir) };
+}
+
+// The full boot `ekolite run` performs, in the developer's project directory: read the
+// config, assemble the App against real infrastructure, apply the app's own definitions,
+// serve it over Fastify with the app's client, arm graceful shutdown, and announce
+// readiness. This is start.ts done from a developer's config rather than by hand; the
+// runtime knobs (mongoUri, port) stay in the environment so a deploy overrides them.
+export async function runApp(dir: string = process.cwd()): Promise<void> {
+  const config = await loadConfig(dir);
+  const entry = await resolveEntry(config, dir);
+
+  const appConfig: AppConfig = {
+    mongoUri: process.env.MONGO_URI ?? 'mongodb://localhost:27017/ekolite',
+    fileDir: config.fileDir ?? process.env.FILE_DIR ?? './uploads',
+    port: Number(process.env.EKOLITE_PORT ?? process.env.PORT ?? 3001),
+  };
+  const app = App.create(appConfig);
+
+  const assetsDir = config.assetsDir === undefined ? undefined : resolve(dir, config.assetsDir);
+  applyAppEntry(app, entry, assetsDir === undefined ? {} : { assetsDir });
+
+  const server = await createServer(buildServerOptions(app, config, dir));
+  await server.listen({ port: appConfig.port, host: '0.0.0.0' });
+  app.armShutdown();
+  process.stdout.write(`${READY_MESSAGE} http://localhost:${String(appConfig.port)}\n`);
 }

--- a/server/run.ts
+++ b/server/run.ts
@@ -3,6 +3,7 @@ import { type Publications } from './logic/publications.ts';
 import { type Methods } from './logic/methods.ts';
 import { type Files } from './logic/files.ts';
 import { type ScriptRunnerWrapper } from './infrastructure/scriptRunner.ts';
+import { type EkoConfig } from './config.ts';
 
 // The narrow surface a developer's app entry defines against. It exposes what you define
 // (publications, methods, files, scriptRunner) and nothing else, so the runner's lifecycle
@@ -27,4 +28,16 @@ export function applyAppEntry(app: App, entry: AppEntry): void {
     files: app.files,
     scriptRunner: app.scriptRunner,
   });
+}
+
+// Discovery: the runner finds a developer's app by convention, an `ekolite.config.ts` at
+// the project root, and returns its default-exported config. Wired in the green step.
+export function loadConfig(_dir: string): Promise<EkoConfig> {
+  return Promise.reject(new Error('loadConfig not implemented'));
+}
+
+// Resolve the config's `app` to the entry function: a path is imported from the project,
+// a function is used as-is. Wired in the green step.
+export function resolveEntry(_config: EkoConfig, _dir: string): Promise<AppEntry> {
+  return Promise.reject(new Error('resolveEntry not implemented'));
 }

--- a/server/run.ts
+++ b/server/run.ts
@@ -1,3 +1,5 @@
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { type App } from './app.ts';
 import { type Publications } from './logic/publications.ts';
 import { type Methods } from './logic/methods.ts';
@@ -31,13 +33,22 @@ export function applyAppEntry(app: App, entry: AppEntry): void {
 }
 
 // Discovery: the runner finds a developer's app by convention, an `ekolite.config.ts` at
-// the project root, and returns its default-exported config. Wired in the green step.
-export function loadConfig(_dir: string): Promise<EkoConfig> {
-  return Promise.reject(new Error('loadConfig not implemented'));
+// the project root, and returns its default-exported config. The import resolves the file
+// through Node's own module loader, which strips the types (Node 24) or hands off to a
+// registered loader, so no build step stands between the developer and `ekolite run`.
+export async function loadConfig(dir: string): Promise<EkoConfig> {
+  const href = pathToFileURL(resolve(dir, 'ekolite.config.ts')).href;
+  const mod = (await import(href)) as { default: EkoConfig };
+  return mod.default;
 }
 
-// Resolve the config's `app` to the entry function: a path is imported from the project,
-// a function is used as-is. Wired in the green step.
-export function resolveEntry(_config: EkoConfig, _dir: string): Promise<AppEntry> {
-  return Promise.reject(new Error('resolveEntry not implemented'));
+// Resolve the config's `app` to the entry function: a path is imported from the project
+// (relative to the config's directory), a function is used as-is.
+export async function resolveEntry(config: EkoConfig, dir: string): Promise<AppEntry> {
+  if (typeof config.app === 'function') {
+    return config.app;
+  }
+  const href = pathToFileURL(resolve(dir, config.app)).href;
+  const mod = (await import(href)) as { default: AppEntry };
+  return mod.default;
 }

--- a/tests/fixtures/run/app.ts
+++ b/tests/fixtures/run/app.ts
@@ -1,0 +1,8 @@
+import { type AppEntry } from '../../../server/run.ts';
+
+// A fixture app entry, the shape a developer's app module default-exports.
+const entry: AppEntry = (eko) => {
+  eko.methods.define('ping', () => Promise.resolve('pong'));
+};
+
+export default entry;

--- a/tests/fixtures/run/ekolite.config.ts
+++ b/tests/fixtures/run/ekolite.config.ts
@@ -1,0 +1,4 @@
+import { defineConfig } from '../../../server/config.ts';
+
+// A fixture ekolite.config.ts, the shape a developer's project root carries.
+export default defineConfig({ app: './app.ts', clientDir: './dist/client' });

--- a/tests/server/config.test.ts
+++ b/tests/server/config.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { defineConfig } from '../../server/config.ts';
+
+describe('defineConfig', () => {
+  it('returns the config it is given', () => {
+    const config = defineConfig({ app: './server/app.ts', clientDir: './dist/client' });
+
+    expect(config).toEqual({ app: './server/app.ts', clientDir: './dist/client' });
+  });
+});

--- a/tests/server/run.boot.test.ts
+++ b/tests/server/run.boot.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { App } from '../../server/app.ts';
+import { buildServerOptions } from '../../server/run.ts';
+
+describe('ekolite run - assembling the server', () => {
+  it('wires the app into createServer options with the static root resolved from the project', () => {
+    const app = App.createNull();
+
+    const options = buildServerOptions(
+      app,
+      { app: './app.ts', clientDir: './dist/client' },
+      '/proj',
+    );
+
+    expect(options.ws).toBe(app.ws);
+    expect(options.publications).toBe(app.publications);
+    expect(options.rpcHandler).toBe(app.rpcHandler);
+    expect(options.files).toBe(app.files);
+    expect(options.staticRoot).toBe('/proj/dist/client');
+  });
+
+  it('omits the static root when no clientDir is configured', () => {
+    const app = App.createNull();
+
+    const options = buildServerOptions(app, { app: './app.ts' }, '/proj');
+
+    expect('staticRoot' in options).toBe(false);
+  });
+});

--- a/tests/server/run.load.test.ts
+++ b/tests/server/run.load.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { App } from '../../server/app.ts';
+import { applyAppEntry, loadConfig, resolveEntry, type AppEntry } from '../../server/run.ts';
+
+const FIXTURE = fileURLToPath(new URL('../fixtures/run', import.meta.url));
+
+describe('ekolite run - loading a project', () => {
+  it('loads the config from the project directory', async () => {
+    const config = await loadConfig(FIXTURE);
+
+    expect(config.clientDir).toBe('./dist/client');
+  });
+
+  it('resolves an app entry given as a path by importing it', async () => {
+    const entry = await resolveEntry({ app: './app.ts' }, FIXTURE);
+    const app = App.createNull();
+
+    applyAppEntry(app, entry);
+
+    await expect(app.methods.call('ping', [])).resolves.toBe('pong');
+  });
+
+  it('resolves an inline function entry as itself', async () => {
+    const fn: AppEntry = (eko) => {
+      eko.methods.define('noop', () => Promise.resolve(null));
+    };
+
+    await expect(resolveEntry({ app: fn }, FIXTURE)).resolves.toBe(fn);
+  });
+});

--- a/tests/server/run.test.ts
+++ b/tests/server/run.test.ts
@@ -30,6 +30,21 @@ describe('ekolite run - applying an app entry', () => {
     });
 
     // Only what you define against, so armShutdown, close, mongo and proc stay the runner's.
-    expect(keys.sort()).toEqual(['files', 'methods', 'publications', 'scriptRunner']);
+    expect(keys.sort()).toEqual(['asset', 'files', 'methods', 'publications', 'scriptRunner']);
+  });
+
+  it('resolves an asset path against the assets directory', () => {
+    const app = App.createNull();
+    let resolved = '';
+
+    applyAppEntry(
+      app,
+      (eko) => {
+        resolved = eko.asset('countC.py');
+      },
+      { assetsDir: '/proj/scripts' },
+    );
+
+    expect(resolved).toBe('/proj/scripts/countC.py');
   });
 });

--- a/tests/server/run.test.ts
+++ b/tests/server/run.test.ts
@@ -20,4 +20,16 @@ describe('ekolite run - applying an app entry', () => {
 
     await expect(app.methods.call('greet', ['world'])).resolves.toBe('hi world');
   });
+
+  it('gives the entry a narrow context, not the whole app', () => {
+    const app = App.createNull();
+    const keys: string[] = [];
+
+    applyAppEntry(app, (eko) => {
+      keys.push(...Object.keys(eko));
+    });
+
+    // Only what you define against, so armShutdown, close, mongo and proc stay the runner's.
+    expect(keys.sort()).toEqual(['files', 'methods', 'publications', 'scriptRunner']);
+  });
 });

--- a/tests/server/run.test.ts
+++ b/tests/server/run.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { App } from '../../server/app.ts';
+import { applyAppEntry } from '../../server/run.ts';
+
+// The seam of `ekolite run`. The runner owns App.create; the developer's app entry
+// only defines. applyAppEntry is where the two meet: the runner calls the entry with a
+// narrow context backed by the assembled app's own registries, so whatever the entry
+// defines is defined on the app the runner is about to serve.
+//
+// Narrow on purpose: the context exposes what you define against (publications, methods,
+// files, scriptRunner) and nothing else, so armShutdown, close, mongo and proc stay the
+// runner's. This first red pins the happy path; a follow-up red pins the narrowness.
+describe('ekolite run - applying an app entry', () => {
+  it('calls the entry with the app registries so its methods are callable', async () => {
+    const app = App.createNull();
+
+    applyAppEntry(app, (eko) => {
+      eko.methods.define('greet', (name) => Promise.resolve(`hi ${String(name)}`));
+    });
+
+    await expect(app.methods.call('greet', ['world'])).resolves.toBe('hi world');
+  });
+});


### PR DESCRIPTION
## What

`ekolite run` boots a developer's own app from an `ekolite.config.ts`, with no `start.ts` to copy. EKO-309.

The seam, settled: the app exports `(eko) => void`, and the runner calls it with a **narrow context** `{ publications, methods, files, scriptRunner, asset }`, so the runner's lifecycle (`armShutdown`, `close`, `mongo`, `proc`) stays the runner's. Discovery is by **config file** (`ekolite.config.ts`), the option we weighed as cleanest since the app needs `clientDir` and `assetsDir` too, not just an entry path.

A developer's project ends up as:

```ts
// ekolite.config.ts
import { defineConfig } from 'ekolite/config';
export default defineConfig({ app: './server/app.ts', clientDir: './dist/client', assetsDir: './scripts' });
```
```ts
// server/app.ts
import type { AppEntry } from 'ekolite'; // (eko) => void
const app: AppEntry = (eko) => {
  eko.publications.define('files.all', () => ({ collection: 'files', query: {} }));
  eko.methods.define('runCountC', async (id) => { /* eko.files, eko.scriptRunner, eko.asset('countC.py') */ });
};
export default app;
```
```
$ npx ekolite run
ekolite: ready on http://localhost:3001
```

## Built test first, red then green

- `applyAppEntry` runs the entry against the assembled app
- the entry gets a **narrow context**, not the whole `App`
- `defineConfig` returns a typed `EkoConfig`
- `loadConfig` imports `ekolite.config.ts`; `resolveEntry` loads the app (path import or inline function)
- `asset` resolves a bundled script against `assetsDir` (the `Assets.absoluteFilePath` equivalent)
- `buildServerOptions` wires the app into `createServer` and resolves the static root

Then the process shell, `runApp` and the `ekolite` bin, the same shape as `start.ts` (App.create → apply → createServer with staticRoot → listen → armShutdown → ready), covered by the acceptance rather than a unit test. TS entry loading relies on Node 24's native type stripping, so no build step and no new dependency.

Full fast suite green (298 passing), typecheck and lint clean.

## Not done yet (why this is a draft)

- **From-outside acceptance:** extend `scripts/package-smoke.mjs` with an `ekolite run` case, install the tarball, drop in a config + app + client, run the bin, assert it serves the app's own publication and method.
- **The real proof:** convert `meteorHilbert/spike/eko-server-proof.ts` to boot via `ekolite run` and pass its pipeline assertions.
- Ships in **0.3.0** together with the README fix (#145).
