### PR TITLE
chore: release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `ekolite` are recorded here. The project is pre-1.0, so a minor version may carry a breaking change.
 
+## 0.3.0
+
+### Added
+
+- **`ekolite run`.** Boot your own app from an `ekolite.config.ts`, with no `start.ts` to copy. Define your publications and methods in a `(eko) => void` app entry, and the runner assembles `App`, applies them, serves your built client, and arms graceful shutdown. Adds the `ekolite` bin (`ekolite run`) and an `ekolite/config` export (`defineConfig`, plus the `AppEntry` and `AppContext` types). TypeScript entries load through Node 24's native type stripping, so there is no build step and no new dependency. A consumer project must set `"type": "module"`. (#146)
+
 ## 0.2.0
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ekolite",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ekolite",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@fastify/multipart": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ekolite",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "bin": {
     "ekolite": "dist/server/cli.js"
   },


### PR DESCRIPTION
## Release 0.3.0

Bumps `package.json` to 0.3.0 and adds the changelog entry. Since 0.2.0: `ekolite run` (#146) and the README status truth-fix (#145).

### What ships

- **`ekolite run`**: boot your own app from an `ekolite.config.ts`, no `start.ts` to copy. A `(eko) => void` entry defines your publications and methods; the runner assembles `App`, applies them, serves your client, and arms shutdown. New `ekolite` bin and `ekolite/config` export (`defineConfig`, `AppEntry`, `AppContext`). TS entries load via Node 24 native type stripping, no build step, no new dependency. Consumer projects set `"type": "module"`.

### Verified

`npm run test:package` is green on the 0.3.0 tarball, including the new from-outside case: a throwaway project carrying only an `ekolite.config.ts` and its app entry runs the installed `ekolite run` and serves its own client. Also booted by hand from the packed tarball in a sandbox.

### To publish, after merge

From `main`: `npm publish --access public` (2FA), then tag `v0.3.0`. `prepublishOnly` re-gates typecheck, tests and build.
