### PR TITLE
fix: expose ekolite/react in the package exports map

### DIFF
--- a/client/react.ts
+++ b/client/react.ts
@@ -9,10 +9,10 @@ export interface UseSubscriptionResult {
   isLoading: boolean;
 }
 
-// The React binding — Meteor's useTracker, for EkoLite. Subscribes on mount, streams
-// the collection's live documents through useSyncExternalStore, and reports isLoading
-// until the subscription is ready; stops the subscription on unmount. A thin wrapper
-// over bindStore (the tested subscribe/getSnapshot core) and ConnectionManager.
+// The React binding: keeps a component in sync with a live server collection. Subscribes
+// on mount, streams the collection's live documents through useSyncExternalStore, and
+// reports isLoading until the subscription is ready; stops the subscription on unmount.
+// A thin wrapper over bindStore (the tested subscribe/getSnapshot core) and ConnectionManager.
 //
 // The collection name is passed explicitly rather than derived from the subscription
 // name: the server chooses the collection and it is not exposed on the handle.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,10 @@
     "./client": {
       "types": "./dist/client/index.d.ts",
       "import": "./dist/client/index.js"
+    },
+    "./react": {
+      "types": "./dist/client/react.d.ts",
+      "import": "./dist/client/react.js"
     }
   },
   "files": [

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -222,7 +222,9 @@ async function main() {
       pkgPath,
       JSON.stringify({ ...JSON.parse(readFileSync(pkgPath, 'utf8')), type: 'module' }, null, 2),
     );
-    run('npm', ['install', tarball], { cwd: dir });
+    // react and its types stand in for a React consumer: the hook's entry must resolve
+    // and compile for them, while the other entries stay importable without React.
+    run('npm', ['install', tarball, 'react@^18', '@types/react@^18'], { cwd: dir });
 
     // 3. A consumer that knows only the published package: import App, define a method on
     //    it, and call it. A fresh App carries nothing of its own, so whatever the consumer
@@ -269,6 +271,7 @@ async function main() {
         "import { App } from 'ekolite';",
         "import type { ReadyMsg } from 'ekolite/shared';",
         "import { ConnectionManager } from 'ekolite/client';",
+        "import { useSubscription } from 'ekolite/react';",
         '',
         'const app = App.createNull();',
         "const ready: ReadyMsg = { type: 'ready', id: 'sub-1', collection: 'files' };",
@@ -276,6 +279,7 @@ async function main() {
         'void app;',
         'void ready;',
         'void ConnectionManager;',
+        'void useSubscription;',
         '',
       ].join('\n'),
     );
@@ -339,7 +343,7 @@ async function main() {
     console.log('package smoke: PASS');
     console.log(`  consumer said: ${out}`);
     console.log('  declarations resolve to shipped files only');
-    console.log('  a TS consumer compiles against ekolite, ekolite/shared and ekolite/client');
+    console.log('  a TS consumer compiles against ekolite, ekolite/shared, ekolite/client and ekolite/react');
     console.log('  a consumer serves their own client through createServer');
     if (process.platform !== 'win32') {
       console.log('  a consumer arms graceful shutdown and the process exits 0 on a signal');


### PR DESCRIPTION
## Why

#114 added the hook at `client/react.ts` and the build emits `dist/client/react.js`, but `package.json`'s exports map never gained a `./react` entry. From the published tarball, `import { useSubscription } from 'ekolite/react'` fails to resolve, so the entry the hook was built for does not exist for a consumer. Nothing in the repo caught it because our own tests import the source directly; only a consumer of the packed tarball sees the gap.

## What changed

- The package smoke's TS consumer now also imports `useSubscription` from `ekolite/react`. Red first: `TS2307: Cannot find module 'ekolite/react'`. The throwaway consumer installs `react` and `@types/react` to play the part of a React app; ekolite's own dependencies are unchanged and react stays an optional peer.
- Green: a `./react` entry in the exports map, pointing at `dist/client/react.js` and its declarations.
- The hook's header comment now describes it in its own terms rather than by comparison.

## Testing

Package smoke passes: the TS consumer compiles against `ekolite`, `ekolite/shared`, `ekolite/client` and `ekolite/react` from the installed tarball, and `ekolite run` exercises `ekolite/config` at runtime. Typecheck and unit suite green.

Caught while preparing the 0.4.0 release, which this blocks.
