### PR TITLE
chore: release 0.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ekolite",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ekolite",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "@fastify/multipart": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ekolite",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "bin": {
     "ekolite": "dist/server/cli.js"
   },


### PR DESCRIPTION
- **`@types/node` ships as a dependency.** EkoLite's public types mention `Buffer` and `node:http`, so a TypeScript consumer who had not installed `@types/node` themselves saw errors inside `node_modules/ekolite` rather than in their own code. It is a dependency now and resolves on its own. (da40a01)
- **The npm README opens with a real quick start.** It used to start with `npm install` and `npm run dev:server`, which boot this repo's own bare server and mean nothing to someone who has just installed the package. It now shows an app entry, `ekolite.config.ts`, `npx ekolite run`, and subscribing from the browser. (da40a01)
- **The documented quick start runs end to end.** "Running your app" folded into it, so one page carries the prerequisites, MongoDB as a replica set, the app entry, the runner, the browser client and the file routes. It also states two things it previously left out: `eko` hands your methods no database handle, so writes need your own `mongodb` client, and the upload routes accept `.bam` and nothing else. (da40a01)