### PR TITLE
docs: add npm, CI, license and docs badges to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # EkoLite
 
+[![npm](https://img.shields.io/npm/v/ekolite)](https://www.npmjs.com/package/ekolite)
+[![CI](https://github.com/ekohacks/ekolite/actions/workflows/ci.yml/badge.svg)](https://github.com/ekohacks/ekolite/actions/workflows/ci.yml)
+[![license](https://img.shields.io/npm/l/ekolite)](./LICENSE)
+[![docs](https://img.shields.io/badge/docs-ekohacks.github.io-blue)](https://ekohacks.github.io/ekolite/)
+
 A lightweight, real time backend framework. Fastify, MongoDB and WebSocket with a typed pub/sub protocol, built test first with James Shore's Nullables pattern. No mocks anywhere in the suite.
 
 EkoLite is a public, work in progress framework for real time, data driven apps, built in the open with deliberate design choices. The documents in [`docs/ekolite-overview/`](docs/ekolite-overview/) cover the thinking. This README covers what is actually built today.


### PR DESCRIPTION
## Why

The repo now has proper About metadata (description, website, topics). This adds the matching signal at the top of the README so the framework reads as published and maintained at a glance, and gives readers the npm link the GitHub sidebar cannot (the Packages sidebar only surfaces GitHub Packages, not npmjs).

## What

A badge row under the `# EkoLite` title:

- **npm** version → https://www.npmjs.com/package/ekolite
- **CI** status → the `ci.yml` workflow
- **license** (MIT) → `./LICENSE`
- **docs** → https://ekohacks.github.io/ekolite/

All four link targets verified to exist. No content or code changes.