### PR TITLE
chore: release 0.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ekolite",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ekolite",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "MIT",
       "dependencies": {
         "@fastify/multipart": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ekolite",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "bin": {
     "ekolite": "dist/server/cli.js"
   },


### PR DESCRIPTION
### Added

- **`allowedExtensions`: the upload allowlist belongs to your project.** `POST /api/files` accepted `.bam` and nothing else, hardcoded, with no way to say otherwise. `ekolite.config.ts` now takes `allowedExtensions: ['bam', 'csv']` and the runner carries it down to the file routes. Leaving the key out keeps `.bam` alone, so upgrading cannot quietly start accepting file types a deployment was refusing yesterday. The list replaces the default rather than adding to it, so `['csv']` refuses `.bam` too, and the check reads the extension off the filename: it keeps the obvious wrong file out, it does not prove what the bytes are. `App.create` and `App.createNull` take the same key for anyone wiring the app by hand. (#201)

### Changed

- **The docs no longer say the upload list is fixed.** The quick start and the README both described `.bam` only as a gap you had to live with. They now document `allowedExtensions`, what it replaces, and the one gap that does remain on the file routes: no auth. (#201)
- **The npm README explains `App.createNull()` and how to test against it.** (e0fccde)