### PR TITLE
chore: release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `ekolite` are recorded here. The project is pre-1.0, so a minor version may carry a breaking change.
 
+## 0.4.0
+
+### Added
+
+- **`ekolite/react`: a `useSubscription` hook.** `useSubscription(manager, name, collection, params?)` returns `{ data, isLoading }` and keeps a component in sync with a live server collection: it subscribes on mount, streams the collection's live documents through `useSyncExternalStore`, reports `isLoading` until the subscription is ready, and stops on unmount. `react >= 18` is an optional peer dependency; every other entry stays React free. (#114, #153)
+
+### Fixed
+
+- **Subscribing before the socket opens works.** A `subscribe()` made while the socket is still connecting holds its frame and replays it exactly once on open, the same path a reconnect uses. `stopSubscription()` sends an unsubscribe only for a subscription the socket actually carried, and a `call()` before open rejects cleanly instead of throwing at the call site. The null socket now throws `InvalidStateError` on a send before open, exactly as a real WebSocket does, so this class of bug is caught by tests rather than only in a browser. (#152)
+
 ## 0.3.0
 
 ### Added

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,20 @@
+# Releasing
+
+EkoLite ships to npm without a token leaving anyone's machine. A release is two small human decisions, a version PR and a GitHub Release, and the machines do the rest.
+
+## The flow
+
+1. **Open a release PR.** Branch `release/vX.Y.Z` off `main`. Bump `version` in `package.json`, and write the CHANGELOG entry: everything merged since the last release that a consumer can feel, in plain sentences with PR references. Title it `chore: release X.Y.Z`, let CI go green, merge.
+2. **Cut the GitHub Release.** Tag `vX.Y.Z` on `main`, notes lifted from the CHANGELOG entry. Publishing the Release fires `.github/workflows/publish.yml`.
+3. **Approve the gate.** The workflow waits on the `release` environment; a maintainer approves the deployment under Actions.
+4. **The workflow publishes.** It authenticates with OIDC trusted publishing: npmjs.com trusts this repo, this workflow and this environment, so there is no stored secret to leak or rotate. `prepublishOnly` re-runs typecheck, tests and build as the last gate, then `npm publish --provenance` ships with an attestation linking the package on npm back to this repo and this exact run.
+
+## Before cutting
+
+- `npm run test:package` passes: the consumer smoke installs the packed tarball into a project outside the repo and proves every export entry from a consumer's side.
+- The lockfile resolves only to `registry.npmjs.org`. A local mirror config can quietly rewrite tarball URLs; `grep npmmirror package-lock.json` should find nothing.
+- The CHANGELOG entry reads like release notes, because it becomes them.
+
+## Verify
+
+`npm view ekolite version` shows the new version, and the package page on npm carries the provenance badge.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ekolite",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ekolite",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@fastify/multipart": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ekolite",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "bin": {
     "ekolite": "dist/server/cli.js"
   },


### PR DESCRIPTION
0.4.0: `ekolite/react` with the `useSubscription` hook, plus the subscribe-before-open fix. See CHANGELOG.md.

Also writes the release process down in RELEASING.md.
