### PR TITLE
fix: the client tolerates subscribing before the socket opens

### DIFF
--- a/client/clientSocket.ts
+++ b/client/clientSocket.ts
@@ -188,7 +188,18 @@ class NullWebSocket implements WebSocketLike {
   }
 
   send(_data: string): void {
-    // No network. The wrapper has already emitted EVENT_OUTBOUND for tracking.
+    if (this.readyState === NullWebSocket.CONNECTING) {
+      // A real WebSocket throws when asked to send before it opens. The null
+      // mirrors that exactly, so a send-before-open is caught by a test rather
+      // than hiding behind a no-op and only surfacing in a browser.
+      throw new DOMException(
+        "Failed to execute 'send' on 'WebSocket': Still in CONNECTING state.",
+        'InvalidStateError',
+      );
+    }
+    // Open or closed: no network to write to, and a real socket past CONNECTING
+    // does not throw either. The wrapper has already emitted EVENT_OUTBOUND for
+    // tracking.
   }
 
   close(): void {

--- a/client/connectionManager.ts
+++ b/client/connectionManager.ts
@@ -116,6 +116,15 @@ export class ConnectionManager {
   call(name: string, ...args: unknown[]): Promise<unknown> {
     this.assertNotDisposed();
 
+    // A call cannot be sent before the socket is open, and unlike a
+    // subscription it is not held and replayed on connect: its result would
+    // die with any later disconnect anyway. So reject rather than push it at a
+    // connecting socket or leave the caller waiting for a reply that can never
+    // come.
+    if (!this.socket.isConnected) {
+      return Promise.reject(new Error(`cannot call '${name}' before the connection is open`));
+    }
+
     const id = generateSubscriptionId();
 
     const promise = new Promise<unknown>((resolve, reject) => {

--- a/client/connectionManager.ts
+++ b/client/connectionManager.ts
@@ -155,17 +155,24 @@ export class ConnectionManager {
       readyRejector: rejectReady,
     });
 
-    const subscribeMessage: SubscribeMsg = {
-      type: 'subscribe',
-      id,
-      name,
-      ...(params ? { params } : {}),
-    };
+    // The frame goes out now only if the socket is open. While it is still
+    // connecting the subscription waits in the map, and resubscribeAll()
+    // replays it when the socket opens. That keeps subscribe() safe to call
+    // before the connection is up, as a React mount effect does at cold load
+    // and during every reconnect gap.
+    if (this.socket.isConnected) {
+      const subscribeMessage: SubscribeMsg = {
+        type: 'subscribe',
+        id,
+        name,
+        ...(params ? { params } : {}),
+      };
 
-    this.socket.send(subscribeMessage).catch((error: unknown) => {
-      this.subscriptions.delete(id);
-      rejectReady(error);
-    });
+      this.socket.send(subscribeMessage).catch((error: unknown) => {
+        this.subscriptions.delete(id);
+        rejectReady(error);
+      });
+    }
 
     return new SubscriptionHandleImpl(this, id, ready);
   }

--- a/client/connectionManager.ts
+++ b/client/connectionManager.ts
@@ -178,8 +178,6 @@ export class ConnectionManager {
   }
 
   stopSubscription(id: string): void {
-    const unsubscribeMessage: UnsubscribeMsg = { type: 'unsubscribe', id };
-
     const subscription = this.subscriptions.get(id);
 
     if (subscription) {
@@ -188,9 +186,16 @@ export class ConnectionManager {
 
     this.subscriptions.delete(id);
 
-    this.socket.send(unsubscribeMessage).catch((error: unknown) => {
-      console.error('Failed to send unsubscribe message:', error);
-    });
+    // Only unsubscribe from a subscription the socket actually carried. If we
+    // are not connected it was either held before open and never sent, or
+    // already dropped by the disconnect; either way resubscribeAll() no longer
+    // sees it, so there is nothing to take back.
+    if (this.socket.isConnected) {
+      const unsubscribeMessage: UnsubscribeMsg = { type: 'unsubscribe', id };
+      this.socket.send(unsubscribeMessage).catch((error: unknown) => {
+        console.error('Failed to send unsubscribe message:', error);
+      });
+    }
   }
 
   store(collection: string): ReactiveStore {

--- a/tests/client/clientSocket.beforeOpen.test.ts
+++ b/tests/client/clientSocket.beforeOpen.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { ClientSocketWrapper } from '../../client/clientSocket.ts';
+
+// The null socket has to behave like the real WebSocket it stands in for. A
+// real WebSocket.send() throws InvalidStateError while the socket is still
+// CONNECTING; a no-op null hides that, which is exactly how subscribing before
+// the socket opened stayed green in the suite while it threw in a browser. So
+// the null throws too, and any code that sends before open is caught here
+// rather than in production.
+describe('ClientSocketWrapper — sending before the socket opens', () => {
+  it('throws InvalidStateError, like a real WebSocket that is still connecting', () => {
+    const socket = ClientSocketWrapper.createNull();
+
+    let thrown: unknown;
+    try {
+      void socket.send({ type: 'ping' });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(DOMException);
+    expect((thrown as DOMException).name).toBe('InvalidStateError');
+  });
+
+  it('sends without throwing once the socket is open', async () => {
+    const socket = ClientSocketWrapper.createNull();
+    await socket.connect();
+
+    expect(() => {
+      void socket.send({ type: 'ping' });
+    }).not.toThrow();
+  });
+});

--- a/tests/client/connectionManager.beforeOpen.test.ts
+++ b/tests/client/connectionManager.beforeOpen.test.ts
@@ -60,3 +60,36 @@ describe('ConnectionManager — subscribing before the socket opens', () => {
     expect(messages.data).toHaveLength(0);
   });
 });
+
+// A method call is not a subscription: it is not held and replayed on connect,
+// because its result would have died with the connection anyway. So a call made
+// before the socket opens settles as a rejection rather than throwing at the
+// call site or hanging forever waiting for a reply that can never come.
+describe('ConnectionManager — calling before the socket opens', () => {
+  it('rejects a method call made before the socket opens', async () => {
+    const socket = ClientSocketWrapper.createNull();
+    const manager = new ConnectionManager(socket);
+    const messages = socket.trackMessages();
+
+    const pending = manager.call('files.rename', 'a.bam');
+
+    // Race a short timer so a hang fails fast and clearly rather than via the
+    // suite timeout. The rejection handler keeps a correct rejection from going
+    // unhandled.
+    const outcome = await Promise.race([
+      pending.then(
+        () => 'resolved',
+        () => 'rejected',
+      ),
+      new Promise<string>((resolve) => {
+        setTimeout(() => {
+          resolve('pending');
+        }, 50);
+      }),
+    ]);
+
+    expect(outcome).toBe('rejected');
+    // Nothing was pushed at the connecting socket.
+    expect(messages.data).toHaveLength(0);
+  });
+});

--- a/tests/client/connectionManager.beforeOpen.test.ts
+++ b/tests/client/connectionManager.beforeOpen.test.ts
@@ -39,4 +39,24 @@ describe('ConnectionManager — subscribing before the socket opens', () => {
 
     expect(manager.store('files').getById('1')).toEqual({ _id: '1', name: 'existing.bam' });
   });
+
+  it('stopping a subscription made before open sends no unsubscribe and cleans up', async () => {
+    const socket = ClientSocketWrapper.createNull();
+    const manager = new ConnectionManager(socket);
+    const messages = socket.trackMessages();
+
+    const handle = manager.subscribe('files.all');
+    handle.stop();
+
+    // The subscription never reached the socket, so there is nothing to
+    // unsubscribe: no frame is sent, and none is pushed at the connecting
+    // socket. ready settles as a rejection and the bookkeeping is released.
+    expect(messages.data).toHaveLength(0);
+    expect(manager.activeSubscriptionCount()).toBe(0);
+    await expect(handle.ready).rejects.toThrow('subscription stopped before ready');
+
+    // When the socket finally opens, the stopped subscription is not replayed.
+    await socket.connect();
+    expect(messages.data).toHaveLength(0);
+  });
 });

--- a/tests/client/connectionManager.beforeOpen.test.ts
+++ b/tests/client/connectionManager.beforeOpen.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { ClientSocketWrapper } from '../../client/clientSocket.ts';
+import { ConnectionManager } from '../../client/connectionManager.ts';
+import { SubscribeMsg } from '../../shared/protocol.ts';
+
+// A React component subscribes from its mount effect, which fires while the
+// socket is still CONNECTING at cold load and during every reconnect gap. So
+// subscribing before the socket is open must be safe: no throw, and the frame
+// waits for the connection rather than being pushed at a socket that cannot
+// take it.
+describe('ConnectionManager — subscribing before the socket opens', () => {
+  it('holds the subscribe frame until the socket opens, then sends it once and delivers', async () => {
+    const socket = ClientSocketWrapper.createNull();
+    const manager = new ConnectionManager(socket);
+    const messages = socket.trackMessages();
+    const server = socket.simulateServer();
+
+    // Subscribing before the connection is up must not throw and must return a
+    // usable handle.
+    const handle = manager.subscribe('files.all');
+    expect(manager.activeSubscriptionCount()).toBe(1);
+
+    // Nothing goes on the wire while the socket is still CONNECTING; the
+    // subscription is held, waiting for the socket to open.
+    expect(messages.data).toHaveLength(0);
+
+    await socket.connect();
+
+    // On open the held subscription is replayed exactly once, with its id and
+    // name intact.
+    expect(messages.data).toHaveLength(1);
+    const sent = messages.data[0] as SubscribeMsg;
+    expect(sent.type).toBe('subscribe');
+    expect(sent.name).toBe('files.all');
+
+    server.send({ type: 'added', collection: 'files', id: '1', fields: { name: 'existing.bam' } });
+    server.send({ type: 'ready', id: sent.id, collection: 'files' });
+    await handle.ready;
+
+    expect(manager.store('files').getById('1')).toEqual({ _id: '1', name: 'existing.bam' });
+  });
+});

--- a/tests/client/connectionManager.call.test.ts
+++ b/tests/client/connectionManager.call.test.ts
@@ -10,6 +10,7 @@ describe('ClientSocketWrapper call', () => {
     const manager = new ConnectionManager(socket);
     const messages = socket.trackMessages();
     const server = socket.simulateServer();
+    await socket.connect();
 
     const result = manager.call('echo', 'hello');
 
@@ -27,6 +28,7 @@ describe('ClientSocketWrapper call', () => {
     const manager = new ConnectionManager(socket);
     const messages = socket.trackMessages();
     const server = socket.simulateServer();
+    await socket.connect();
 
     const result = manager.call('nope');
 
@@ -51,6 +53,7 @@ describe('ClientSocketWrapper call', () => {
     const socket = ClientSocketWrapper.createNull();
     const manager = new ConnectionManager(socket);
     const server = socket.simulateServer();
+    await socket.connect();
 
     // A call whose reply will never come, because the socket drops first.
     const result = manager.call('slow');
@@ -81,6 +84,7 @@ describe('ClientSocketWrapper call', () => {
     const server = socket.simulateServer();
     const manager = new ConnectionManager(socket);
     const messages = socket.trackMessages();
+    await socket.connect();
 
     const call = manager.call('missingMethod');
 

--- a/tests/client/connectionManager.collectionGate.test.ts
+++ b/tests/client/connectionManager.collectionGate.test.ts
@@ -16,6 +16,7 @@ describe('ConnectionManager collection gate', () => {
     const manager = new ConnectionManager(socket);
     const messages = socket.trackMessages();
     const store = manager.store('files');
+    await socket.connect();
 
     // A publication named for what it returns, not for its collection. On the
     // server this maps to { collection: 'files', query: {...} }.
@@ -44,6 +45,7 @@ describe('ConnectionManager collection gate', () => {
     const manager = new ConnectionManager(socket);
     const messages = socket.trackMessages();
     const store = manager.store('archive');
+    await socket.connect();
 
     // Dotted name, but the first segment ('files') is not the collection the
     // publication reads from ('archive').
@@ -75,6 +77,7 @@ describe('ConnectionManager collection gate', () => {
     const messages = socket.trackMessages();
     const files = manager.store('files');
     const archive = manager.store('archive');
+    await socket.connect();
 
     // Both subscriptions are outstanding before any server reply, and neither
     // publication name starts with the collection it actually reads from.
@@ -130,6 +133,7 @@ describe('ConnectionManager learns its collection from ready', () => {
     const manager = new ConnectionManager(socket);
     const messages = socket.trackMessages();
     const store = manager.store('files');
+    await socket.connect();
 
     const handle = manager.subscribe('recentFiles');
     const subId = (messages.data[0] as SubscribeMsg).id;

--- a/tests/client/connectionManager.socketClose.test.ts
+++ b/tests/client/connectionManager.socketClose.test.ts
@@ -12,6 +12,7 @@ describe('ConnectionManager - after the socket dies unexpectedly', () => {
     const server = socket.simulateServer();
     const manager = new ConnectionManager(socket);
     const messages = socket.trackMessages();
+    await socket.connect();
 
     const handle = manager.subscribe('files.all');
     server.send({ type: 'ready', id: (messages.data[0] as SubscribeMsg).id, collection: 'files' });

--- a/tests/client/connectionManager.socketClose.test.ts
+++ b/tests/client/connectionManager.socketClose.test.ts
@@ -28,6 +28,7 @@ describe('ConnectionManager - after the socket dies unexpectedly', () => {
     const socket = ClientSocketWrapper.createNull();
     const server = socket.simulateServer();
     const manager = new ConnectionManager(socket);
+    await socket.connect();
 
     const pending = manager.call('files.rename', 'a.bam');
     server.simulateClose();

--- a/tests/client/connectionManager.test.ts
+++ b/tests/client/connectionManager.test.ts
@@ -10,6 +10,7 @@ describe('ConnectionManager', () => {
     const manager = new ConnectionManager(socket);
     const messages = socket.trackMessages();
     const server = socket.simulateServer();
+    await socket.connect();
 
     const handle = manager.subscribe('files.all');
 
@@ -38,6 +39,7 @@ describe('ConnectionManager', () => {
     const manager = new ConnectionManager(socket);
     const messages = socket.trackMessages();
     const server = socket.simulateServer();
+    await socket.connect();
 
     const handle = manager.subscribe('files.byFolder', { folderId: 'folder-a' });
 
@@ -59,6 +61,7 @@ describe('ConnectionManager', () => {
     const server = socket.simulateServer();
     const manager = new ConnectionManager(socket);
     const messages = socket.trackMessages();
+    await socket.connect();
 
     const handle = manager.subscribe('nope');
     const sent = messages.data[0] as SubscribeMsg;
@@ -77,6 +80,7 @@ describe('ConnectionManager', () => {
     const server = socket.simulateServer();
     const manager = new ConnectionManager(socket);
     const messages = socket.trackMessages();
+    await socket.connect();
 
     const handle = manager.subscribe('nope');
     const sent = messages.data[0] as SubscribeMsg;
@@ -99,6 +103,7 @@ describe('ConnectionManager', () => {
     const server = socket.simulateServer();
     const manager = new ConnectionManager(socket);
     const messages = socket.trackMessages();
+    await socket.connect();
 
     const handle = manager.subscribe('files.all');
     const subId = (messages.data[0] as SubscribeMsg).id;
@@ -136,6 +141,7 @@ describe('ConnectionManager', () => {
     const manager = new ConnectionManager(socket);
     const messages = socket.trackMessages();
     const store = manager.store('files');
+    await socket.connect();
 
     const handle = manager.subscribe('files.all');
     server.send({ type: 'ready', id: (messages.data[0] as SubscribeMsg).id, collection: 'files' });
@@ -160,6 +166,7 @@ describe('ConnectionManager', () => {
     const manager = new ConnectionManager(socket);
     const messages = socket.trackMessages();
     const server = socket.simulateServer();
+    await socket.connect();
 
     const handle = manager.subscribe('files.all');
     const subId = (messages.data[0] as SubscribeMsg).id;
@@ -187,6 +194,7 @@ describe('ConnectionManager', () => {
     const manager = new ConnectionManager(socket);
     const messages = socket.trackMessages();
     const store = manager.store('files');
+    await socket.connect();
 
     const handle = manager.subscribe('files.all');
     const subId = (messages.data[0] as SubscribeMsg).id;
@@ -222,6 +230,7 @@ describe('ConnectionManager', () => {
     const manager = new ConnectionManager(socket);
     const messages = socket.trackMessages();
     const store = manager.store('files');
+    await socket.connect();
 
     const handle = manager.subscribe('files.all');
     const subId = (messages.data[0] as SubscribeMsg).id;


### PR DESCRIPTION
## Why

The React `useSubscription` hook (#114) subscribes from a mount effect, which fires while the socket is still connecting at cold load and during every reconnect gap. `ConnectionManager.subscribe()` pushed its frame at the socket the moment it was called, and on a real WebSocket `send()` throws `InvalidStateError` while the socket is still CONNECTING. Because `ClientSocketWrapper.send` is synchronous, that throw escaped the `.catch` and, with no error boundary, unmounted the tree. So the hook could not subscribe on mount, which is the whole point of a hook.

It stayed invisible because the null socket's `send` was a no op in every state, so the suite never saw the throw a browser would. Several existing tests subscribed before connecting and passed only because of that.

## What changed, in the order it landed

**1. A subscribe made before open waits for the socket.** `subscribe()` puts its frame on the wire only when the socket is open. Otherwise the subscription sits in the map and `resubscribeAll()` replays it when the socket opens, exactly once. It is the same path a reconnect already used, so subscribing before the first open now works the way catching up after a drop does.

**2. Stop takes back only what the socket carried.** `stopSubscription()` sends an unsubscribe only when connected. A subscription still held before open, or one already dropped by a disconnect, has nothing on the server to take back, so there is no frame to push at a socket that cannot take it.

**3. A call made before open rejects.** Unlike a subscription, a method call is not held and replayed: its result would die with any later disconnect anyway. So it settles as a rejection rather than throwing at the call site or hanging forever waiting for a reply that can never come.

**4. The null socket tells the truth.** `NullWebSocket.send` now throws `InvalidStateError` while connecting, exactly as a real WebSocket does. That is the change that stops this whole class of bug from hiding: a send before open is now caught by a test rather than surfacing only in a browser. The existing manager tests that leaned on the old no op now connect first, which is the contract they always should have stated.

## Testing

- Unit suite green (client 129, full 303 plus the one expected fail).
- Real socket integration green, including reconnect and resubscribe over a live server.
- The before open tests run against the now faithful null, so a socket that throws on a connecting send proves the fix end to end.

The hook in #114 needs no changes: once the manager tolerates a subscribe before open, `useSubscription` is a safe drop in with no app level gating. #114 rebases onto this once it lands.
