### PR TITLE
docs: document the ekolite/react entry point and useSubscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ Work in progress, published early at `0.x` to claim the name and share the shape
 npm install ekolite
 ```
 
-Three entry points, everything else stays internal for now:
+Four entry points, everything else stays internal for now:
 
 ```ts
 import { App } from 'ekolite'; // the server framework
 import { ConnectionManager } from 'ekolite/client'; // the browser client stack
+import { useSubscription } from 'ekolite/react'; // the React binding (React 18+, optional peer)
 import type { ReadyMsg } from 'ekolite/shared'; // the wire protocol types
 
 const app = App.createNull();
@@ -28,7 +29,7 @@ app.methods.define('greet', (name) => `hello ${String(name)}`);
 await app.methods.call('greet', ['world']); // 'hello world'
 ```
 
-Verify the packaged shape from a consumer's point of view with `npm run test:package`: it builds, packs, installs the tarball into a throwaway project outside this repo, and imports from all three entries. It does a real `npm install`, so it takes 30 to 60 seconds and runs as a manual gate rather than on every CI push.
+Verify the packaged shape from a consumer's point of view with `npm run test:package`: it builds, packs, installs the tarball into a throwaway project outside this repo, and imports from the three framework-agnostic entries. It does a real `npm install`, so it takes 30 to 60 seconds and runs as a manual gate rather than on every CI push.
 
 ## What works today
 
@@ -38,6 +39,7 @@ Verify the packaged shape from a consumer's point of view with `npm run test:pac
 - **RPC methods** (`Methods`): register a named server method, call it over the socket, and get a typed result or a structured error back through the `method` / `result` / `error` messages
 - **File storage over HTTP** (`Files`): `POST /api/files` saves the bytes and inserts a document that streams into the live list through pub/sub; `GET /api/files/:id` streams them back
 - **Client stack**: `ClientSocketWrapper` (nullable WebSocket client), `ConnectionManager` (subscription lifecycle) and `ReactiveStore` (client side collection state)
+- **React binding** (`ekolite/react`): `useSubscription(connection, name, collection)` keeps a component in sync with a live collection through `useSyncExternalStore`, returning `{ data, isLoading }`. React 18+ is an optional peer dependency, so the other entries stay framework agnostic
 - **Mini DDP protocol** ([`shared/protocol.ts`](shared/protocol.ts)): eleven message types, typed end to end
 - **Heartbeat and reconnect** (`ping` / `pong`): a socket can die while both ends still think it is open, so the client pings and closes a connection that stops answering, then reopens it: instant first retry, exponential backoff with jitter, capped, forever. Subscriptions replay with their original ids and each store swaps to the fresh documents in one move, so the page never renders empty in between. On by default with 15 second pings and a 10 second pong window; `reconnect: false` or a zero interval opts out, and `status` reports connecting / connected / reconnecting / closed
 - **Graceful shutdown** (`Shutdown`): on a stop signal, or a shutdown message from a supervisor, it stops taking requests, closes the streams, drops the database connection, and exits cleanly

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -6,11 +6,12 @@
 npm install ekolite
 ```
 
-Three entry points, everything else stays internal for now:
+Four entry points, everything else stays internal for now:
 
 ```ts
 import { App } from 'ekolite'; // the server framework
 import { ConnectionManager } from 'ekolite/client'; // the browser client stack
+import { useSubscription } from 'ekolite/react'; // the React binding (React 18+, optional peer)
 import type { ReadyMsg } from 'ekolite/shared'; // the wire protocol types
 
 const app = App.createNull();
@@ -30,6 +31,28 @@ app.methods.define('addTask', (title) => createTask(title));
 ```
 
 To run your app as a server without writing a boot file, point an `ekolite.config.ts` at your definitions and use the `ekolite run` command. See [Running your app](/running-your-app).
+
+## React
+
+`ekolite/react` ships `useSubscription`, the hook that keeps a component in sync with a live server collection. It subscribes on mount, streams the collection's documents through `useSyncExternalStore`, reports loading, and unsubscribes on unmount:
+
+```tsx
+import { useSubscription } from 'ekolite/react';
+
+function FileList({ connection }) {
+  const { data, isLoading } = useSubscription(connection, 'files.all', 'files');
+  if (isLoading) return <p>Loading</p>;
+  return (
+    <ul>
+      {data.map((file) => (
+        <li key={file._id}>{file.name}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+`connection` is your app's `ConnectionManager`. React 18+ is an optional peer dependency, so the other entries stay framework agnostic.
 
 ## Where next
 


### PR DESCRIPTION
## Why

0.4.0 exposed `ekolite/react` (`useSubscription`) as a public entry point in the package `exports` map, but the docs never caught up: the README and Quick start both still said **three entry points** and never mentioned the hook. The docs site (auto-deployed to GitHub Pages on merge to `main`) therefore does not reflect the shipped API.

## What

- **README** and **docs/quick-start.md**: `ekolite/react` added as the fourth entry point in the import block.
- **docs/quick-start.md**: a `useSubscription` example showing `{ data, isLoading }` and the `(connection, name, collection)` signature.
- **README** "What works today": a **React binding** bullet noting React 18+ is an optional peer dependency, so the other entries stay framework agnostic.
- The `test:package` line reworded to "the three framework-agnostic entries", since the React entry is verified separately (it needs React installed).

## Verification

`npm run docs:build` passes locally (VitePress). Merging to `main` triggers the existing `docs.yml` Pages deploy.