### PR TITLE
chore: release 0.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ekolite",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ekolite",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@fastify/multipart": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ekolite",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "bin": {
     "ekolite": "dist/server/cli.js"
   },


### PR DESCRIPTION
Documentation only, no code changes. 0.4.0 made `ekolite/react` a public entry point, but the README that shipped to npm still described three entries and never mentioned the hook. This release refreshes the npm page.

- **The README and quick start document `ekolite/react`.** `useSubscription` joins the entry point list with a quick start example, and What works today gains a React binding bullet. (#155)
- **The README carries npm, CI, license and docs badges.** (#156)