### PR TITLE
ci: publish to npm on release via OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+name: Publish to npm
+
+# Publishes to npm when a GitHub Release is published. Auth is OIDC trusted publishing, no
+# stored token: npmjs.com is configured to trust this repo, this workflow and the `release`
+# environment. prepublishOnly re-runs typecheck, tests and build as the gate before it ships.
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: release # must match the Environment name set on the npm trusted publisher
+    permissions:
+      contents: read
+      id-token: write # OIDC for trusted publishing and provenance
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: 'Setup Node.js'
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: 'Update npm (trusted publishing needs >= 11.5)'
+        run: npm install -g npm@latest
+
+      - name: 'Install dependencies'
+        run: npm ci
+
+      - name: 'Publish to npm'
+        run: npm publish --provenance --access public


### PR DESCRIPTION
Adds `.github/workflows/publish.yml`. On a published GitHub Release it runs npm ci and `npm publish --provenance --access public`, authenticated by OIDC trusted publishing (no stored token), gated on the `release` environment.

Must be on `main` before creating a release, since release events only trigger workflows on the default branch. This missed the 0.3.0 release PR (#147) merge, so it comes on its own.

After merge: create the `release` environment in repo settings (optionally with a required reviewer), then cut the GitHub Release for v0.3.0 to fire the first automated publish.