### PR TITLE
ci: gate merges on ekohacks docs check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,32 @@ jobs:
       - name: 'Run tests'
         run: npm test
 
+  # The docs deploy themselves on merge to main (docs.yml), so drifted docs ship
+  # silently — 0.4.0 added an entry point and the site advertised the old surface for
+  # a day before anyone noticed. This gate compares the docs' entry-point claims (the
+  # ekohacks:entry-points blocks and any "N entry points" prose) against the exports
+  # map in package.json, builds the VitePress site, and fails the PR with the drift
+  # named. The version is pinned; bump it deliberately when ekohacks ships.
+  docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: 'Setup Node.js'
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: 'Install dependencies'
+        run: npm ci
+
+      - name: 'Docs drift gate'
+        run: npx ekohacks@0.2.0 docs check
+
   # The integration suite needs a real MongoDB running as a single-node replica set
   # (change streams demand one). Each runner boots its own throwaway mongod on
   # localhost: Linux runs the mongo service from docker-compose.yml, as a laptop does;

--- a/README.md
+++ b/README.md
@@ -21,12 +21,15 @@ Work in progress, published early at `0.x` to claim the name and share the shape
 npm install ekolite
 ```
 
-Four entry points, everything else stays internal for now:
+Five entry points, everything else stays internal for now:
+
+<!-- ekohacks:entry-points -->
 
 ```ts
 import { App } from 'ekolite'; // the server framework
 import { ConnectionManager } from 'ekolite/client'; // the browser client stack
 import { useSubscription } from 'ekolite/react'; // the React binding (React 18+, optional peer)
+import { defineConfig } from 'ekolite/config'; // the runner's config schema (ekolite.config.ts)
 import type { ReadyMsg } from 'ekolite/shared'; // the wire protocol types
 
 const app = App.createNull();
@@ -34,7 +37,9 @@ app.methods.define('greet', (name) => `hello ${String(name)}`);
 await app.methods.call('greet', ['world']); // 'hello world'
 ```
 
-Verify the packaged shape from a consumer's point of view with `npm run test:package`: it builds, packs, installs the tarball into a throwaway project outside this repo, and imports from the three framework-agnostic entries. It does a real `npm install`, so it takes 30 to 60 seconds and runs as a manual gate rather than on every CI push.
+<!-- /ekohacks:entry-points -->
+
+Verify the packaged shape from a consumer's point of view with `npm run test:package`: it builds, packs, installs the tarball into a throwaway project outside this repo, and imports from the framework-agnostic entries. It does a real `npm install`, so it takes 30 to 60 seconds and runs as a manual gate rather than on every CI push.
 
 ## What works today
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -6,18 +6,23 @@
 npm install ekolite
 ```
 
-Four entry points, everything else stays internal for now:
+Five entry points, everything else stays internal for now:
+
+<!-- ekohacks:entry-points -->
 
 ```ts
 import { App } from 'ekolite'; // the server framework
 import { ConnectionManager } from 'ekolite/client'; // the browser client stack
 import { useSubscription } from 'ekolite/react'; // the React binding (React 18+, optional peer)
+import { defineConfig } from 'ekolite/config'; // the runner's config schema (ekolite.config.ts)
 import type { ReadyMsg } from 'ekolite/shared'; // the wire protocol types
 
 const app = App.createNull();
 app.methods.define('greet', (name) => `hello ${String(name)}`);
 await app.methods.call('greet', ['world']); // 'hello world'
 ```
+
+<!-- /ekohacks:entry-points -->
 
 `App.createNull()` assembles the whole graph in memory, so you can exercise methods, publications and files without a running MongoDB. Swap it for `App.create({ mongoUri, fileDir, port })` to talk to the real thing.
 


### PR DESCRIPTION
Closes the loop on the 0.4.0 docs drift. Two commits:

- **The docs adopt the tool-owned block.** README and quick-start now carry the `ekohacks:entry-points` markers around the import example, list `ekolite/config` as the fifth public entry point, and say five, not four. The stale "three framework-agnostic entries" claim about the package smoke loses its number entirely — counts in free prose are exactly what rots.
- **CI gains a `docs` job** running `npx ekohacks@0.2.0 docs check`: the exports map is the truth, the docs' entry-point claims and the VitePress build are checked against it, and a release that changes the public surface can no longer merge while the docs disagree. The gate turns on already green because the docs fix rides in the same PR.

The command is specified red-first in ekohacks/cli`stories/6-docs-check.md`; run inside this repo before the docs commit it failed naming `ekolite/config` and the four-versus-five count.