### PR TITLE
fix: repoint the lockfile off the npmmirror mirror

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7922,7 +7922,7 @@
     },
     "node_modules/ws": {
       "version": "8.20.1",
-      "resolved": "https://registry.npmmirror.com/ws/-/ws-8.20.1.tgz",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
       "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
The 0.3.0 publish workflow failed at `npm ci` with `EALLOWREMOTE ... Refusing to fetch ws@https://registry.npmmirror.com/...`.

One `package-lock.json` entry (ws@8.20.1) resolved to `registry.npmmirror.com`, left there by an install against a mirror; the other 550 are already `registry.npmjs.org`. Newer npm refuses to fetch a non-registry remote tarball, so `npm ci` dies in CI.

Repoints that one URL at `registry.npmjs.org`. The integrity hash is unchanged (the mirror serves the identical file), verified locally with `npm ci`.

After merge, the v0.3.0 release needs recutting at the fixed commit so the publish re-runs against a clean lockfile.